### PR TITLE
MSEARCH-38: Update module descriptor.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -11,7 +11,7 @@
             "POST"
           ],
           "pathPattern": "/search/index/indices",
-          "permissionsRequired": ["search.index.indexes.item.post"]
+          "permissionsRequired": ["search.index.indices.item.post"]
         },
         {
           "methods": [
@@ -51,9 +51,9 @@
   ],
   "permissionSets" : [
     {
-      "permissionName": "search.index.indexes.item.post",
-      "displayName": "Search - create an index",
-      "description": "Create an index"
+      "permissionName": "search.index.indices.item.post",
+      "displayName": "Search - creates an index",
+      "description": "Creates an index"
     },
     {
       "permissionName": "search.index.mappings.item.post",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1,29 +1,76 @@
 {
   "id": "${artifactId}-${version}",
-  "name": "The blueprint module that could be used as a template for folio spring based backend modules.",
+  "name": "Search Module",
   "provides": [
     {
-      "id": "spring-template",
-      "version": "1.0",
-      "handlers": []
-    },
-    {
-      "id": "_tenant",
-      "version": "1.2",
-      "interfaceType": "system",
+      "id": "indexes",
+      "version": "0.1",
       "handlers": [
         {
-          "methods": ["POST"],
-          "pathPattern": "/_/tenant"
-        }, {
-          "methods": ["DELETE"],
-          "pathPattern": "/_/tenant"
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/search/index/indices",
+          "permissionsRequired": ["search.index.indexes.item.post"]
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/search/index/mappings",
+          "permissionsRequired": ["search.index.mappings.item.post"]
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/search/index/resources",
+          "permissionsRequired": ["search.index.resources.collection.post"]
+        }
+      ]
+    },
+    {
+      "id": "search",
+      "version": "0.1",
+      "handlers": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/search/instances",
+          "permissionsRequired": ["search.instances.collection.get"]
         }
       ]
     }
   ],
-  "permissionSets" : [],
-  "requires": [],
+  "requires": [
+    {
+      "id": "instance-storage",
+      "version": "7.5"
+    }
+  ],
+  "permissionSets" : [
+    {
+      "permissionName": "search.index.indexes.item.post",
+      "displayName": "Search - create an index",
+      "description": "Create an index"
+    },
+    {
+      "permissionName": "search.index.mappings.item.post",
+      "displayName": "Search - updates mappings for the index",
+      "description": "Updates mappings for the index"
+    },
+    {
+      "permissionName": "search.index.resources.collection.post",
+      "displayName": "Search - saves resource to the search engine",
+      "description": "Saves resource to the search engine"
+    },
+    {
+      "permissionName": "search.instances.collection.get",
+      "displayName": "Search - searches instances by given query",
+      "description": "Searches instances by given query"
+    }
+  ],
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerPull": false,
@@ -34,8 +81,25 @@
       }
     },
     "env": [
-      { "name": "JAVA_OPTIONS",
+      {
+        "name": "JAVA_OPTIONS",
         "value": "-XX:MaxRAMPercentage=66.0"
+      },
+      {
+        "name": "KAFKA_HOST",
+        "value": "kafka"
+      },
+      {
+        "name": "KAFKA_PORT",
+        "value": "9092"
+      },
+      {
+        "name": "ELASTICSEARCH_HOST",
+        "value": "elasticsearch"
+      },
+      {
+        "name": "ELASTICSEARCH_PORT",
+        "value": "9200"
       }
     ]
   }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -3,7 +3,7 @@
   "name": "Search Module",
   "provides": [
     {
-      "id": "indexes",
+      "id": "indices",
       "version": "0.1",
       "handlers": [
         {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,9 +8,9 @@ spring:
       accept-single-value-as-array: true
   elasticsearch:
     rest:
-      uris: http://elasticsearch:9200
+      uris: http://${ELASTICSEARCH_HOST:elasticsearch}:${ELASTICSEARCH_PORT:9200}
   kafka:
-    bootstrap-servers: kafka:9092
+    bootstrap-servers: ${KAFKA_HOST:kafka}:${KAFKA_PORT:9092}
 
 application:
   kafka:


### PR DESCRIPTION
https://issues.folio.org/browse/MSEARCH-38 - Update module-descriptor with new APIs

## Changes:
* Update module descriptor and add new APIs:
  * `indexes` contains all operations for indexes (create/update index, index resources)
  *  `search` contains instance search API;
* Assign permissions for each endpoint;
* Requires `instance-storage:7.5` API (it is not directly queried but needed to prevent breaking changes being applied to the instance schema without the team notification).
* Inject kafka host and port and elasticsearch host and port from env variables. 