### PR TITLE
MSEARCH-46: Add expandAll property for /search/instances

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -31,7 +31,7 @@
     },
     {
       "id": "search",
-      "version": "0.1",
+      "version": "0.2",
       "handlers": [
         {
           "methods": [

--- a/src/main/java/org/folio/search/controller/SearchController.java
+++ b/src/main/java/org/folio/search/controller/SearchController.java
@@ -24,13 +24,16 @@ public class SearchController implements InstancesApi {
   private final SearchService searchService;
 
   @Override
-  public ResponseEntity<SearchResult> searchInstances(String query, String tenantId, Integer limit, Integer offset) {
+  public ResponseEntity<SearchResult> searchInstances(String query, String tenantId, Boolean expandAll,
+    Integer limit, Integer offset) {
+
     var searchResult = searchService.search(CqlSearchRequest.builder()
       .cqlQuery(query)
       .resource(INSTANCE_RESOURCE)
       .tenantId(tenantId)
       .limit(limit)
       .offset(offset)
+      .expandAll(expandAll)
       .build());
 
     return ResponseEntity.ok(searchResult);

--- a/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
@@ -74,9 +74,16 @@ public class CqlSearchQueryConverter {
       }
     }
 
+    if (!searchRequest.isExpandAll()) {
+      final String[] includes = searchFieldProvider
+        .getSourceFields(searchRequest.getResource())
+        .toArray(String[]::new);
+
+      queryBuilder.fetchSource(includes, null);
+    }
+
     return queryBuilder
       .query(convertToQuery(searchRequest, node))
-      .fetchSource(searchFieldProvider.getSourceFields(searchRequest.getResource()).toArray(String[]::new), null)
       .from(searchRequest.getOffset())
       .size(searchRequest.getLimit());
   }

--- a/src/main/java/org/folio/search/model/service/CqlSearchRequest.java
+++ b/src/main/java/org/folio/search/model/service/CqlSearchRequest.java
@@ -40,4 +40,7 @@ public class CqlSearchRequest {
    */
   @Builder.Default
   private Integer offset = 0;
+
+  @Builder.Default
+  private boolean expandAll = false;
 }

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -47,7 +47,7 @@
           "index": "keyword"
         },
         "identifierTypeId": {
-          "index": "none"
+          "index": "source"
         }
       }
     },

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -16,6 +16,13 @@ paths:
         - $ref: '#/components/parameters/search-pageable-limit'
         - $ref: '#/components/parameters/search-pageable-offset'
         - $ref: '#/components/parameters/x-okapi-tenant-header'
+        - in: query
+          name: expandAll
+          description: Whether to return only basic properties or entire instance.
+          schema:
+            type: boolean
+            default: false
+          required: true
 
       responses:
         '200':

--- a/src/test/java/org/folio/search/controller/EsInstanceToInventoryInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/EsInstanceToInventoryInstanceIT.java
@@ -34,4 +34,17 @@ class EsInstanceToInventoryInstanceIT extends BaseIntegrationTest {
     assertThat(actual.getContributors(), is(expected.getContributors()));
     assertThat(actual.getPublication(), is(expected.getPublication()));
   }
+
+  @Test
+  void responseContainsAllInstanceProperties() throws Exception {
+    final var expected = getSemanticWeb();
+    final var actualJson = mockMvc.perform(get(searchInstancesByQuery("id=={value}&expandAll=true"), expected.getId())
+      .headers(defaultHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("totalRecords", is(1)))
+      .andReturn().getResponse().getContentAsString();
+
+    final var actual = JsonPath.parse(actualJson).read("instances[0]", Instance.class);
+    assertThat(actual, is(expected));
+  }
 }

--- a/src/test/java/org/folio/search/controller/SearchControllerTest.java
+++ b/src/test/java/org/folio/search/controller/SearchControllerTest.java
@@ -35,7 +35,7 @@ class SearchControllerTest {
     expectedSearchResult.setInstances(emptyList());
 
     var cqlQuery = "title all \"test-query\"";
-    var expectedSearchRequest = CqlSearchRequest.of("instance", cqlQuery, TENANT_ID, 100, 0);
+    var expectedSearchRequest = CqlSearchRequest.of("instance", cqlQuery, TENANT_ID, 100, 0, false);
 
     when(searchService.search(expectedSearchRequest)).thenReturn(expectedSearchResult);
 

--- a/src/test/java/org/folio/search/repository/SearchRepositoryTest.java
+++ b/src/test/java/org/folio/search/repository/SearchRepositoryTest.java
@@ -58,7 +58,7 @@ class SearchRepositoryTest {
     expectedResult.setTotalRecords(totalResults);
     expectedResult.setInstances(List.of(new Instance()));
 
-    var searchRequest = CqlSearchRequest.of(RESOURCE_NAME, "query", TENANT_ID, 1, 20);
+    var searchRequest = CqlSearchRequest.of(RESOURCE_NAME, "query", TENANT_ID, 1, 20, false);
     var actual = searchRepository.search(searchRequest, queryBuilder);
     assertThat(actual).isEqualTo(expectedResult);
   }

--- a/src/test/java/org/folio/search/service/SearchServiceTest.java
+++ b/src/test/java/org/folio/search/service/SearchServiceTest.java
@@ -32,7 +32,7 @@ class SearchServiceTest {
     expectedResult.setInstances(Collections.emptyList());
     expectedResult.setTotalRecords(0);
 
-    var searchRequest = CqlSearchRequest.of(RESOURCE_NAME, "query", TENANT_ID, 0, 10);
+    var searchRequest = CqlSearchRequest.of(RESOURCE_NAME, "query", TENANT_ID, 0, 10, false);
     var searchSourceBuilder = searchSource();
 
     when(searchRepository.search(searchRequest, searchSourceBuilder)).thenReturn(expectedResult);

--- a/src/test/java/org/folio/search/utils/SearchUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchUtilsTest.java
@@ -42,7 +42,7 @@ class SearchUtilsTest {
 
   @Test
   void getElasticsearchIndexName_cqlSearchRequest_positive() {
-    var cqlSearchRequest = CqlSearchRequest.of(RESOURCE_NAME, null, TENANT_ID, null, null);
+    var cqlSearchRequest = CqlSearchRequest.of(RESOURCE_NAME, null, TENANT_ID, null, null, false);
     var actual = getElasticsearchIndexName(cqlSearchRequest);
     assertThat(actual).isEqualTo(INDEX_NAME);
   }


### PR DESCRIPTION
https://issues.folio.org/browse/MSEARCH-46 - Allow returning of all instance properties.

## Changes:
* Add new `expandAll` property for the `/search/instances` endpoint;
* Bump up minor version for the API;
* Add tests for the new change.
* Make `identifierTypeId` as source.