### PR TITLE
Revert "FOLIO-2997 Set port for elasticsearch in default LaunchDescriptor"

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -158,7 +158,7 @@
       },
       {
         "name": "ELASTICSEARCH_PORT",
-        "value": "9301"
+        "value": "9200"
       },
       {
         "name": "DB_HOST",


### PR DESCRIPTION
Reverts folio-org/mod-search#24