### PR TITLE
MSEARCH-55 Implement filters and facets for item and holding fields

### DIFF
--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -189,6 +189,15 @@
         "effectiveLocationId": {
           "searchTypes": [ "facet", "filter" ],
           "index": "keyword"
+        },
+        "status": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "searchTypes": [ "facet", "filter" ],
+              "index": "keyword"
+            }
+          }
         }
       }
     },
@@ -196,6 +205,10 @@
       "type": "object",
       "properties": {
         "id": {
+          "index": "keyword"
+        },
+        "permanentLocationId": {
+          "searchTypes": [ "facet", "filter" ],
           "index": "keyword"
         }
       }

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -185,6 +185,10 @@
         },
         "barcode": {
           "index": "keyword"
+        },
+        "effectiveLocationId": {
+          "searchTypes": [ "facet", "filter" ],
+          "index": "keyword"
         }
       }
     },

--- a/src/main/resources/swagger.api/schemas/holding.json
+++ b/src/main/resources/swagger.api/schemas/holding.json
@@ -6,6 +6,10 @@
     "id": {
       "type": "string",
       "description": "Unique ID of the holding record"
+    },
+    "permanentLocationId": {
+      "type": "string",
+      "description": "The permanent shelving location in which an item resides."
     }
   }
 }

--- a/src/main/resources/swagger.api/schemas/item.json
+++ b/src/main/resources/swagger.api/schemas/item.json
@@ -18,6 +18,39 @@
     "effectiveLocationId": {
       "type": "string",
       "description": "Read only current home location for the item."
+    },
+    "status": {
+      "description": "The status of the item",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the status e.g. Available, Checked out, In transit",
+          "type": "string",
+          "enum": [
+            "Aged to lost",
+            "Available",
+            "Awaiting pickup",
+            "Awaiting delivery",
+            "Checked out",
+            "Claimed returned",
+            "Declared lost",
+            "In process",
+            "In process (non-requestable)",
+            "In transit",
+            "Intellectual item",
+            "Long missing",
+            "Lost and paid",
+            "Missing",
+            "On order",
+            "Paged",
+            "Restricted",
+            "Order closed",
+            "Unavailable",
+            "Unknown",
+            "Withdrawn"
+          ]
+        }
+      }
     }
   }
 }

--- a/src/main/resources/swagger.api/schemas/item.json
+++ b/src/main/resources/swagger.api/schemas/item.json
@@ -25,30 +25,7 @@
       "properties": {
         "name": {
           "description": "Name of the status e.g. Available, Checked out, In transit",
-          "type": "string",
-          "enum": [
-            "Aged to lost",
-            "Available",
-            "Awaiting pickup",
-            "Awaiting delivery",
-            "Checked out",
-            "Claimed returned",
-            "Declared lost",
-            "In process",
-            "In process (non-requestable)",
-            "In transit",
-            "Intellectual item",
-            "Long missing",
-            "Lost and paid",
-            "Missing",
-            "On order",
-            "Paged",
-            "Restricted",
-            "Order closed",
-            "Unavailable",
-            "Unknown",
-            "Withdrawn"
-          ]
+          "type": "string"
         }
       }
     }

--- a/src/main/resources/swagger.api/schemas/item.json
+++ b/src/main/resources/swagger.api/schemas/item.json
@@ -14,6 +14,10 @@
     "barcode": {
       "type": "string",
       "description": "Unique inventory control number for physical resources, used largely for circulation purposes"
+    },
+    "effectiveLocationId": {
+      "type": "string",
+      "description": "Read only current home location for the item."
     }
   }
 }

--- a/src/test/java/org/folio/search/controller/EsInstanceToInventoryInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/EsInstanceToInventoryInstanceIT.java
@@ -2,6 +2,7 @@ package org.folio.search.controller;
 
 import static org.folio.search.sample.SampleInstances.getSemanticWeb;
 import static org.folio.search.support.base.ApiEndpoints.searchInstancesByQuery;
+import static org.folio.search.utils.TestUtils.OBJECT_MAPPER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
@@ -12,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.jayway.jsonpath.JsonPath;
 import java.util.stream.Collectors;
 import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.SearchResult;
 import org.folio.search.support.base.BaseIntegrationTest;
 import org.folio.search.utils.types.IntegrationTest;
 import org.hamcrest.Matchers;
@@ -47,7 +49,7 @@ class EsInstanceToInventoryInstanceIT extends BaseIntegrationTest {
       .andExpect(jsonPath("totalRecords", is(1)))
       .andReturn().getResponse().getContentAsString();
 
-    final var actual = JsonPath.parse(actualJson).read("instances[0]", Instance.class);
+    final var actual = OBJECT_MAPPER.readValue(actualJson, SearchResult.class).getInstances().get(0);
     assertThat(actual.getHoldings(), containsInAnyOrder(expected.getHoldings().stream()
       .map(Matchers::is).collect(Collectors.toList())));
     assertThat(actual.getItems(), containsInAnyOrder(expected.getItems().stream()

--- a/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
@@ -3,6 +3,9 @@ package org.folio.search.controller;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.domain.dto.ItemStatus.NameEnum.AVAILABLE;
+import static org.folio.search.domain.dto.ItemStatus.NameEnum.CHECKED_OUT;
+import static org.folio.search.domain.dto.ItemStatus.NameEnum.MISSING;
 import static org.folio.search.support.base.ApiEndpoints.getFacets;
 import static org.folio.search.support.base.ApiEndpoints.searchInstancesByQuery;
 import static org.folio.search.utils.TestUtils.OBJECT_MAPPER;
@@ -25,9 +28,12 @@ import java.util.stream.Stream;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.folio.search.domain.dto.Facet;
 import org.folio.search.domain.dto.FacetResult;
+import org.folio.search.domain.dto.Holding;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.InstanceTags;
 import org.folio.search.domain.dto.Item;
+import org.folio.search.domain.dto.ItemStatus;
+import org.folio.search.domain.dto.ItemStatus.NameEnum;
 import org.folio.search.support.base.BaseIntegrationTest;
 import org.folio.search.utils.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
@@ -64,6 +70,11 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
   private static final String[] LOCATIONS = array(
     "ce23dfa1-17e8-4a1f-ad6b-34ce6ab352c2",
     "f1a49577-5096-4771-a8a0-d07d642241eb");
+
+  private static final String[] PERMANENT_LOCATIONS = array(
+    "765b4c3b-485c-4ce4-a117-f99c01ac49fe",
+    "4fdca025-1629-4688-aeb7-9c5fe5c73549",
+    "81f1ab2c-83c5-4a90-a8b7-c8c8179c0697");
 
   @BeforeAll
   static void createTenant(@Autowired MockMvc mockMvc) {
@@ -136,18 +147,33 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       arguments("(id=* and instanceTags==science) sortby title", List.of(IDS[0], IDS[2])),
       arguments("(instanceTags==science) sortby title", List.of(IDS[0], IDS[2])),
 
-      arguments(String.format("(id=* and items.effectiveLocationId==%s) sortby title", LOCATIONS[0]),
+      arguments(format("(id=* and items.effectiveLocationId==%s) sortby title", LOCATIONS[0]),
         List.of(IDS[0], IDS[2], IDS[3], IDS[4])),
-      arguments(String.format("(id=* and items.effectiveLocationId==%s) sortby title", LOCATIONS[1]),
+      arguments(format("(id=* and items.effectiveLocationId==%s) sortby title", LOCATIONS[1]),
         List.of(IDS[1], IDS[2], IDS[4])),
-      arguments(String.format("(items.effectiveLocationId==%s) sortby title", LOCATIONS[0]),
-        List.of(IDS[0], IDS[2], IDS[3], IDS[4]))
+      arguments(format("(items.effectiveLocationId==%s) sortby title", LOCATIONS[0]),
+        List.of(IDS[0], IDS[2], IDS[3], IDS[4])),
+
+      arguments("(items.status.name==Available) sortby title", List.of(IDS[0], IDS[1], IDS[4])),
+      arguments("(items.status.name==Missing) sortby title", List.of(IDS[2], IDS[3])),
+      arguments("(items.status.name==\"Checked out\") sortby title", List.of(IDS[2], IDS[4])),
+      arguments("(items.status.name==Available and source==MARC) sortby title", List.of(IDS[0], IDS[1])),
+
+      arguments(format("(holdings.permanentLocationId==%s) sortby title", PERMANENT_LOCATIONS[0]),
+        List.of(IDS[0], IDS[3])),
+      arguments(format("(holdings.permanentLocationId==%s) sortby title", PERMANENT_LOCATIONS[1]),
+        List.of(IDS[1], IDS[3])),
+      arguments(format("(holdings.permanentLocationId==%s) sortby title", PERMANENT_LOCATIONS[2]),
+        List.of(IDS[3], IDS[4])),
+      arguments(format("(holdings.permanentLocationId==%s and source==MARC) sortby title", PERMANENT_LOCATIONS[2]),
+        List.of(IDS[3]))
     );
   }
 
   private static Stream<Arguments> facetQueriesProvider() {
     var allFacets = array("discoverySuppress", "staffSuppress", "languages", "instanceTags", "source",
-      "instanceTypeId", "instanceFormatId", "items.effectiveLocationId");
+      "instanceTypeId", "instanceFormatId", "items.effectiveLocationId", "items.status.name",
+      "holdings.permanentLocationId");
     return Stream.of(
       arguments("id=*", allFacets, mapOf(
         "discoverySuppress", facet(facetItem("false", 3), facetItem("true", 2)),
@@ -159,7 +185,10 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
         "source", facet(facetItem("MARC", 3), facetItem("FOLIO", 2)),
         "instanceTypeId", facet(facetItem(TYPES[1], 3), facetItem(TYPES[0], 2)),
         "instanceFormatId", facet(facetItem(FORMATS[1], 4), facetItem(FORMATS[2], 3), facetItem(FORMATS[0], 1)),
-        "items.effectiveLocationId", facet(facetItem(LOCATIONS[0], 4), facetItem(LOCATIONS[1], 3)))),
+        "items.effectiveLocationId", facet(facetItem(LOCATIONS[0], 4), facetItem(LOCATIONS[1], 3)),
+        "items.status.name", facet(facetItem("Available", 3), facetItem("Checked out", 2), facetItem("Missing", 2)),
+        "holdings.permanentLocationId", facet(facetItem(PERMANENT_LOCATIONS[1], 2),
+          facetItem(PERMANENT_LOCATIONS[0], 2), facetItem(PERMANENT_LOCATIONS[2], 2)))),
 
       arguments("id=*", array("source"), mapOf("source", facet(facetItem("MARC", 3), facetItem("FOLIO", 2)))),
 
@@ -201,7 +230,14 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
 
       arguments("source==MARC", array("source", "items.effectiveLocationId"), mapOf(
         "source", facet(facetItem("MARC", 3), facetItem("FOLIO", 2)),
-        "items.effectiveLocationId", facet(facetItem(LOCATIONS[0], 2), facetItem(LOCATIONS[1], 1))))
+        "items.effectiveLocationId", facet(facetItem(LOCATIONS[0], 2), facetItem(LOCATIONS[1], 1)))),
+
+      arguments("id=*", array("items.status.name"), mapOf(
+        "items.status.name", facet(facetItem("Available", 3), facetItem("Checked out", 2), facetItem("Missing", 2)))),
+
+      arguments("id=*", array("holdings.permanentLocationId"), mapOf(
+        "holdings.permanentLocationId", facet(facetItem(PERMANENT_LOCATIONS[1], 2),
+          facetItem(PERMANENT_LOCATIONS[0], 2), facetItem(PERMANENT_LOCATIONS[2], 2))))
     );
   }
 
@@ -218,7 +254,8 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .discoverySuppress(true)
       .instanceFormatId(List.of(FORMATS[1], FORMATS[2]))
       .tags(instanceTags("text", "science"))
-      .items(List.of(new Item().id(randomId()).effectiveLocationId(LOCATIONS[0])));
+      .items(List.of(new Item().id(randomId()).effectiveLocationId(LOCATIONS[0]).status(itemStatus(AVAILABLE))))
+      .holdings(List.of(new Holding().id(randomId()).permanentLocationId(PERMANENT_LOCATIONS[0])));
 
     instances[1]
       .source("MARC")
@@ -228,7 +265,8 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .discoverySuppress(true)
       .instanceFormatId(List.of(FORMATS[1]))
       .tags(instanceTags("future"))
-      .items(List.of(new Item().id(randomId()).effectiveLocationId(LOCATIONS[1])));
+      .items(List.of(new Item().id(randomId()).effectiveLocationId(LOCATIONS[1]).status(itemStatus(AVAILABLE))))
+      .holdings(List.of(new Holding().id(randomId()).permanentLocationId(PERMANENT_LOCATIONS[1])));
 
     instances[2]
       .source("FOLIO")
@@ -238,8 +276,8 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .instanceFormatId(List.of(FORMATS[2]))
       .tags(instanceTags("future", "science"))
       .items(List.of(
-        new Item().id(randomId()).effectiveLocationId(LOCATIONS[0]),
-        new Item().id(randomId()).effectiveLocationId(LOCATIONS[1])));
+        new Item().id(randomId()).effectiveLocationId(LOCATIONS[0]).status(itemStatus(MISSING)),
+        new Item().id(randomId()).effectiveLocationId(LOCATIONS[1]).status(itemStatus(CHECKED_OUT))));
 
     instances[3]
       .source("MARC")
@@ -249,7 +287,11 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .instanceTypeId(TYPES[1])
       .instanceFormatId(List.of(FORMATS))
       .tags(instanceTags("casual", "cooking"))
-      .items(List.of(new Item().id(randomId()).effectiveLocationId(LOCATIONS[0])));
+      .items(List.of(new Item().id(randomId()).effectiveLocationId(LOCATIONS[0]).status(itemStatus(MISSING))))
+      .holdings(List.of(
+        new Holding().id(randomId()).permanentLocationId(PERMANENT_LOCATIONS[0]),
+        new Holding().id(randomId()).permanentLocationId(PERMANENT_LOCATIONS[1]),
+        new Holding().id(randomId()).permanentLocationId(PERMANENT_LOCATIONS[2])));
 
     instances[4]
       .source("FOLIO")
@@ -258,10 +300,15 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .instanceFormatId(List.of(FORMATS[1]))
       .tags(instanceTags("cooking"))
       .items(List.of(
-        new Item().id(randomId()).effectiveLocationId(LOCATIONS[0]),
-        new Item().id(randomId()).effectiveLocationId(LOCATIONS[1])));
+        new Item().id(randomId()).effectiveLocationId(LOCATIONS[0]).status(itemStatus(CHECKED_OUT)),
+        new Item().id(randomId()).effectiveLocationId(LOCATIONS[1]).status(itemStatus(AVAILABLE))))
+      .holdings(List.of(new Holding().id(randomId()).permanentLocationId(PERMANENT_LOCATIONS[2])));
 
     return instances;
+  }
+
+  private static ItemStatus itemStatus(NameEnum itemStatus) {
+    return new ItemStatus().name(itemStatus);
   }
 
   private static InstanceTags instanceTags(String... tags) {

--- a/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
@@ -3,9 +3,6 @@ package org.folio.search.controller;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.folio.search.domain.dto.ItemStatus.NameEnum.AVAILABLE;
-import static org.folio.search.domain.dto.ItemStatus.NameEnum.CHECKED_OUT;
-import static org.folio.search.domain.dto.ItemStatus.NameEnum.MISSING;
 import static org.folio.search.support.base.ApiEndpoints.getFacets;
 import static org.folio.search.support.base.ApiEndpoints.searchInstancesByQuery;
 import static org.folio.search.utils.TestUtils.OBJECT_MAPPER;
@@ -33,7 +30,6 @@ import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.InstanceTags;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.domain.dto.ItemStatus;
-import org.folio.search.domain.dto.ItemStatus.NameEnum;
 import org.folio.search.support.base.BaseIntegrationTest;
 import org.folio.search.utils.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
@@ -48,7 +44,9 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @IntegrationTest
 class SearchInstanceFilterIT extends BaseIntegrationTest {
-
+  private static final String AVAILABLE = "Available";
+  private static final String CHECKED_OUT = "Checked out";
+  private static final String MISSING = "Missing";
   private static final String TENANT_ID = "filter_test_instance";
 
   private static final String[] IDS = array(
@@ -307,7 +305,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
     return instances;
   }
 
-  private static ItemStatus itemStatus(NameEnum itemStatus) {
+  private static ItemStatus itemStatus(String itemStatus) {
     return new ItemStatus().name(itemStatus);
   }
 

--- a/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
@@ -27,6 +27,7 @@ import org.folio.search.domain.dto.Facet;
 import org.folio.search.domain.dto.FacetResult;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.InstanceTags;
+import org.folio.search.domain.dto.Item;
 import org.folio.search.support.base.BaseIntegrationTest;
 import org.folio.search.utils.types.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
@@ -44,9 +45,25 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
 
   private static final String TENANT_ID = "filter_test_instance";
 
-  private static final String[] IDS = generateRandomIds(5);
-  private static final String[] FORMATS = generateRandomIds(3);
-  private static final String[] TYPES = generateRandomIds(2);
+  private static final String[] IDS = array(
+    "1353873c-0e5e-4d64-a2f9-6c444dc4cd46",
+    "cc6bbc19-3f54-43c5-8736-b85688619641",
+    "39a52d91-8dbb-4348-ab06-5c6115e600cd",
+    "62f72eeb-ed5a-4619-b01f-1750d5528d25",
+    "6d9ccc82-8142-4fbc-b6ba-8e3429fd9aca");
+
+  private static final String[] FORMATS = array(
+    "89f6d4f0-9cd2-4015-828d-331dc3adb47a",
+    "25a81102-a2a9-4576-85ff-133ebcbcef2c",
+    "e57e36a3-80ff-46a6-ac2f-5c8bd79bc2bb");
+
+  private static final String[] TYPES = array(
+    "24da24dd-03ae-4e34-bad6-c79e342baeb9",
+    "de9e38bb-89a8-43ee-922f-c973b122cbb3");
+
+  private static final String[] LOCATIONS = array(
+    "ce23dfa1-17e8-4a1f-ad6b-34ce6ab352c2",
+    "f1a49577-5096-4771-a8a0-d07d642241eb");
 
   @BeforeAll
   static void createTenant(@Autowired MockMvc mockMvc) {
@@ -91,14 +108,16 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       arguments("(id=* and languages==\"fra\") sortby title", List.of(IDS[1], IDS[4])),
       arguments("(id=* and languages==\"rus\") sortby title", List.of(IDS[2])),
       arguments("(id=* and languages==\"ukr\") sortby title", List.of(IDS[2])),
+      arguments("(languages==\"ukr\") sortby title", List.of(IDS[2])),
 
       arguments("(id=* and source==\"MARC\" and languages==\"eng\") sortby title", List.of(IDS[0], IDS[1])),
       arguments("(id=* and source==\"FOLIO\" and languages==\"eng\") sortby title", List.of(IDS[4])),
+      arguments("(source==\"FOLIO\" and languages==\"eng\") sortby title", List.of(IDS[4])),
 
       arguments(format("(id=* and instanceTypeId==%s) sortby title", TYPES[0]), List.of(IDS[1], IDS[2])),
       arguments(format("(id=* and instanceTypeId==%s) sortby title", TYPES[1]), List.of(IDS[0], IDS[3], IDS[4])),
 
-      arguments(format("(id=* and instanceFormatId==\"%s\") sortby title", FORMATS[0]), List.of(IDS[1], IDS[3])),
+      arguments(format("(id=* and instanceFormatId==\"%s\") sortby title", FORMATS[0]), List.of(IDS[3])),
       arguments(format("(id=* and instanceFormatId==%s) sortby title", FORMATS[1]),
         List.of(IDS[0], IDS[1], IDS[3], IDS[4])),
       arguments(format("(id=* and instanceFormatId==%s) sortby title", FORMATS[2]), List.of(IDS[0], IDS[2], IDS[3])),
@@ -106,19 +125,29 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
 
       arguments("(id=* and staffSuppress==true) sortby title", List.of(IDS[0], IDS[1], IDS[2])),
       arguments("(id=* and staffSuppress==false) sortby title", List.of(IDS[3], IDS[4])),
+      arguments("(staffSuppress==false) sortby title", List.of(IDS[3], IDS[4])),
 
       arguments("(id=* and discoverySuppress==true) sortby title", List.of(IDS[0], IDS[1])),
       arguments("(id=* and discoverySuppress==false) sortby title", List.of(IDS[2], IDS[3], IDS[4])),
+      arguments("(discoverySuppress==false) sortby title", List.of(IDS[2], IDS[3], IDS[4])),
       arguments("(id=* and staffSuppress==true and discoverySuppress==false) sortby title", List.of(IDS[2])),
 
       arguments("(id=* and instanceTags==text) sortby title", List.of(IDS[0])),
-      arguments("(id=* and instanceTags==science) sortby title", List.of(IDS[0], IDS[2]))
+      arguments("(id=* and instanceTags==science) sortby title", List.of(IDS[0], IDS[2])),
+      arguments("(instanceTags==science) sortby title", List.of(IDS[0], IDS[2])),
+
+      arguments(String.format("(id=* and items.effectiveLocationId==%s) sortby title", LOCATIONS[0]),
+        List.of(IDS[0], IDS[2], IDS[3], IDS[4])),
+      arguments(String.format("(id=* and items.effectiveLocationId==%s) sortby title", LOCATIONS[1]),
+        List.of(IDS[1], IDS[2], IDS[4])),
+      arguments(String.format("(items.effectiveLocationId==%s) sortby title", LOCATIONS[0]),
+        List.of(IDS[0], IDS[2], IDS[3], IDS[4]))
     );
   }
 
   private static Stream<Arguments> facetQueriesProvider() {
     var allFacets = array("discoverySuppress", "staffSuppress", "languages", "instanceTags", "source",
-      "instanceTypeId", "instanceFormatId");
+      "instanceTypeId", "instanceFormatId", "items.effectiveLocationId");
     return Stream.of(
       arguments("id=*", allFacets, mapOf(
         "discoverySuppress", facet(facetItem("false", 3), facetItem("true", 2)),
@@ -129,7 +158,8 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
           facetItem("casual", 1), facetItem("text", 1)),
         "source", facet(facetItem("MARC", 3), facetItem("FOLIO", 2)),
         "instanceTypeId", facet(facetItem(TYPES[1], 3), facetItem(TYPES[0], 2)),
-        "instanceFormatId", facet(facetItem(FORMATS[1], 4), facetItem(FORMATS[2], 3), facetItem(FORMATS[0], 2)))),
+        "instanceFormatId", facet(facetItem(FORMATS[1], 4), facetItem(FORMATS[2], 3), facetItem(FORMATS[0], 1)),
+        "items.effectiveLocationId", facet(facetItem(LOCATIONS[0], 4), facetItem(LOCATIONS[1], 3)))),
 
       arguments("id=*", array("source"), mapOf("source", facet(facetItem("MARC", 3), facetItem("FOLIO", 2)))),
 
@@ -137,6 +167,9 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
         facetItem("ita", 2), facetItem("ger", 1), facetItem("rus", 1), facetItem("ukr", 1)))),
 
       arguments("id=*", array("languages:2"), mapOf("languages", facet(facetItem("eng", 3), facetItem("fra", 2)))),
+
+      arguments("languages==eng", array("languages:2"), mapOf(
+        "languages", facet(facetItem("eng", 3), facetItem("fra", 2)))),
 
       arguments("id=*", array("discoverySuppress"), mapOf(
         "discoverySuppress", facet(facetItem("false", 3), facetItem("true", 2)))),
@@ -155,7 +188,20 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
         facetItem(TYPES[1], 3), facetItem(TYPES[0], 2)))),
 
       arguments("id=*", array("instanceFormatId"), mapOf("instanceFormatId", facet(
-        facetItem(FORMATS[1], 4), facetItem(FORMATS[2], 3), facetItem(FORMATS[0], 2))))
+        facetItem(FORMATS[1], 4), facetItem(FORMATS[2], 3), facetItem(FORMATS[0], 1)))),
+
+      arguments("instanceFormatId==" + FORMATS[0], array("instanceFormatId"), mapOf(
+        "instanceFormatId", facet(facetItem(FORMATS[1], 4), facetItem(FORMATS[2], 3), facetItem(FORMATS[0], 1)))),
+
+      arguments("source==MARC", array("instanceFormatId"), mapOf(
+        "instanceFormatId", facet(facetItem(FORMATS[1], 3), facetItem(FORMATS[2], 2), facetItem(FORMATS[0], 1)))),
+
+      arguments("id=*", array("items.effectiveLocationId"), mapOf(
+        "items.effectiveLocationId", facet(facetItem(LOCATIONS[0], 4), facetItem(LOCATIONS[1], 3)))),
+
+      arguments("source==MARC", array("source", "items.effectiveLocationId"), mapOf(
+        "source", facet(facetItem("MARC", 3), facetItem("FOLIO", 2)),
+        "items.effectiveLocationId", facet(facetItem(LOCATIONS[0], 2), facetItem(LOCATIONS[1], 1))))
     );
   }
 
@@ -171,7 +217,8 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .staffSuppress(true)
       .discoverySuppress(true)
       .instanceFormatId(List.of(FORMATS[1], FORMATS[2]))
-      .tags(instanceTags("text", "science"));
+      .tags(instanceTags("text", "science"))
+      .items(List.of(new Item().id(randomId()).effectiveLocationId(LOCATIONS[0])));
 
     instances[1]
       .source("MARC")
@@ -179,8 +226,9 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .instanceTypeId(TYPES[0])
       .staffSuppress(true)
       .discoverySuppress(true)
-      .instanceFormatId(List.of(FORMATS[0], FORMATS[1]))
-      .tags(instanceTags("future"));
+      .instanceFormatId(List.of(FORMATS[1]))
+      .tags(instanceTags("future"))
+      .items(List.of(new Item().id(randomId()).effectiveLocationId(LOCATIONS[1])));
 
     instances[2]
       .source("FOLIO")
@@ -188,7 +236,10 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .instanceTypeId(TYPES[0])
       .staffSuppress(true)
       .instanceFormatId(List.of(FORMATS[2]))
-      .tags(instanceTags("future", "science"));
+      .tags(instanceTags("future", "science"))
+      .items(List.of(
+        new Item().id(randomId()).effectiveLocationId(LOCATIONS[0]),
+        new Item().id(randomId()).effectiveLocationId(LOCATIONS[1])));
 
     instances[3]
       .source("MARC")
@@ -197,23 +248,23 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .discoverySuppress(false)
       .instanceTypeId(TYPES[1])
       .instanceFormatId(List.of(FORMATS))
-      .tags(instanceTags("casual", "cooking"));
+      .tags(instanceTags("casual", "cooking"))
+      .items(List.of(new Item().id(randomId()).effectiveLocationId(LOCATIONS[0])));
 
     instances[4]
       .source("FOLIO")
       .languages(List.of("eng", "fra"))
       .instanceTypeId(TYPES[1])
       .instanceFormatId(List.of(FORMATS[1]))
-      .tags(instanceTags("cooking"));
+      .tags(instanceTags("cooking"))
+      .items(List.of(
+        new Item().id(randomId()).effectiveLocationId(LOCATIONS[0]),
+        new Item().id(randomId()).effectiveLocationId(LOCATIONS[1])));
 
     return instances;
   }
 
   private static InstanceTags instanceTags(String... tags) {
     return new InstanceTags().tagList(asList(tags));
-  }
-
-  private static String[] generateRandomIds(int size) {
-    return IntStream.range(0, size).mapToObj(i -> randomId()).toArray(String[]::new);
   }
 }


### PR DESCRIPTION
- [MSEARCH-55](https://issues.folio.org/browse/MSEARCH-55) Instance - filter/facet by item effective locations 
- [MSEARCH-56](https://issues.folio.org/browse/MSEARCH-56) Holdings - filter/facet by permanent locations 
- [MSEARCH-63](https://issues.folio.org/browse/MSEARCH-63) Item - status filters/facets