### PR TITLE
MSEARCH-75: Make Kafka consumer batch smaller.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   kafka:
     bootstrap-servers: ${KAFKA_HOST:kafka}:${KAFKA_PORT:9092}
     consumer:
-      max-poll-records: 200
+      max-poll-records: 50
   datasource:
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:postgres}


### PR DESCRIPTION
There is a known restrictions related to URI length for GET requests, it is limited to ~1000 bytes.

This PR makes the batch size for consumer = 50 so that there will be no case when we rich this URI limit (50 ids is sent in inventory-view request)