### PR TITLE
MSEARCH-12: Implement items.effectiveCallNumberComponents search.

### DIFF
--- a/src/main/java/org/folio/search/service/metadata/LocalSearchFieldProvider.java
+++ b/src/main/java/org/folio/search/service/metadata/LocalSearchFieldProvider.java
@@ -131,7 +131,16 @@ public class LocalSearchFieldProvider implements SearchFieldProvider {
   private static Map<String, List<String>> collectFieldsBySearchType(ResourceDescription description) {
     var fieldsBySearchType = new LinkedHashMap<String, List<String>>();
 
-    description.getFlattenFields().forEach((fieldPath, currentFieldDesc) -> {
+    collectFieldsBySearchType(fieldsBySearchType, description.getFlattenFields());
+    collectFieldsBySearchType(fieldsBySearchType, description.getSearchFields());
+
+    return fieldsBySearchType;
+  }
+
+  private static void collectFieldsBySearchType(
+    Map<String, List<String>> fieldsBySearchType, Map<String, ? extends PlainFieldDescription> fields) {
+
+    fields.forEach((fieldPath, currentFieldDesc) -> {
       final var updatedPath = currentFieldDesc.isMultilang()
         ? updatePathForMultilangField(fieldPath) : fieldPath;
 
@@ -139,8 +148,6 @@ public class LocalSearchFieldProvider implements SearchFieldProvider {
         .map(type -> fieldsBySearchType.computeIfAbsent(type, k -> new ArrayList<>()))
         .forEach(list -> list.add(updatedPath));
     });
-
-    return fieldsBySearchType;
   }
 
   private static Map<String, List<String>> collectSourceFields(List<ResourceDescription> descriptions) {

--- a/src/main/java/org/folio/search/service/setter/item/EffectiveCallNumberComponentsProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/EffectiveCallNumberComponentsProcessor.java
@@ -1,0 +1,43 @@
+package org.folio.search.service.setter.item;
+
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.search.domain.dto.Item;
+import org.folio.search.service.setter.FieldProcessor;
+import org.folio.search.utils.JsonConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EffectiveCallNumberComponentsProcessor implements FieldProcessor<Set<String>> {
+  private final JsonConverter jsonConverter;
+
+  @Override
+  public Set<String> getFieldValue(Map<String, Object> eventBody) {
+    var items = jsonConverter.convert(eventBody.get("items"), new TypeReference<List<Item>>() {});
+
+    if (items == null) {
+      return emptySet();
+    }
+
+    return items.stream()
+      .map(Item::getEffectiveCallNumberComponents)
+      .filter(Objects::nonNull)
+      .map(cn -> Stream.of(cn.getPrefix(), cn.getCallNumber(), cn.getSuffix())
+        .filter(StringUtils::isNotBlank)
+        .map(String::trim)
+        .collect(joining(" ")))
+      .filter(StringUtils::isNotBlank)
+      .collect(toSet());
+  }
+}

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -202,6 +202,20 @@
         "materialTypeId": {
           "searchTypes": [ "facet", "filter" ],
           "index": "keyword"
+        },
+        "effectiveCallNumberComponents": {
+          "type": "object",
+          "properties": {
+            "callNumber": {
+              "index": "source"
+            },
+            "prefix": {
+              "index": "source"
+            },
+            "suffix": {
+              "index": "source"
+            }
+          }
         }
       }
     },
@@ -262,6 +276,12 @@
       "type": "search",
       "processor": "discoverySuppressProcessor",
       "index": "bool"
+    },
+    "itemsFullCallNumbers": {
+      "type": "search",
+      "index": "keyword",
+      "inventorySearchTypes": ["items.effectiveCallNumberComponents", "items.fullCallNumber"],
+      "processor": "effectiveCallNumberComponentsProcessor"
     }
   },
   "indexMappings": {

--- a/src/main/resources/swagger.api/schemas/item.json
+++ b/src/main/resources/swagger.api/schemas/item.json
@@ -32,6 +32,24 @@
     "materialTypeId": {
       "type": "string",
       "description": "Material type, term. Define what type of thing the item is."
+    },
+    "effectiveCallNumberComponents": {
+      "type": "object",
+      "description": "Elements of a full call number generated from the item or holding",
+      "properties": {
+        "callNumber": {
+          "type": "string",
+          "description": "Effective Call Number is an identifier assigned to an item or its holding and associated with the item."
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Effective Call Number Prefix is the prefix of the identifier assigned to an item or its holding and associated with the item."
+        },
+        "suffix": {
+          "type": "string",
+          "description": "Effective Call Number Suffix is the suffix of the identifier assigned to an item or its holding and associated with the item."
+        }
+      }
     }
   }
 }

--- a/src/test/java/org/folio/search/controller/SearchItemIT.java
+++ b/src/test/java/org/folio/search/controller/SearchItemIT.java
@@ -1,0 +1,26 @@
+package org.folio.search.controller;
+
+import static org.folio.search.sample.SampleInstances.getSemanticWeb;
+import static org.folio.search.support.base.ApiEndpoints.searchInstancesByQuery;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import org.folio.search.support.base.BaseIntegrationTest;
+import org.folio.search.utils.types.IntegrationTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@IntegrationTest
+public class SearchItemIT extends BaseIntegrationTest {
+
+  @CsvSource({
+    "items.fullCallNumber=={value}, prefix-90000 TK51*",
+    "items.effectiveCallNumberComponents=={value}, *suffix-10101"
+  })
+  @ParameterizedTest(name = "[{index}] {0}: {1}")
+  void canSearchByItems_wildcardMatch(String query, String value) throws Throwable {
+    doGet(searchInstancesByQuery(query), value)
+      .andExpect(jsonPath("totalRecords", is(1)))
+      .andExpect(jsonPath("instances[0].id", is(getSemanticWeb().getId())));
+  }
+}

--- a/src/test/java/org/folio/search/controller/SearchItemIT.java
+++ b/src/test/java/org/folio/search/controller/SearchItemIT.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 @IntegrationTest
-public class SearchItemIT extends BaseIntegrationTest {
+class SearchItemIT extends BaseIntegrationTest {
 
   @CsvSource({
     "items.fullCallNumber=={value}, prefix-90000 TK51*",

--- a/src/test/java/org/folio/search/service/metadata/LocalSearchFieldProviderTest.java
+++ b/src/test/java/org/folio/search/service/metadata/LocalSearchFieldProviderTest.java
@@ -5,18 +5,20 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestUtils.mapOf;
 import static org.folio.search.utils.TestUtils.objectField;
-import static org.folio.search.utils.TestUtils.resourceDescription;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.folio.search.exception.ResourceDescriptionException;
 import org.folio.search.model.metadata.FieldDescription;
 import org.folio.search.model.metadata.PlainFieldDescription;
 import org.folio.search.model.metadata.ResourceDescription;
+import org.folio.search.model.metadata.SearchFieldDescriptor;
 import org.folio.search.model.metadata.SearchFieldType;
+import org.folio.search.utils.TestUtils;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,7 +62,8 @@ class LocalSearchFieldProviderTest {
   @Test
   void getFieldByInventorySearchType_positive() {
     var fields = searchFieldProvider.getFields(RESOURCE_NAME, TITLE_SEARCH_TYPE);
-    assertThat(fields).containsExactlyInAnyOrder("title1.*", "title2.sub1", "title2.sub2.*", "title2.sub3.sub4");
+    assertThat(fields).containsExactlyInAnyOrder("title1.*", "title2.sub1", "title2.sub2.*",
+      "title2.sub3.sub4", "search1");
   }
 
   @Test
@@ -143,7 +146,10 @@ class LocalSearchFieldProviderTest {
           "sub3", objectField(mapOf(
             "sub4", plainField("keyword", false, TITLE_SEARCH_TYPE),
             "sub5", plainField("multilang", true))))),
-        "source", plainField("keyword", true)))
+        "source", plainField("keyword", true)),
+        mapOf(
+          "search1", searchField(TITLE_SEARCH_TYPE),
+          "search2", searchField()))
     );
   }
 
@@ -168,5 +174,22 @@ class LocalSearchFieldProviderTest {
     fieldDescription.setInventorySearchTypes(List.of(searchTypes));
     fieldDescription.setShowInResponse(showInResponse);
     return fieldDescription;
+  }
+
+  private static SearchFieldDescriptor searchField(String... searchTypes) {
+    var fieldDescription = new SearchFieldDescriptor();
+    fieldDescription.setIndex("keyword");
+    fieldDescription.setInventorySearchTypes(List.of(searchTypes));
+    fieldDescription.setProcessor("processor");
+    return fieldDescription;
+  }
+
+  private static ResourceDescription resourceDescription(
+    Map<String, FieldDescription> fields, Map<String, SearchFieldDescriptor> searchFields) {
+
+    var resourceDescription = TestUtils.resourceDescription(fields);
+    resourceDescription.setSearchFields(searchFields);
+
+    return resourceDescription;
   }
 }

--- a/src/test/java/org/folio/search/service/setter/item/EffectiveCallNumberComponentsProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/EffectiveCallNumberComponentsProcessorTest.java
@@ -1,0 +1,59 @@
+package org.folio.search.service.setter.item;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.TestUtils.OBJECT_MAPPER;
+
+import java.util.List;
+import java.util.Map;
+import org.folio.search.domain.dto.Item;
+import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
+import org.folio.search.utils.JsonConverter;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class EffectiveCallNumberComponentsProcessorTest {
+  private final JsonConverter jsonConverter = new JsonConverter(OBJECT_MAPPER);
+  private final EffectiveCallNumberComponentsProcessor processor =
+    new EffectiveCallNumberComponentsProcessor(jsonConverter);
+
+  @Test
+  void canGetFieldValue_multipleItems() {
+    var items = List.of(itemWithCallNumber("prefix1", "cn1", "suffix1"),
+      itemWithCallNumber("prefix2", "cn2", "suffix2"));
+
+    assertThat(processor.getFieldValue(Map.of("items", items)))
+      .containsExactlyInAnyOrder("prefix1 cn1 suffix1", "prefix2 cn2 suffix2");
+  }
+
+  @Test
+  void canGetFieldValue_someComponentsAreNulls() {
+    var items = List.of(
+      itemWithCallNumber(null, "cn1", "suffix1"),
+      itemWithCallNumber("prefix2", "cn2", null),
+      itemWithCallNumber(null, "cn3", null));
+
+    assertThat(processor.getFieldValue(Map.of("items", items)))
+      .containsExactlyInAnyOrder("cn1 suffix1", "prefix2 cn2", "cn3");
+  }
+
+  @Test
+  void shouldReturnEmptySetWhenNoItems() {
+    assertThat(processor.getFieldValue(emptyMap())).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptySetWhenItemsHasNoCallNumber() {
+    var items = List.of(new Item(), new Item(),
+      new Item().effectiveCallNumberComponents(new ItemEffectiveCallNumberComponents()));
+
+    assertThat(processor.getFieldValue(Map.of("items", items))).isEmpty();
+  }
+
+  private Item itemWithCallNumber(String prefix, String cn, String suffix) {
+    return new Item().effectiveCallNumberComponents(
+      new ItemEffectiveCallNumberComponents()
+        .prefix(prefix).callNumber(cn).suffix(suffix));
+  }
+}

--- a/src/test/resources/samples/semantic-web-primer/items.json
+++ b/src/test/resources/samples/semantic-web-primer/items.json
@@ -7,7 +7,9 @@
     "barcode": "10101",
     "itemLevelCallNumber": "TK5105.88815 . A58 2004 FT MEADE",
     "effectiveCallNumberComponents": {
+      "suffix": "suffix-10101",
       "callNumber": "TK5105.88815 . A58 2004 FT MEADE",
+      "prefix": "prefix-10101",
       "typeId": "512173a7-bd09-490e-b773-17d83f2b63fe"
     },
     "volume": "v1",
@@ -54,7 +56,9 @@
     "barcode": "90000",
     "itemLevelCallNumber": "TK5105.88815 . A58 2004 FT MEADE",
     "effectiveCallNumberComponents": {
+      "prefix": "prefix-90000",
       "callNumber": "TK5105.88815 . A58 2004 FT MEADE",
+      "suffix": "suffix-90000",
       "typeId": "512173a7-bd09-490e-b773-17d83f2b63fe"
     },
     "enumeration": "",


### PR DESCRIPTION
## Approach:

1. Generate a synthetic instance-level property called `itemsFullCallNumbers` - that is a string array of concatenated `prefix callNumber suffix` (concatenated with space) for each item of the instance. The property has search aliases -  `items.effectiveCallNumberComponents`, `items.fullCallNumber`.

2. The `src/main/java/org/folio/search/service/metadata/LocalSearchFieldProvider.java` has been updated to support the search aliases for `searchFields` as well as for regular fields.
