### PR TITLE
MSEARCH-72: Throw more explicit error if tenant is not initialized yet

### DIFF
--- a/src/main/java/org/folio/search/controller/FolioTenantController.java
+++ b/src/main/java/org/folio/search/controller/FolioTenantController.java
@@ -36,6 +36,7 @@ public class FolioTenantController extends TenantController {
       tenantService.initializeTenant();
     }
 
+    log.info("Tenant init has been completed [response={}]", tenantInit);
     return tenantInit;
   }
 }

--- a/src/main/java/org/folio/search/exception/TenantNotInitializedException.java
+++ b/src/main/java/org/folio/search/exception/TenantNotInitializedException.java
@@ -3,9 +3,9 @@ package org.folio.search.exception;
 import java.util.Arrays;
 
 public class TenantNotInitializedException extends RuntimeException {
-  public TenantNotInitializedException(String ... tenants) {
+  public TenantNotInitializedException(String[] tenants, Throwable cause) {
     // This will construct an exception without stack trace.
     super("Following tenants might not be initialized yet: " + Arrays.toString(tenants),
-      null, false, false);
+      cause, false, false);
   }
 }

--- a/src/main/java/org/folio/search/exception/TenantNotInitializedException.java
+++ b/src/main/java/org/folio/search/exception/TenantNotInitializedException.java
@@ -1,0 +1,11 @@
+package org.folio.search.exception;
+
+import java.util.Arrays;
+
+public class TenantNotInitializedException extends RuntimeException {
+  public TenantNotInitializedException(String ... tenants) {
+    // This will construct an exception without stack trace.
+    super("Following tenants might not be initialized yet: " + Arrays.toString(tenants),
+      null, false, false);
+  }
+}

--- a/src/main/java/org/folio/search/integration/KafkaMessageListener.java
+++ b/src/main/java/org/folio/search/integration/KafkaMessageListener.java
@@ -39,7 +39,8 @@ public class KafkaMessageListener {
     containerFactory = "kafkaListenerContainerFactory",
     topics = "#{'${application.kafka.listener.events.topics}'.split(',')}",
     groupId = "${application.kafka.listener.events.group-id}",
-    concurrency = "${application.kafka.listener.events.concurrency}")
+    concurrency = "${application.kafka.listener.events.concurrency}",
+    errorHandler = "kafkaErrorHandler")
   public void handleEvents(List<ConsumerRecord<String, ResourceEventBody>> consumerRecords) {
     log.info("Processing instance ids from kafka events [number of events: {}]", consumerRecords.size());
     var resourceIds = consumerRecords.stream()

--- a/src/main/java/org/folio/search/integration/error/KafkaErrorHandler.java
+++ b/src/main/java/org/folio/search/integration/error/KafkaErrorHandler.java
@@ -29,13 +29,13 @@ public class KafkaErrorHandler implements KafkaListenerErrorHandler {
     // which is treated as a grammar exception.
     // It is possible to have false positives here, when an invalid SQL is used
     // but anyway it results in retrying the consume operation
-    return getThrowableList(exception).stream().anyMatch(ex -> ex instanceof SQLGrammarException);
+    return getThrowableList(exception).stream().anyMatch(SQLGrammarException.class::isInstance);
   }
 
   @SuppressWarnings("unchecked")
   private String[] getTenantNames(Message<?> message) {
     if (!isSupportedType(message)) {
-      return null;
+      return new String[0];
     }
     var consumerRecords = (List<ConsumerRecord<String, ResourceEventBody>>) message.getPayload();
     return consumerRecords.stream()
@@ -52,7 +52,7 @@ public class KafkaErrorHandler implements KafkaListenerErrorHandler {
     }
 
     var payloads = (List) message.getPayload();
-    return payloads.size() > 0 && payloads.get(0) instanceof ConsumerRecord
+    return !payloads.isEmpty() && payloads.get(0) instanceof ConsumerRecord
       && ((ConsumerRecord) payloads.get(0)).value() instanceof ResourceEventBody;
   }
 }

--- a/src/main/java/org/folio/search/integration/error/KafkaErrorHandler.java
+++ b/src/main/java/org/folio/search/integration/error/KafkaErrorHandler.java
@@ -1,0 +1,58 @@
+package org.folio.search.integration.error;
+
+import static org.apache.commons.lang3.exception.ExceptionUtils.getThrowableList;
+
+import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.folio.search.domain.dto.ResourceEventBody;
+import org.folio.search.exception.TenantNotInitializedException;
+import org.hibernate.exception.SQLGrammarException;
+import org.springframework.kafka.listener.KafkaListenerErrorHandler;
+import org.springframework.kafka.listener.ListenerExecutionFailedException;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KafkaErrorHandler implements KafkaListenerErrorHandler {
+  @Override
+  public Object handleError(Message<?> message, ListenerExecutionFailedException exception) {
+    if (isTenantNotInitializedYet(exception)) {
+      throw new TenantNotInitializedException(getTenantNames(message));
+    } else {
+      throw exception;
+    }
+  }
+
+  private boolean isTenantNotInitializedYet(ListenerExecutionFailedException exception) {
+    // In case when the schema for tenant is not created
+    // DB will throw an error saying that a table does not exists
+    // which is treated as a grammar exception.
+    // It is possible to have false positives here, when an invalid SQL is used
+    // but anyway it results in retrying the consume operation
+    return getThrowableList(exception).stream().anyMatch(ex -> ex instanceof SQLGrammarException);
+  }
+
+  @SuppressWarnings("unchecked")
+  private String[] getTenantNames(Message<?> message) {
+    if (!isSupportedType(message)) {
+      return null;
+    }
+    var consumerRecords = (List<ConsumerRecord<String, ResourceEventBody>>) message.getPayload();
+    return consumerRecords.stream()
+      .map(ConsumerRecord::value)
+      .map(ResourceEventBody::getTenant)
+      .distinct()
+      .toArray(String[]::new);
+  }
+
+  @SuppressWarnings("rawtypes")
+  private boolean isSupportedType(Message<?> message) {
+    if (!(message.getPayload() instanceof List)) {
+      return false;
+    }
+
+    var payloads = (List) message.getPayload();
+    return payloads.size() > 0 && payloads.get(0) instanceof ConsumerRecord
+      && ((ConsumerRecord) payloads.get(0)).value() instanceof ResourceEventBody;
+  }
+}

--- a/src/main/java/org/folio/search/service/systemuser/SystemUserService.java
+++ b/src/main/java/org/folio/search/service/systemuser/SystemUserService.java
@@ -46,18 +46,23 @@ public class SystemUserService {
   private final SystemUserTokenCache tokenCache;
 
   public void prepareSystemUser(FolioExecutionContext context) {
+    log.info("Preparing system user...");
     var folioUser = getFolioUser(folioSystemUserConf.getUsername());
     var userId = folioUser.map(User::getId)
       .orElse(UUID.randomUUID().toString());
 
     if (folioUser.isPresent()) {
+      log.info("System user already exists");
       addPermissions(userId);
     } else {
+      log.info("No system user exist, creating...");
+
       createFolioUser(userId);
       saveCredentials();
       assignPermissions(userId);
     }
 
+    log.info("System user has been created");
     systemUserRepository.save(SystemUser.builder()
       .id(userId)
       .username(folioSystemUserConf.getUsername())

--- a/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
+++ b/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
@@ -1,0 +1,56 @@
+package org.folio.search.integration;
+
+import static org.apache.commons.lang3.exception.ExceptionUtils.getThrowableList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.folio.search.utils.TestUtils.randomId;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.ResourceEventBody;
+import org.folio.search.integration.error.KafkaErrorHandler;
+import org.folio.search.support.base.BaseIntegrationTest;
+import org.folio.search.utils.types.IntegrationTest;
+import org.hibernate.exception.SQLGrammarException;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.kafka.listener.ListenerExecutionFailedException;
+import org.springframework.messaging.Message;
+
+@IntegrationTest
+class KafkaMessageListenerIT extends BaseIntegrationTest {
+  @SpyBean
+  private KafkaErrorHandler errorHandler;
+  @SpyBean
+  private ResourceFetchService fetchService;
+
+  @Test
+  void shouldReConsumeMessageWhenTenantNotInitialized() {
+    var tenantName = "not_existent_tenant";
+    inventoryApi.createInstance(tenantName,
+      new Instance().id(randomId()));
+
+    await().untilAsserted(() -> {
+      var messageCaptor = forClass(Message.class);
+      var exceptionCaptor = forClass(ListenerExecutionFailedException.class);
+
+      verify(errorHandler, times(2)).handleError(messageCaptor.capture(), exceptionCaptor.capture());
+
+      messageCaptor.getAllValues().forEach(message -> {
+        @SuppressWarnings("unchecked")
+        var consumerRecords = (List<ConsumerRecord<String, ResourceEventBody>>) message.getPayload();
+        assertThat(consumerRecords).hasSizeGreaterThanOrEqualTo(1);
+        assertThat(consumerRecords.get(0).value())
+          .extracting(ResourceEventBody::getTenant).isEqualTo(tenantName);
+      });
+
+      exceptionCaptor.getAllValues()
+        .forEach(ex -> assertThat(getThrowableList(ex))
+          .hasAtLeastOneElementOfType(SQLGrammarException.class));
+    });
+  }
+}

--- a/src/test/java/org/folio/search/integration/error/KafkaErrorHandlerTest.java
+++ b/src/test/java/org/folio/search/integration/error/KafkaErrorHandlerTest.java
@@ -27,17 +27,18 @@ class KafkaErrorHandlerTest {
 
     assertThatThrownBy(() -> errorHandler.handleError(message, exception))
       .isInstanceOf(TenantNotInitializedException.class)
-      .hasMessage("Following tenants might not be initialized yet: [one, two]");
+      .hasMessage("Following tenants might not be initialized yet: [one, two]")
+      .hasCauseExactlyInstanceOf(SQLGrammarException.class);
   }
 
   @Test
-  void shouldThrowTenantInitializationExceptionEventWithUnsupportedMessage() {
+  void shouldPropagateOriginalExceptionWhenUnsupportedMessage() {
     var message = buildMessage(Map.of());
     var exception = buildException(new SQLGrammarException("grammar", new SQLException()));
 
     assertThatThrownBy(() -> errorHandler.handleError(message, exception))
-      .isInstanceOf(TenantNotInitializedException.class)
-      .hasMessage("Following tenants might not be initialized yet: []");
+      .isInstanceOf(ListenerExecutionFailedException.class)
+      .hasCauseExactlyInstanceOf(SQLGrammarException.class);
   }
 
   @Test

--- a/src/test/java/org/folio/search/integration/error/KafkaErrorHandlerTest.java
+++ b/src/test/java/org/folio/search/integration/error/KafkaErrorHandlerTest.java
@@ -37,7 +37,7 @@ class KafkaErrorHandlerTest {
 
     assertThatThrownBy(() -> errorHandler.handleError(message, exception))
       .isInstanceOf(TenantNotInitializedException.class)
-      .hasMessage("Following tenants might not be initialized yet: null");
+      .hasMessage("Following tenants might not be initialized yet: []");
   }
 
   @Test

--- a/src/test/java/org/folio/search/integration/error/KafkaErrorHandlerTest.java
+++ b/src/test/java/org/folio/search/integration/error/KafkaErrorHandlerTest.java
@@ -1,0 +1,71 @@
+package org.folio.search.integration.error;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.folio.search.domain.dto.ResourceEventBody;
+import org.folio.search.exception.TenantNotInitializedException;
+import org.folio.search.utils.types.UnitTest;
+import org.hibernate.exception.SQLGrammarException;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.listener.ListenerExecutionFailedException;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
+
+@UnitTest
+class KafkaErrorHandlerTest {
+  private final KafkaErrorHandler errorHandler = new KafkaErrorHandler();
+
+  @Test
+  void shouldThrowTenantInitializationException() {
+    var message = buildResourceEvents();
+    var exception = buildException(new SQLGrammarException("grammar", new SQLException()));
+
+    assertThatThrownBy(() -> errorHandler.handleError(message, exception))
+      .isInstanceOf(TenantNotInitializedException.class)
+      .hasMessage("Following tenants might not be initialized yet: [one, two]");
+  }
+
+  @Test
+  void shouldThrowTenantInitializationExceptionEventWithUnsupportedMessage() {
+    var message = buildMessage(Map.of());
+    var exception = buildException(new SQLGrammarException("grammar", new SQLException()));
+
+    assertThatThrownBy(() -> errorHandler.handleError(message, exception))
+      .isInstanceOf(TenantNotInitializedException.class)
+      .hasMessage("Following tenants might not be initialized yet: null");
+  }
+
+  @Test
+  void shouldThrowOriginalCauseIfNotTenantInitException() {
+    var message = buildResourceEvents();
+    var exception = buildException(new IllegalStateException("illegal state exception"));
+
+    assertThatThrownBy(() -> errorHandler.handleError(message, exception))
+      .isInstanceOf(ListenerExecutionFailedException.class)
+      .hasCauseExactlyInstanceOf(IllegalStateException.class);
+  }
+
+  private Message<List<ConsumerRecord<String, ResourceEventBody>>> buildResourceEvents() {
+    var payloads = List.of(new ResourceEventBody().tenant("one"),
+      new ResourceEventBody().tenant("two"));
+
+    var consumerRecords = payloads.stream()
+      .map(payload -> new ConsumerRecord<>("topic", 1, 0, "key", payload))
+      .collect(Collectors.toList());
+
+    return buildMessage(consumerRecords);
+  }
+
+  private <T> Message<T> buildMessage(T payload) {
+    return new GenericMessage<>(payload);
+  }
+
+  private ListenerExecutionFailedException buildException(Throwable cause) {
+    return new ListenerExecutionFailedException("exception", cause);
+  }
+}


### PR DESCRIPTION
When kafka listener starts consuming events from the topic but tenant is not initialized yet we throw a `TenantNotInitializedException` vs a sql exception which confuses folks.