### PR TITLE
MSEARCH-85 cannot read mod-search.csv from classpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+bin/
+.checkstyle
 
 ### STS ###
 .apt_generated

--- a/src/main/java/org/folio/search/service/systemuser/SystemUserService.java
+++ b/src/main/java/org/folio/search/service/systemuser/SystemUserService.java
@@ -178,12 +178,8 @@ public class SystemUserService {
 
   @SneakyThrows
   private static List<String> getResourceLines(String permissionsFilePath) {
-    try {
-      ClassPathResource resource = new ClassPathResource(permissionsFilePath);
-      return IOUtils.readLines(resource.getInputStream(), StandardCharsets.UTF_8);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    return null;
+    ClassPathResource resource = new ClassPathResource(permissionsFilePath);
+    return IOUtils.readLines(resource.getInputStream(), StandardCharsets.UTF_8);
   }
+  
 }

--- a/src/main/java/org/folio/search/service/systemuser/SystemUserService.java
+++ b/src/main/java/org/folio/search/service/systemuser/SystemUserService.java
@@ -8,7 +8,7 @@ import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.
 import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.endFolioExecutionContext;
 import static org.springframework.util.CollectionUtils.isEmpty;
 
-import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.io.IOUtils;
 import org.folio.search.client.AuthnClient;
 import org.folio.search.client.PermissionsClient;
 import org.folio.search.client.UsersClient;
@@ -28,9 +29,9 @@ import org.folio.search.service.context.FolioExecutionContextBuilder;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.ResourceUtils;
 
 @Log4j2
 @RequiredArgsConstructor
@@ -177,6 +178,12 @@ public class SystemUserService {
 
   @SneakyThrows
   private static List<String> getResourceLines(String permissionsFilePath) {
-    return Files.readAllLines(ResourceUtils.getFile(permissionsFilePath).toPath());
+    try {
+      ClassPathResource resource = new ClassPathResource(permissionsFilePath);
+      return IOUtils.readLines(resource.getInputStream(), StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return null;
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ application:
     username: mod-search
     password: ${SYSTEM_USER_PASSWORD:Mod-search-1-0-0}
     lastname: System
-    permissionsFilePath: classpath:permissions/mod-search.csv
+    permissionsFilePath: permissions/mod-search.csv
   kafka:
     listener:
       events:

--- a/src/test/java/org/folio/search/service/systemuser/SystemUserServiceTest.java
+++ b/src/test/java/org/folio/search/service/systemuser/SystemUserServiceTest.java
@@ -155,7 +155,7 @@ class SystemUserServiceTest {
     return FolioSystemUserProperties.builder()
       .password("password")
       .username("username")
-      .permissionsFilePath("classpath:permissions/test-permissions.csv")
+      .permissionsFilePath("permissions/test-permissions.csv")
       .build();
   }
 
@@ -163,7 +163,7 @@ class SystemUserServiceTest {
     return FolioSystemUserProperties.builder()
       .password("password")
       .username("username")
-      .permissionsFilePath("classpath:permissions/empty-permissions.csv")
+      .permissionsFilePath("permissions/empty-permissions.csv")
       .build();
   }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,7 +31,7 @@ application:
     username: mod-search
     password: Mod-search-1-0-0
     lastname: System
-    permissionsFilePath: classpath:permissions/test-permissions.csv
+    permissionsFilePath: permissions/test-permissions.csv
   kafka:
     listener:
       events:


### PR DESCRIPTION
This PR is to address below error in Bugfest env when enabling mod-search for tenant. See https://issues.folio.org/browse/MSEARCH-85
`Caused by: java.io.FileNotFoundException: class path resource [permissions/mod-search.csv] cannot be resolved to absolute file path because it does not reside in the file system: jar:file:/usr/ms/ms.jar!/BOOT-INF/classes!/permissions/mod-search.csv`