### PR TITLE
Release mod-search 1.2.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## 1.2.1 2021-04-07
+
+* Do not add resources if index does not exist (MSEARCH-86)
+* Support DELETE event for items/holdings/instances (MSEARCH-90)
+* Change multi-match operator from `OR` to `AND` (MSEARCH-91)
+
 ## 1.2.0 2021-04-02
 
 * Adds holdings.fullCallNumber search option (MSEARCH-81)

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <name>mod-search</name>
   <groupId>org.folio</groupId>
   <artifactId>mod-search</artifactId>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.2.1</version>
   <description>FOLIO search service</description>
   <packaging>jar</packaging>
 
@@ -496,7 +496,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v1.2.0</tag>
+    <tag>v1.2.1</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <name>mod-search</name>
   <groupId>org.folio</groupId>
   <artifactId>mod-search</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2-SNAPSHOT</version>
   <description>FOLIO search service</description>
   <packaging>jar</packaging>
 
@@ -496,7 +496,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v1.2.1</tag>
+    <tag>v1.2.0</tag>
   </scm>
 
 </project>

--- a/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
@@ -2,6 +2,8 @@ package org.folio.search.cql;
 
 import static java.util.Collections.emptyList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.elasticsearch.index.query.MultiMatchQueryBuilder.Type.CROSS_FIELDS;
+import static org.elasticsearch.index.query.Operator.AND;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
@@ -126,6 +128,9 @@ public class CqlSearchQueryConverter {
       case "=":
       case "adj":
       case "all":
+        return prepareElasticsearchQuery(fieldList,
+          fields -> multiMatchQuery(term, fields.toArray(String[]::new)).operator(AND).type(CROSS_FIELDS),
+          () -> matchQuery(fieldName, term).operator(AND));
       case "any":
         return prepareElasticsearchQuery(fieldList,
           fields -> multiMatchQuery(term, fields.toArray(String[]::new)),

--- a/src/main/java/org/folio/search/repository/IndexRepository.java
+++ b/src/main/java/org/folio/search/repository/IndexRepository.java
@@ -9,6 +9,7 @@ import static org.folio.search.utils.SearchUtils.performExceptionalOperation;
 import java.util.LinkedHashSet;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -21,12 +22,15 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.folio.search.domain.dto.FolioCreateIndexResponse;
 import org.folio.search.domain.dto.FolioIndexOperationResponse;
 import org.folio.search.model.SearchDocumentBody;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
 /**
  * Search resource repository with set of operation to create/modify/update index settings and
  * mappings.
  */
+@Log4j2
 @Repository
 @RequiredArgsConstructor
 public class IndexRepository {
@@ -41,6 +45,7 @@ public class IndexRepository {
    * @param mappings mappings JSON {@link String} object
    * @return {@link FolioCreateIndexResponse} object
    */
+  @CacheEvict(cacheNames = "esIndicesCache", key = "#index")
   public FolioCreateIndexResponse createIndex(String index, String settings, String mappings) {
     var createIndexRequest = new CreateIndexRequest(index)
       .settings(settings, XContentType.JSON)
@@ -100,7 +105,9 @@ public class IndexRepository {
       : getSuccessIndexOperationResponse();
   }
 
+  @Cacheable(value = "esIndicesCache", key = "#index", unless = "#result == true")
   public boolean indexExists(String index) {
+    log.info("Checking that index exists [index: {}]", index);
     var request = new GetIndexRequest(index);
     return performExceptionalOperation(() ->
       elasticsearchClient.indices().exists(request, RequestOptions.DEFAULT),

--- a/src/main/java/org/folio/search/repository/IndexRepository.java
+++ b/src/main/java/org/folio/search/repository/IndexRepository.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -114,10 +115,36 @@ public class IndexRepository {
       index, "indexExists");
   }
 
+  public FolioIndexOperationResponse removeResources(List<SearchDocumentBody> documents) {
+    if (CollectionUtils.isEmpty(documents)) {
+      return getSuccessIndexOperationResponse();
+    }
+
+    var bulkRequest = new BulkRequest();
+    var indices = new LinkedHashSet<String>();
+    for (var searchDocument : documents) {
+      indices.add(searchDocument.getIndex());
+      bulkRequest.add(prepareDeleteRequest(searchDocument));
+    }
+
+    var bulkApiResponse = performExceptionalOperation(
+      () -> elasticsearchClient.bulk(bulkRequest, RequestOptions.DEFAULT),
+      String.join(",", indices), "bulkRemove");
+
+    return bulkApiResponse.hasFailures()
+      ? getErrorIndexOperationResponse(bulkApiResponse.buildFailureMessage())
+      : getSuccessIndexOperationResponse();
+  }
+
   private static IndexRequest prepareIndexRequest(String index, SearchDocumentBody body) {
     return new IndexRequest(index)
       .id(body.getId())
       .routing(body.getRouting())
       .source(body.getRawJson(), XContentType.JSON);
+  }
+
+  private static DeleteRequest prepareDeleteRequest(SearchDocumentBody event) {
+    return new DeleteRequest(event.getIndex())
+      .id(event.getId()).routing(event.getRouting());
   }
 }

--- a/src/main/java/org/folio/search/service/IndexService.java
+++ b/src/main/java/org/folio/search/service/IndexService.java
@@ -1,5 +1,6 @@
 package org.folio.search.service;
 
+import static java.util.stream.Collectors.toList;
 import static org.folio.search.utils.SearchResponseHelper.getSuccessIndexOperationResponse;
 import static org.folio.search.utils.SearchUtils.getElasticsearchIndexName;
 
@@ -16,6 +17,7 @@ import org.folio.search.domain.dto.FolioIndexOperationResponse;
 import org.folio.search.domain.dto.ReindexJob;
 import org.folio.search.domain.dto.ResourceEventBody;
 import org.folio.search.exception.SearchServiceException;
+import org.folio.search.model.SearchDocumentBody;
 import org.folio.search.repository.IndexRepository;
 import org.folio.search.service.converter.MultiTenantSearchDocumentConverter;
 import org.folio.search.service.es.SearchMappingsHelper;
@@ -79,6 +81,7 @@ public class IndexService {
     }
 
     var elasticsearchDocuments = multiTenantSearchDocumentConverter.convert(resources);
+    checkThatDocumentsCanBeIndexed(elasticsearchDocuments);
     return indexRepository.indexResources(elasticsearchDocuments);
   }
 
@@ -91,5 +94,19 @@ public class IndexService {
 
   public ReindexJob reindexInventory() {
     return instanceStorageClient.submitReindex();
+  }
+
+  private void checkThatDocumentsCanBeIndexed(List<SearchDocumentBody> elasticsearchDocuments) {
+    var absentIndexNames = elasticsearchDocuments.stream()
+      .map(SearchDocumentBody::getIndex)
+      .distinct()
+      .filter(index -> !indexRepository.indexExists(index))
+      .collect(toList());
+
+    if (CollectionUtils.isNotEmpty(absentIndexNames)) {
+      throw new SearchServiceException(String.format(
+        "Cancelling bulk operation [reason: Cannot index resources for non existing indices [indices=%s]]",
+        absentIndexNames));
+    }
   }
 }

--- a/src/main/java/org/folio/search/service/IndexService.java
+++ b/src/main/java/org/folio/search/service/IndexService.java
@@ -18,6 +18,7 @@ import org.folio.search.domain.dto.ReindexJob;
 import org.folio.search.domain.dto.ResourceEventBody;
 import org.folio.search.exception.SearchServiceException;
 import org.folio.search.model.SearchDocumentBody;
+import org.folio.search.model.service.ResourceIdEvent;
 import org.folio.search.repository.IndexRepository;
 import org.folio.search.service.converter.MultiTenantSearchDocumentConverter;
 import org.folio.search.service.es.SearchMappingsHelper;
@@ -83,6 +84,15 @@ public class IndexService {
     var elasticsearchDocuments = multiTenantSearchDocumentConverter.convert(resources);
     checkThatDocumentsCanBeIndexed(elasticsearchDocuments);
     return indexRepository.indexResources(elasticsearchDocuments);
+  }
+
+  public FolioIndexOperationResponse removeResources(List<ResourceIdEvent> resources) {
+    if (CollectionUtils.isEmpty(resources)) {
+      return getSuccessIndexOperationResponse();
+    }
+
+    var deleteEvents = multiTenantSearchDocumentConverter.convertDeleteEvents(resources);
+    return indexRepository.removeResources(deleteEvents);
   }
 
   public void createIndexIfNotExist(String resourceName, String tenantId) {

--- a/src/main/java/org/folio/search/service/converter/MultiTenantSearchDocumentConverter.java
+++ b/src/main/java/org/folio/search/service/converter/MultiTenantSearchDocumentConverter.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.folio.search.domain.dto.ResourceEventBody;
 import org.folio.search.model.SearchDocumentBody;
+import org.folio.search.model.service.ResourceIdEvent;
 import org.folio.search.service.TenantScopedExecutionService;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +24,10 @@ public class MultiTenantSearchDocumentConverter {
       .collect(groupingBy(ResourceEventBody::getTenant)).entrySet().stream()
       .flatMap(this::convertForTenant)
       .collect(Collectors.toList());
+  }
+
+  public List<SearchDocumentBody> convertDeleteEvents(List<ResourceIdEvent> resourceEvents) {
+    return searchDocumentConverter.convertDeleteEvents(resourceEvents);
   }
 
   private Stream<SearchDocumentBody> convertForTenant(Map.Entry<String, List<ResourceEventBody>> entry) {

--- a/src/main/java/org/folio/search/utils/SearchConverterUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchConverterUtils.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.folio.search.domain.dto.ResourceEventBody;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -66,6 +67,16 @@ public class SearchConverterUtils {
       return Stream.of((String) value);
     }
     return Stream.empty();
+  }
+
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> getNewAsMap(ResourceEventBody resourceEventBody) {
+    return (Map<String, Object>) resourceEventBody.getNew();
+  }
+
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> getOldAsMap(ResourceEventBody resourceEventBody) {
+    return (Map<String, Object>) resourceEventBody.getOld();
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/resources/swagger.api/schemas/resourceEventBody.json
+++ b/src/main/resources/swagger.api/schemas/resourceEventBody.json
@@ -19,6 +19,10 @@
     "new": {
       "description": "Instance record new fields",
       "type": "object"
+    },
+    "old": {
+      "description": "Instance record old fields",
+      "type": "object"
     }
   }
 }

--- a/src/test/java/org/folio/search/controller/IndexingIT.java
+++ b/src/test/java/org/folio/search/controller/IndexingIT.java
@@ -1,0 +1,89 @@
+package org.folio.search.controller;
+
+import static org.awaitility.Awaitility.await;
+import static org.folio.search.support.base.ApiEndpoints.searchInstancesByQuery;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.folio.search.utils.TestUtils.randomId;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.util.List;
+import org.folio.search.domain.dto.Holding;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Item;
+import org.folio.search.support.base.BaseIntegrationTest;
+import org.folio.search.utils.types.IntegrationTest;
+import org.junit.jupiter.api.Test;
+
+@IntegrationTest
+class IndexingIT extends BaseIntegrationTest {
+  @Test
+  void shouldRemoveItem() {
+    var instances = createInstances();
+    var instanceToUse = instances.get(0);
+    var itemToRemove = instanceToUse.getItems().get(1).getId();
+
+    instanceToUse.getItems().forEach(item -> {
+      if (item.getId().equals(itemToRemove)) {
+        inventoryApi.deleteItem(TENANT_ID, item.getId());
+        getByQuery("items.id=={value}", item.getId(), 0);
+      } else {
+        getByQuery("items.id=={value}", item.getId(), 1);
+      }
+    });
+  }
+
+  @Test
+  void shouldRemoveHolding() {
+    var instances = createInstances();
+    var instanceToUse = instances.get(0);
+    var hrToRemove = instanceToUse.getHoldings().get(0).getId();
+
+    instanceToUse.getHoldings().forEach(hr -> {
+      if (hr.getId().equals(hrToRemove)) {
+        inventoryApi.deleteHolding(TENANT_ID, hr.getId());
+        getByQuery("holdings.id=={value}", hr.getId(), 0);
+      } else {
+        getByQuery("holdings.id=={value}", hr.getId(), 1);
+      }
+    });
+  }
+
+  @Test
+  void shouldRemoveInstance() {
+    var instances = createInstances();
+    var instanceToRemove = instances.get(0).getId();
+
+    instances.forEach(instance -> {
+      if (instance.getId().equals(instanceToRemove)) {
+        inventoryApi.deleteInstance(TENANT_ID, instance.getId());
+        getByQuery("id=={value}", instance.getId(), 0);
+      } else {
+        getByQuery("id=={value}", instance.getId(), 1);
+      }
+    });
+  }
+
+  private List<Instance> createInstances() {
+    var instances = List.of(new Instance().id(randomId()),
+      new Instance().id(randomId()),
+      new Instance().id(randomId()));
+
+    instances.get(0)
+      .holdings(List.of(new Holding().id(randomId()), new Holding().id(randomId())))
+      .items(List.of(new Item().id(randomId()), new Item().id(randomId())));
+
+    instances.get(1)
+      .holdings(List.of(new Holding().id(randomId()), new Holding().id(randomId())));
+
+    instances.forEach(instance -> inventoryApi.createInstance(TENANT_ID, instance));
+    getByQuery("id=={value}", instances.get(2).getId(), 1);
+
+    return instances;
+  }
+
+  private void getByQuery(String query, String value, int expectedCount) {
+    await().untilAsserted(() -> doGet(searchInstancesByQuery(query), value)
+      .andExpect(jsonPath("totalRecords", is(expectedCount))));
+  }
+}

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -50,6 +50,12 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("search by instance title (part of title)", "title all {value}", array("primers"), null),
       arguments("search by instance title (alternative title)", "title all {value}", array("primers"), null),
 
+      arguments("search by instance title (and operator)", "title all {value}", array("system information"), null),
+      arguments("search by instance title (zero results)", "title all {value}",
+        array("semantic web word"), zeroResultConsumer()),
+      arguments("search by instance title (search across 2 fields)", "title all {value}",
+        array("systems alternative semantic"), null),
+
       arguments("search by series", "title all {value}", array("cooperate"), null),
       arguments("search by identifiers (wildcard)", "identifiers.value all {value}", array("200306*"), null),
 

--- a/src/test/java/org/folio/search/service/IndexServiceTest.java
+++ b/src/test/java/org/folio/search/service/IndexServiceTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.List;
 import org.folio.search.client.InstanceStorageClient;
+import org.folio.search.domain.dto.ResourceEventBody;
 import org.folio.search.exception.SearchServiceException;
 import org.folio.search.repository.IndexRepository;
 import org.folio.search.service.converter.MultiTenantSearchDocumentConverter;
@@ -86,12 +87,12 @@ class IndexServiceTest {
   @Test
   void indexResources_negative() {
     var searchBody = searchDocumentBody();
-    var eventBody = TestUtils.eventBody(RESOURCE_NAME, mapOf("id", randomId()));
+    var eventBodies = List.of(TestUtils.eventBody(RESOURCE_NAME, mapOf("id", randomId())));
 
-    when(searchDocumentConverter.convert(List.of(eventBody))).thenReturn(List.of(searchBody));
+    when(searchDocumentConverter.convert(eventBodies)).thenReturn(List.of(searchBody));
     when(indexRepository.indexExists(INDEX_NAME)).thenReturn(false);
 
-    assertThatThrownBy(() -> indexService.indexResources(List.of(eventBody)))
+    assertThatThrownBy(() -> indexService.indexResources(eventBodies))
       .isInstanceOf(SearchServiceException.class)
       .hasMessage("Cancelling bulk operation [reason: "
         + "Cannot index resources for non existing indices [indices=[test-resource_test_tenant]]]");

--- a/src/test/java/org/folio/search/service/IndexServiceTest.java
+++ b/src/test/java/org/folio/search/service/IndexServiceTest.java
@@ -1,9 +1,13 @@
 package org.folio.search.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.search.utils.SearchResponseHelper.getSuccessFolioCreateIndexResponse;
 import static org.folio.search.utils.SearchResponseHelper.getSuccessIndexOperationResponse;
 import static org.folio.search.utils.SearchUtils.getElasticsearchIndexName;
+import static org.folio.search.utils.TestConstants.INDEX_NAME;
+import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.mapOf;
 import static org.folio.search.utils.TestUtils.randomId;
 import static org.folio.search.utils.TestUtils.searchDocumentBody;
@@ -16,6 +20,7 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.List;
 import org.folio.search.client.InstanceStorageClient;
+import org.folio.search.exception.SearchServiceException;
 import org.folio.search.repository.IndexRepository;
 import org.folio.search.service.converter.MultiTenantSearchDocumentConverter;
 import org.folio.search.service.es.SearchMappingsHelper;
@@ -32,9 +37,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class IndexServiceTest {
 
-  private static final String RESOURCE_NAME = "test-resource";
-  private static final String TENANT_ID = "test-tenant";
-  public static final String INDEX_NAME = RESOURCE_NAME + "_" + TENANT_ID;
   private static final String EMPTY_OBJECT = "{}";
   @Mock private IndexRepository indexRepository;
   @Mock private SearchMappingsHelper mappingsHelper;
@@ -74,10 +76,25 @@ class IndexServiceTest {
     var expectedResponse = getSuccessIndexOperationResponse();
 
     when(searchDocumentConverter.convert(List.of(eventBody))).thenReturn(List.of(searchBody));
+    when(indexRepository.indexExists(INDEX_NAME)).thenReturn(true);
     when(indexRepository.indexResources(List.of(searchBody))).thenReturn(expectedResponse);
 
     var response = indexService.indexResources(List.of(eventBody));
     assertThat(response).isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void indexResources_negative() {
+    var searchBody = searchDocumentBody();
+    var eventBody = TestUtils.eventBody(RESOURCE_NAME, mapOf("id", randomId()));
+
+    when(searchDocumentConverter.convert(List.of(eventBody))).thenReturn(List.of(searchBody));
+    when(indexRepository.indexExists(INDEX_NAME)).thenReturn(false);
+
+    assertThatThrownBy(() -> indexService.indexResources(List.of(eventBody)))
+      .isInstanceOf(SearchServiceException.class)
+      .hasMessage("Cancelling bulk operation [reason: "
+        + "Cannot index resources for non existing indices [indices=[test-resource_test_tenant]]]");
   }
 
   @Test

--- a/src/test/java/org/folio/search/service/IndexServiceTest.java
+++ b/src/test/java/org/folio/search/service/IndexServiceTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.List;
 import org.folio.search.client.InstanceStorageClient;
-import org.folio.search.domain.dto.ResourceEventBody;
 import org.folio.search.exception.SearchServiceException;
 import org.folio.search.repository.IndexRepository;
 import org.folio.search.service.converter.MultiTenantSearchDocumentConverter;

--- a/src/test/java/org/folio/search/service/converter/SearchDocumentConverterTest.java
+++ b/src/test/java/org/folio/search/service/converter/SearchDocumentConverterTest.java
@@ -33,6 +33,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.folio.search.domain.dto.ResourceEventBody;
 import org.folio.search.model.SearchDocumentBody;
 import org.folio.search.model.metadata.FieldDescription;
+import org.folio.search.model.service.ResourceIdEvent;
 import org.folio.search.service.LanguageConfigService;
 import org.folio.search.service.metadata.ResourceDescriptionService;
 import org.folio.search.service.setter.FieldProcessor;
@@ -260,6 +261,26 @@ class SearchDocumentConverterTest {
     var expectedJson = jsonObject("id", id, "value", defaultValue);
 
     assertThat(actual).isEqualTo(expectedSearchDocument(expectedJson));
+  }
+
+  @Test
+  void convertDeleteEvents() {
+    var deleteEvents = List.of(ResourceIdEvent.of("id1", RESOURCE_NAME, TENANT_ID),
+      ResourceIdEvent.of("id2", RESOURCE_NAME, TENANT_ID + 2),
+      ResourceIdEvent.of("id3", RESOURCE_NAME, TENANT_ID + 3));
+
+    var removeDocuments = documentMapper.convertDeleteEvents(deleteEvents);
+
+    assertThat(removeDocuments).containsExactlyInAnyOrder(
+      deleteSearchDocument("id1", TENANT_ID),
+      deleteSearchDocument("id2", TENANT_ID + 2),
+      deleteSearchDocument("id3", TENANT_ID + 3));
+  }
+
+  private static SearchDocumentBody deleteSearchDocument(String id, String tenant) {
+    return SearchDocumentBody.builder()
+      .id(id).index(RESOURCE_NAME + "_" + tenant).routing(tenant)
+      .build();
   }
 
   private static Map<String, FieldDescription> getDescriptionFields() {

--- a/src/test/java/org/folio/search/support/api/InventoryApi.java
+++ b/src/test/java/org/folio/search/support/api/InventoryApi.java
@@ -1,6 +1,7 @@
 package org.folio.search.support.api;
 
 import static java.util.Collections.emptyMap;
+import static org.folio.search.domain.dto.ResourceEventBody.TypeEnum.DELETE;
 import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
 import static org.folio.search.utils.TestConstants.INVENTORY_HOLDING_TOPIC;
 import static org.folio.search.utils.TestConstants.INVENTORY_INSTANCE_TOPIC;
@@ -66,6 +67,27 @@ public class InventoryApi {
 
     kafkaTemplate.send(INVENTORY_ITEM_TOPIC, instanceId,
       eventBody(INSTANCE_RESOURCE, event).tenant(tenant));
+  }
+
+  public void deleteItem(String tenant, String id) {
+    var item = ITEM_STORE.get(tenant).remove(id);
+
+    kafkaTemplate.send(INVENTORY_ITEM_TOPIC, item.getInstanceId(),
+      eventBody(INSTANCE_RESOURCE, null).old(item).tenant(tenant).type(DELETE));
+  }
+
+  public void deleteHolding(String tenant, String id) {
+    var hr = HOLDING_STORE.get(tenant).remove(id);
+
+    kafkaTemplate.send(INVENTORY_HOLDING_TOPIC, hr.getInstanceId(),
+      eventBody(INSTANCE_RESOURCE, null).old(hr).tenant(tenant).type(DELETE));
+  }
+
+  public void deleteInstance(String tenant, String id) {
+    var instance = INSTANCE_STORE.get(tenant).remove(id);
+
+    kafkaTemplate.send(INVENTORY_INSTANCE_TOPIC, instance.getId(),
+      eventBody(INSTANCE_RESOURCE, null).old(instance).tenant(tenant).type(DELETE));
   }
 
   public static Optional<Instance> getInventoryView(String tenant, String id) {


### PR DESCRIPTION
Includes: 
* https://github.com/folio-org/mod-search/pull/60 - MSEARCH-86 Implement caching of existing indices
* https://github.com/folio-org/mod-search/pull/64 - MSEARCH-90: Support delete events.
* https://github.com/folio-org/mod-search/pull/63 - MSEARCH-91 Use operator 'AND' for match queries [PT1]