### PR TITLE
MSEARCH-112: Check that ES index exists before any indexing logic.

### DIFF
--- a/src/main/java/org/folio/search/integration/KafkaMessageListener.java
+++ b/src/main/java/org/folio/search/integration/KafkaMessageListener.java
@@ -36,7 +36,6 @@ public class KafkaMessageListener {
     EnumSet.of(CREATE, UPDATE, REINDEX);
 
   private final IndexService indexService;
-  private final ResourceFetchService resourceFetchService;
 
   @KafkaListener(
     id = "mod-search-events-listener",
@@ -55,17 +54,12 @@ public class KafkaMessageListener {
 
   private void indexResources(List<ConsumerRecord<String, ResourceEventBody>> events) {
     var resourcesToIndex = getResourceIdRecords(events, this::isIndexEvent);
-    var instancesByIds = resourceFetchService.fetchInstancesByIds(resourcesToIndex);
-
-    indexService.indexResources(instancesByIds);
-    log.info("Instances added/updated [size: {}]", instancesByIds.size());
+    indexService.indexResourcesById(resourcesToIndex);
   }
 
   private void removeResources(List<ConsumerRecord<String, ResourceEventBody>> events) {
     var resourcesToRemove = getResourceIdRecords(events, this::isRemoveEvent);
-
     indexService.removeResources(resourcesToRemove);
-    log.info("Resources removed [size: {}]", resourcesToRemove.size());
   }
 
   private List<ResourceIdEvent> getResourceIdRecords(

--- a/src/main/java/org/folio/search/service/IndexService.java
+++ b/src/main/java/org/folio/search/service/IndexService.java
@@ -31,6 +31,8 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class IndexService {
+  public static final String INDEX_NOT_EXISTS_ERROR = "Cancelling bulk operation [reason: "
+    + "Cannot index resources for non existing indices, tenant not initialized? [indices=%s]]";
 
   private final IndexRepository indexRepository;
   private final SearchMappingsHelper mappingHelper;
@@ -147,9 +149,7 @@ public class IndexService {
       .collect(toList());
 
     if (CollectionUtils.isNotEmpty(absentIndexNames)) {
-      throw new SearchServiceException(String.format(
-        "Cancelling bulk operation [reason: Cannot index resources for non existing indices, "
-          + "tenant not initialized? [indices=%s]]", absentIndexNames));
+      throw new SearchServiceException(String.format(INDEX_NOT_EXISTS_ERROR, absentIndexNames));
     }
   }
 

--- a/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
+++ b/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
@@ -19,6 +19,8 @@ import org.folio.search.domain.dto.ResourceEventBody;
 import org.folio.search.exception.TenantNotInitializedException;
 import org.folio.search.integration.error.KafkaErrorHandler;
 import org.folio.search.integration.inventory.InventoryViewClient;
+import org.folio.search.repository.IndexRepository;
+import org.folio.search.support.extension.EnableElasticSearch;
 import org.folio.search.support.extension.EnableOkapi;
 import org.folio.search.support.extension.EnablePostgres;
 import org.folio.search.utils.types.IntegrationTest;
@@ -34,6 +36,7 @@ import org.springframework.messaging.support.GenericMessage;
 @IntegrationTest
 @SpringBootTest(classes = SearchApplication.class)
 @EnableAutoConfiguration
+@EnableElasticSearch
 @EnablePostgres
 @EnableOkapi
 class KafkaMessageListenerIT {
@@ -41,6 +44,8 @@ class KafkaMessageListenerIT {
   private KafkaErrorHandler errorHandler;
   @MockBean
   private InventoryViewClient inventoryViewClient;
+  @SpyBean
+  private IndexRepository indexRepository;
   @Autowired
   private KafkaMessageListener messageListener;
 
@@ -53,6 +58,7 @@ class KafkaMessageListenerIT {
         new ResourceEventBody().type(CREATE)
           .tenant(tenantName)._new(Map.of("id", randomId()))));
 
+    when(indexRepository.indexExists("instance_" + tenantName)).thenReturn(true);
     when(inventoryViewClient.getInstances(any(), anyInt()))
       .thenReturn(asSinglePage(new InventoryViewClient.InstanceView(
         instance, emptyList(), emptyList())));

--- a/src/test/java/org/folio/search/service/IndexServiceTest.java
+++ b/src/test/java/org/folio/search/service/IndexServiceTest.java
@@ -2,6 +2,7 @@ package org.folio.search.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.service.IndexService.INDEX_NOT_EXISTS_ERROR;
 import static org.folio.search.utils.SearchResponseHelper.getSuccessFolioCreateIndexResponse;
 import static org.folio.search.utils.SearchResponseHelper.getSuccessIndexOperationResponse;
 import static org.folio.search.utils.SearchUtils.getElasticsearchIndexName;
@@ -39,6 +40,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 class IndexServiceTest {
+  private static final String INDEX_NOT_EXISTS_MESSAGE =
+    String.format(INDEX_NOT_EXISTS_ERROR, List.of("test-resource_test_tenant"));
 
   private static final String EMPTY_OBJECT = "{}";
   @Mock private IndexRepository indexRepository;
@@ -94,8 +97,7 @@ class IndexServiceTest {
 
     assertThatThrownBy(() -> indexService.indexResources(eventBodies))
       .isInstanceOf(SearchServiceException.class)
-      .hasMessage("Cancelling bulk operation [reason: Cannot index resources for non existing indices, "
-        + "tenant not initialized? [indices=[test-resource_test_tenant]]]");
+      .hasMessage(INDEX_NOT_EXISTS_MESSAGE);
 
     verifyNoInteractions(searchDocumentConverter);
     verify(indexRepository, times(0)).indexResources(any());
@@ -173,8 +175,7 @@ class IndexServiceTest {
 
     assertThatThrownBy(() -> indexService.indexResourcesById(eventIds))
       .isInstanceOf(SearchServiceException.class)
-      .hasMessage("Cancelling bulk operation [reason: Cannot index resources for non existing indices, "
-        + "tenant not initialized? [indices=[test-resource_test_tenant]]]");
+      .hasMessage(INDEX_NOT_EXISTS_MESSAGE);
 
     verifyNoInteractions(searchDocumentConverter);
     verify(indexRepository, times(0)).indexResources(any());
@@ -200,8 +201,7 @@ class IndexServiceTest {
 
     assertThatThrownBy(() -> indexService.removeResources(eventIds))
       .isInstanceOf(SearchServiceException.class)
-      .hasMessage("Cancelling bulk operation [reason: Cannot index resources for non existing indices, "
-        + "tenant not initialized? [indices=[test-resource_test_tenant]]]");
+      .hasMessage(INDEX_NOT_EXISTS_MESSAGE);
 
     verifyNoInteractions(searchDocumentConverter);
     verify(indexRepository, times(0)).removeResources(any());

--- a/src/test/java/org/folio/search/service/IndexServiceTest.java
+++ b/src/test/java/org/folio/search/service/IndexServiceTest.java
@@ -15,12 +15,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
 import org.folio.search.client.InstanceStorageClient;
 import org.folio.search.exception.SearchServiceException;
+import org.folio.search.integration.ResourceFetchService;
+import org.folio.search.model.service.ResourceIdEvent;
 import org.folio.search.repository.IndexRepository;
 import org.folio.search.service.converter.MultiTenantSearchDocumentConverter;
 import org.folio.search.service.es.SearchMappingsHelper;
@@ -43,6 +46,7 @@ class IndexServiceTest {
   @Mock private SearchSettingsHelper settingsHelper;
   @Mock private MultiTenantSearchDocumentConverter searchDocumentConverter;
   @Mock private InstanceStorageClient instanceStorageClient;
+  @Mock private ResourceFetchService fetchService;
   @InjectMocks private IndexService indexService;
 
   @Test
@@ -85,16 +89,16 @@ class IndexServiceTest {
 
   @Test
   void indexResources_negative() {
-    var searchBody = searchDocumentBody();
     var eventBodies = List.of(TestUtils.eventBody(RESOURCE_NAME, mapOf("id", randomId())));
-
-    when(searchDocumentConverter.convert(eventBodies)).thenReturn(List.of(searchBody));
     when(indexRepository.indexExists(INDEX_NAME)).thenReturn(false);
 
     assertThatThrownBy(() -> indexService.indexResources(eventBodies))
       .isInstanceOf(SearchServiceException.class)
-      .hasMessage("Cancelling bulk operation [reason: "
-        + "Cannot index resources for non existing indices [indices=[test-resource_test_tenant]]]");
+      .hasMessage("Cancelling bulk operation [reason: Cannot index resources for non existing indices, "
+        + "tenant not initialized? [indices=[test-resource_test_tenant]]]");
+
+    verifyNoInteractions(searchDocumentConverter);
+    verify(indexRepository, times(0)).indexResources(any());
   }
 
   @Test
@@ -145,5 +149,61 @@ class IndexServiceTest {
     indexService.dropIndex(RESOURCE_NAME, TENANT_ID);
 
     verify(indexRepository, times(0)).dropIndex(INDEX_NAME);
+  }
+
+  @Test
+  void canIndexResourcesById() {
+    var eventIds = List.of(ResourceIdEvent.of(randomId(), RESOURCE_NAME, TENANT_ID));
+    var eventBody = TestUtils.eventBody(RESOURCE_NAME, mapOf("id", randomId()));
+    var expectedResponse = getSuccessIndexOperationResponse();
+
+    when(indexRepository.indexExists(INDEX_NAME)).thenReturn(true);
+    when(fetchService.fetchInstancesByIds(eventIds)).thenReturn(List.of(eventBody));
+    when(searchDocumentConverter.convert(List.of(eventBody))).thenReturn(List.of(searchDocumentBody()));
+    when(indexRepository.indexResources(any())).thenReturn(expectedResponse);
+
+    assertThat(indexService.indexResourcesById(eventIds))
+      .isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void cannotIndexResourcesById_indexNotExist() {
+    var eventIds = List.of(ResourceIdEvent.of(randomId(), RESOURCE_NAME, TENANT_ID));
+    when(indexRepository.indexExists(INDEX_NAME)).thenReturn(false);
+
+    assertThatThrownBy(() -> indexService.indexResourcesById(eventIds))
+      .isInstanceOf(SearchServiceException.class)
+      .hasMessage("Cancelling bulk operation [reason: Cannot index resources for non existing indices, "
+        + "tenant not initialized? [indices=[test-resource_test_tenant]]]");
+
+    verifyNoInteractions(searchDocumentConverter);
+    verify(indexRepository, times(0)).indexResources(any());
+  }
+
+  @Test
+  void canRemoveResources() {
+    var eventIds = List.of(ResourceIdEvent.of(randomId(), RESOURCE_NAME, TENANT_ID));
+    var expectedResponse = getSuccessIndexOperationResponse();
+
+    when(indexRepository.indexExists(INDEX_NAME)).thenReturn(true);
+    when(searchDocumentConverter.convertDeleteEvents(eventIds)).thenReturn(List.of(searchDocumentBody()));
+    when(indexRepository.removeResources(any())).thenReturn(expectedResponse);
+
+    assertThat(indexService.removeResources(eventIds))
+      .isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void cannotRemoveResources_indexNotExist() {
+    var eventIds = List.of(ResourceIdEvent.of(randomId(), RESOURCE_NAME, TENANT_ID));
+    when(indexRepository.indexExists(INDEX_NAME)).thenReturn(false);
+
+    assertThatThrownBy(() -> indexService.removeResources(eventIds))
+      .isInstanceOf(SearchServiceException.class)
+      .hasMessage("Cancelling bulk operation [reason: Cannot index resources for non existing indices, "
+        + "tenant not initialized? [indices=[test-resource_test_tenant]]]");
+
+    verifyNoInteractions(searchDocumentConverter);
+    verify(indexRepository, times(0)).removeResources(any());
   }
 }


### PR DESCRIPTION
When Indexing resources make sure ES index exists before starting any logic: converting resources, calling inventory, etc.