### PR TITLE
MSEARCH-109 Implement search by items/holdings electronic access

### DIFF
--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -247,6 +247,27 @@
               "index": "multilang"
             }
           }
+        },
+        "electronicAccess": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "inventorySearchTypes": "items.electronicAccess",
+              "index": "keyword"
+            },
+            "linkText": {
+              "inventorySearchTypes": "items.electronicAccess",
+              "index": "multilang"
+            },
+            "materialsSpecification": {
+              "inventorySearchTypes": "items.electronicAccess",
+              "index": "multilang"
+            },
+            "publicNote": {
+              "inventorySearchTypes": "items.electronicAccess",
+              "index": "multilang"
+            }
+          }
         }
       }
     },
@@ -272,6 +293,27 @@
           "type": "object",
           "properties": {
             "tagList": {
+              "index": "multilang"
+            }
+          }
+        },
+        "electronicAccess": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "inventorySearchTypes": "holdings.electronicAccess",
+              "index": "keyword"
+            },
+            "linkText": {
+              "inventorySearchTypes": "holdings.electronicAccess",
+              "index": "multilang"
+            },
+            "materialsSpecification": {
+              "inventorySearchTypes": "holdings.electronicAccess",
+              "index": "multilang"
+            },
+            "publicNote": {
+              "inventorySearchTypes": "holdings.electronicAccess",
               "index": "multilang"
             }
           }

--- a/src/main/resources/swagger.api/schemas/electronicAccess.json
+++ b/src/main/resources/swagger.api/schemas/electronicAccess.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Holding description",
+  "type": "object",
+  "properties": {
+    "uri": {
+      "type": "string",
+      "description": "uniform resource identifier (URI) is a string of characters designed for unambiguous identification of resources"
+    },
+    "linkText": {
+      "type": "string",
+      "description": "The value of the MARC tag field 856 2nd indicator, where the values are: no information provided, resource, version of resource, related resource, no display constant generated"
+    },
+    "materialsSpecification": {
+      "type": "string",
+      "description": "Materials specified is used to specify to what portion or aspect of the resource the electronic location and access information applies (e.g. a portion or subset of the item is electronic, or a related electronic resource is being linked to the record)"
+    },
+    "publicNote": {
+      "type": "string",
+      "description": "URL public note to be displayed in the discovery"
+    }
+  }
+}

--- a/src/main/resources/swagger.api/schemas/electronicAccess.json
+++ b/src/main/resources/swagger.api/schemas/electronicAccess.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Holding description",
+  "description": "Electronic access object",
   "type": "object",
   "properties": {
     "uri": {

--- a/src/main/resources/swagger.api/schemas/holding.json
+++ b/src/main/resources/swagger.api/schemas/holding.json
@@ -34,6 +34,13 @@
     "callNumberSuffix": {
       "type": "string",
       "description": "Suffix of the call number on the holding level."
+    },
+    "electronicAccess": {
+      "type": "array",
+      "description": "List of electronic access items",
+      "items": {
+        "$ref": "electronicAccess.json"
+      }
     }
   }
 }

--- a/src/main/resources/swagger.api/schemas/instance.json
+++ b/src/main/resources/swagger.api/schemas/instance.json
@@ -163,25 +163,7 @@
       "type": "array",
       "description": "List of electronic access items",
       "items": {
-        "type": "object",
-        "properties": {
-          "uri": {
-            "type": "string",
-            "description": "uniform resource identifier (URI) is a string of characters designed for unambiguous identification of resources"
-          },
-          "linkText": {
-            "type": "string",
-            "description": "The value of the MARC tag field 856 2nd indicator, where the values are: no information provided, resource, version of resource, related resource, no display constant generated"
-          },
-          "materialsSpecification": {
-            "type": "string",
-            "description": "Materials specified is used to specify to what portion or aspect of the resource the electronic location and access information applies (e.g. a portion or subset of the item is electronic, or a related electronic resource is being linked to the record)"
-          },
-          "publicNote": {
-            "type": "string",
-            "description": "URL public note to be displayed in the discovery"
-          }
-        }
+        "$ref": "electronicAccess.json"
       }
     },
     "notes": {

--- a/src/main/resources/swagger.api/schemas/item.json
+++ b/src/main/resources/swagger.api/schemas/item.json
@@ -58,6 +58,13 @@
     "tags": {
       "description": "arbitrary tags associated with this item",
       "$ref": "tags.json"
+    },
+    "electronicAccess": {
+      "type": "array",
+      "description": "List of electronic access items",
+      "items": {
+        "$ref": "electronicAccess.json"
+      }
     }
   }
 }

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -104,7 +104,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
         "classifications.classificationNumber=={value}", array("025*"), null),
 
       arguments("search by electronic access (uri)", "electronicAccess.uri==\"{value}\"",
-        array("http://testlibrary.sample.com/journal/10.1002/(ISSN)1938-3703"), null),
+        array("https://testlibrary.sample.com/journal/10.1002/(ISSN)1938-3703"), null),
       arguments("search by electronic access (link text)",
         "electronicAccess.linkText all {value}", array("access"), null),
       arguments("search by electronic access (materials specification)",
@@ -132,7 +132,28 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("search by items hrid", "items.hrid = {value}", array("item000000000014"), null),
       arguments("search by items hrid (start with)", "items.hrid = {value}", array("item*"), null),
       arguments("search by items hrid (ends with)", "items.hrid = {value}", array("*00014"), null),
-      arguments("search by items hrid (wildcard)", "items.hrid = {value}", array("item*00014"), null)
+      arguments("search by items hrid (wildcard)", "items.hrid = {value}", array("item*00014"), null),
+
+      arguments("search by items electronic access", "items.electronicAccess==\"{value}\"", array("table"), null),
+      arguments("search by items electronic access (uri)", "items.electronicAccess.uri==\"{value}\"",
+        array("https://www.loc.gov/catdir/toc/ecip0718/2007020429.html"), null),
+      arguments("search by items electronic access (link text)",
+        "items.electronicAccess.linkText all {value}", array("links available"), null),
+      arguments("search by items electronic access (materials specification)",
+        "items.electronicAccess.materialsSpecification all {value}", array("table"), null),
+      arguments("search by items electronic access (public note)",
+        "items.electronicAccess.publicNote all {value}", array("table of contents"), null),
+
+      arguments("search by items electronic access (uri)", "holdings.electronicAccess==\"{value}\"",
+        array("electronicAccess"), null),
+      arguments("search by items electronic access (uri)", "holdings.electronicAccess.uri==\"{value}\"",
+        array("https://testlibrary.sample.com/holdings?hrid=ho00000000006"), null),
+      arguments("search by items electronic access (link text)",
+        "holdings.electronicAccess.linkText all {value}", array("link text"), null),
+      arguments("search by items electronic access (materials specification)",
+        "holdings.electronicAccess.materialsSpecification all {value}", array("specification"), null),
+      arguments("search by items electronic access (public note)",
+        "holdings.electronicAccess.publicNote all {value}", array("note"), null)
     );
   }
 

--- a/src/test/resources/samples/semantic-web-primer/holdings.json
+++ b/src/test/resources/samples/semantic-web-primer/holdings.json
@@ -32,7 +32,15 @@
     "formerIds": [],
     "instanceId": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",
     "permanentLocationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
-    "electronicAccess": [],
+    "electronicAccess": [
+      {
+        "uri": "https://testlibrary.sample.com/holdings?hrid=ho00000000006",
+        "linkText": "Holding's electronicAccess link Text",
+        "materialsSpecification": "Holding's electronicAccess material specification",
+        "publicNote": "Holding's electronicAccess public note",
+        "relationshipId": "3b430592-2e09-4b48-9a0c-0636d66b9fb3"
+      }
+    ],
     "notes": [],
     "holdingsStatements": [],
     "holdingsStatementsForIndexes": [],

--- a/src/test/resources/samples/semantic-web-primer/instance.json
+++ b/src/test/resources/samples/semantic-web-primer/instance.json
@@ -79,7 +79,7 @@
   "publicationRange": [],
   "electronicAccess": [
     {
-      "uri": "http://testlibrary.sample.com/journal/10.1002/(ISSN)1938-3703",
+      "uri": "https://testlibrary.sample.com/journal/10.1002/(ISSN)1938-3703",
       "linkText": "electronic access link text",
       "publicNote": "Online access via Wiley (1996-current)",
       "materialsSpecification": "electronic access material"

--- a/src/test/resources/samples/semantic-web-primer/items.json
+++ b/src/test/resources/samples/semantic-web-primer/items.json
@@ -29,7 +29,7 @@
     "effectiveLocationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
     "electronicAccess": [
       {
-        "uri": "http://www.loc.gov/catdir/toc/ecip0718/2007020429.html",
+        "uri": "https://www.loc.gov/catdir/toc/ecip0718/2007020429.html",
         "linkText": "Links available",
         "materialsSpecification": "Table of contents",
         "publicNote": "Table of contents only",


### PR DESCRIPTION
Following stories are similar and done in single PR:
 - [MSEARCH-109](https://issues.folio.org/browse/MSEARCH-109) Implement search by items electronic access
 - [MSEARCH-110](https://issues.folio.org/browse/MSEARCH-110) Implement search by holdings electronic access 