### PR TITLE
MSEARCH-67: Add ASCII folding filter.

### DIFF
--- a/src/main/java/org/folio/search/service/converter/SearchDocumentConverter.java
+++ b/src/main/java/org/folio/search/service/converter/SearchDocumentConverter.java
@@ -183,9 +183,7 @@ public class SearchDocumentConverter {
     var multilangValueMap = new LinkedHashMap<String, Object>();
     var languages = ctx.getLanguages();
     languages.forEach(language -> multilangValueMap.put(language, plainFieldValue));
-    if (languages.isEmpty()) {
-      multilangValueMap.put(MULTILANG_SOURCE_SUBFIELD, plainFieldValue);
-    }
+    multilangValueMap.put(MULTILANG_SOURCE_SUBFIELD, plainFieldValue);
 
     var resultMap = new LinkedHashMap<String, Object>(2);
     resultMap.put(key, multilangValueMap);

--- a/src/main/resources/elasticsearch/index/instance.json
+++ b/src/main/resources/elasticsearch/index/instance.json
@@ -17,7 +17,7 @@
     "analyzer": {
       "source_analyzer": {
         "tokenizer": "standard",
-        "filter": [ "lowercase" ],
+        "filter": [ "lowercase", "asciifolding" ],
         "type": "custom"
       }
     },

--- a/src/test/java/org/folio/search/controller/ConfigControllerIT.java
+++ b/src/test/java/org/folio/search/controller/ConfigControllerIT.java
@@ -93,9 +93,10 @@ class ConfigControllerIT extends BaseIntegrationTest {
 
     final var indexedInstance = getIndexedInstanceById(newInstance.getId());
 
-    assertThat((Map<String, Object>) getMapValueByPath("title", indexedInstance), aMapWithSize(2));
+    assertThat((Map<String, Object>) getMapValueByPath("title", indexedInstance), aMapWithSize(3));
     assertThat(getMapValueByPath("title.eng", indexedInstance), is(newInstance.getTitle()));
     assertThat(getMapValueByPath("title.rus", indexedInstance), is(newInstance.getTitle()));
+    assertThat(getMapValueByPath("title.src", indexedInstance), is(newInstance.getTitle()));
     assertThat(getMapValueByPath("title.fre", indexedInstance), nullValue());
   }
 

--- a/src/test/java/org/folio/search/controller/EsInstanceToInventoryInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/EsInstanceToInventoryInstanceIT.java
@@ -2,19 +2,17 @@ package org.folio.search.controller;
 
 import static org.folio.search.sample.SampleInstances.getSemanticWeb;
 import static org.folio.search.support.base.ApiEndpoints.searchInstancesByQuery;
-import static org.folio.search.utils.TestUtils.OBJECT_MAPPER;
+import static org.folio.search.utils.TestUtils.parseResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.jayway.jsonpath.JsonPath;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.stream.Collectors;
 import org.folio.search.domain.dto.Holding;
 import org.folio.search.domain.dto.Instance;
-import org.folio.search.domain.dto.SearchResult;
+import org.folio.search.model.service.ResultList;
 import org.folio.search.support.base.BaseIntegrationTest;
 import org.folio.search.utils.types.IntegrationTest;
 import org.hamcrest.Matchers;
@@ -24,17 +22,13 @@ import org.junit.jupiter.api.Test;
 class EsInstanceToInventoryInstanceIT extends BaseIntegrationTest {
   @Test
   void responseContainsOnlyBasicInstanceProperties() throws Exception {
-    final var expected = getSemanticWeb();
-    final var actualJson = mockMvc.perform(get(searchInstancesByQuery("id=={value}"), expected.getId())
-      .headers(defaultHeaders()))
-      .andExpect(status().isOk())
+    var expected = getSemanticWeb();
+    var response = doGet(searchInstancesByQuery("id=={value}"), expected.getId())
       .andExpect(jsonPath("totalRecords", is(1)))
       // make sure that no unexpected properties are present
-      .andExpect(jsonPath("instances[0].length()", is(4)))
-      .andReturn().getResponse().getContentAsString();
+      .andExpect(jsonPath("instances[0].length()", is(4)));
 
-    final var actual = JsonPath.parse(actualJson).read("instances[0]", Instance.class);
-
+    var actual = parseResponse(response, new TypeReference<ResultList<Instance>>() {}).getResult().get(0);
     assertThat(actual.getId(), is(expected.getId()));
     assertThat(actual.getTitle(), is(expected.getTitle()));
     assertThat(actual.getContributors(), is(expected.getContributors()));
@@ -43,14 +37,11 @@ class EsInstanceToInventoryInstanceIT extends BaseIntegrationTest {
 
   @Test
   void responseContainsAllInstanceProperties() throws Exception {
-    final var expected = getSemanticWeb();
-    final var actualJson = mockMvc.perform(get(searchInstancesByQuery("id=={value}&expandAll=true"), expected.getId())
-      .headers(defaultHeaders()))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("totalRecords", is(1)))
-      .andReturn().getResponse().getContentAsString();
+    var expected = getSemanticWeb();
+    var response = doGet(searchInstancesByQuery("id=={value}&expandAll=true"), expected.getId())
+      .andExpect(jsonPath("totalRecords", is(1)));
 
-    final var actual = OBJECT_MAPPER.readValue(actualJson, SearchResult.class).getInstances().get(0);
+    var actual = parseResponse(response, new TypeReference<ResultList<Instance>>() {}).getResult().get(0);
     assertThat(actual.getHoldings(), containsInAnyOrder(expected.getHoldings().stream()
       .map(hr -> hr.discoverySuppress(false))
       .map(this::removeUnexpectedProperties)

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -64,6 +64,8 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("search by title (phrase match)", "title=={value}", array("semantic web"), null),
       arguments("search by title (phrase match - NO MATCH)", "title=={value}", array("web semantic"),
         zeroResultConsumer()),
+      arguments("search by title (ASCII folding, match origin)", "title=={value}", array("déjà vu"), null),
+      arguments("search by title (ASCII folding)", "title=={value}", array("deja vu"), null),
 
       arguments("search by instance title (and operator)", "title all {value}", array("system information"), null),
       arguments("search by instance title (zero results)", "title all {value}",

--- a/src/test/java/org/folio/search/service/converter/SearchDocumentConverterTest.java
+++ b/src/test/java/org/folio/search/service/converter/SearchDocumentConverterTest.java
@@ -134,7 +134,8 @@ class SearchDocumentConverterTest {
     when(descriptionService.get(RESOURCE_NAME)).thenReturn(resourceDescription);
 
     var actual = convert(eventBody);
-    var expectedJson = jsonObject("id", id, "title", jsonObject("eng", "val"), "plain_title", "val");
+    var expectedJson = jsonObject("id", id, "title", jsonObject("eng", "val", "src", "val"),
+      "plain_title", "val");
 
     assertThat(actual).isEqualTo(expectedSearchDocument(expectedJson));
   }
@@ -332,7 +333,7 @@ class SearchDocumentConverterTest {
       "id", id,
       "title", jsonArray("instance title"),
       "language", "eng",
-      "multilang_value", jsonObject("eng", "some value"),
+      "multilang_value", jsonObject("eng", "some value", "src", "some value"),
       "plain_multilang_value", "some value",
       "bool", true,
       "number", 123,

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -119,7 +119,8 @@ public abstract class BaseIntegrationTest {
   @SneakyThrows
   public static ResultActions doGet(MockMvc mockMvc, String uri, Object... args) {
     return mockMvc.perform(get(uri, args)
-      .headers(defaultHeaders()))
+      .headers(defaultHeaders())
+      .header("Accept", "application/json;charset=UTF-8"))
       .andExpect(status().isOk());
   }
 

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -10,6 +10,7 @@ import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -61,6 +62,12 @@ public class TestUtils {
 
   @SneakyThrows
   public static <T> T parseResponse(ResultActions result, Class<T> type) {
+    return OBJECT_MAPPER.readValue(result.andReturn().getResponse()
+      .getContentAsString(), type);
+  }
+
+  @SneakyThrows
+  public static <T> T parseResponse(ResultActions result, TypeReference<T> type) {
     return OBJECT_MAPPER.readValue(result.andReturn().getResponse()
       .getContentAsString(), type);
   }

--- a/src/test/resources/samples/semantic-web-primer/instance.json
+++ b/src/test/resources/samples/semantic-web-primer/instance.json
@@ -7,6 +7,9 @@
   "alternativeTitles": [
     {
       "alternativeTitle": "An alternative title"
+    },
+    {
+      "alternativeTitle": "déjà vu"
     }
   ],
   "editions": [],


### PR DESCRIPTION
## Changes:
* Add ASCII folding filter for multilang fields (src property);
* `Src` field is always present for multilang now.