### PR TITLE
MSEARCH-89 Add ability to specify language analyzer in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ It is required to have Docker installed and available on the host where the test
 ## Multi-language search support
 
 Each tenant is allowed to pick up to **5** languages from pre-installed list for multi-language indexes (e.g. title, contributors, etc.).
-This can be done via following API:
+This can be done via following API (`languageAnalyzer` field is optional):
 `POST /search/config/languages`
-```javascript
+```json
 {
-  "code":"eng"
+  "code":"eng",
+  "languageAnalyzer": "english"
 }
 ```
 
@@ -36,7 +37,7 @@ The `code` here is an ISO-639-2/B three-letter code. Here is the list of pre-ins
 - heb
 - ita
 - jpn
-- kor
+- kor (default analyzer: seunjeon_analyzer, alternative for k8s and on-premise deployment - nori)
 - rus
 - swe
 - chi

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -186,7 +186,7 @@
       "description": "Returns list of all supported languages for multi-lang indexes"
     },
     {
-      "permissionName": "search.config.languages.item.delete",
+      "permissionName": "search.config.languages.item.put",
       "displayName": "Search - updates a supported language by id",
       "description": "Updates a supported language by id"
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -91,6 +91,13 @@
         },
         {
           "methods": [
+            "PUT"
+          ],
+          "pathPattern": "/search/config/languages/{id}",
+          "permissionsRequired": [ "search.config.languages.item.put" ]
+        },
+        {
+          "methods": [
             "DELETE"
           ],
           "pathPattern": "/search/config/languages/{id}",
@@ -177,6 +184,11 @@
       "permissionName": "search.config.languages.collection.get",
       "displayName": "Search - returns list of all supported languages for multi-lang indexes",
       "description": "Returns list of all supported languages for multi-lang indexes"
+    },
+    {
+      "permissionName": "search.config.languages.item.delete",
+      "displayName": "Search - updates a supported language by id",
+      "description": "Updates a supported language by id"
     },
     {
       "permissionName": "search.config.languages.item.delete",

--- a/src/main/java/org/folio/search/controller/ApiExceptionHandler.java
+++ b/src/main/java/org/folio/search/controller/ApiExceptionHandler.java
@@ -4,15 +4,18 @@ import static java.util.Collections.emptyList;
 import static org.apache.logging.log4j.Level.DEBUG;
 import static org.apache.logging.log4j.Level.WARN;
 import static org.folio.search.model.types.ErrorCode.ELASTICSEARCH_ERROR;
+import static org.folio.search.model.types.ErrorCode.NOT_FOUND_ERROR;
 import static org.folio.search.model.types.ErrorCode.SERVICE_ERROR;
 import static org.folio.search.model.types.ErrorCode.UNKNOWN_ERROR;
 import static org.folio.search.model.types.ErrorCode.VALIDATION_ERROR;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.EntityNotFoundException;
 import javax.validation.ConstraintViolationException;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
@@ -166,6 +169,18 @@ public class ApiExceptionHandler {
   public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException exception) {
     logException(DEBUG, exception);
     return buildResponseEntity(exception, BAD_REQUEST, VALIDATION_ERROR);
+  }
+
+  /**
+   * Handles all uncaught exceptions.
+   *
+   * @param exception {@link Exception} object
+   * @return {@link ResponseEntity} with {@link ErrorResponse} body.
+   */
+  @ExceptionHandler(EntityNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException exception) {
+    logException(WARN, exception);
+    return buildResponseEntity(exception, NOT_FOUND, NOT_FOUND_ERROR);
   }
 
   /**

--- a/src/main/java/org/folio/search/controller/ConfigController.java
+++ b/src/main/java/org/folio/search/controller/ConfigController.java
@@ -30,6 +30,11 @@ public class ConfigController implements ConfigApi {
   }
 
   @Override
+  public ResponseEntity<LanguageConfig> updateLanguageConfig(String code, LanguageConfig languageConfig) {
+    return ok(languageConfigService.update(code, languageConfig));
+  }
+
+  @Override
   public ResponseEntity<Void> deleteLanguageConfig(String code) {
     log.info("Attempting to remove language config [code: {}]", code);
     languageConfigService.delete(code);

--- a/src/main/java/org/folio/search/converter/LanguageConfigConverter.java
+++ b/src/main/java/org/folio/search/converter/LanguageConfigConverter.java
@@ -11,6 +11,7 @@ public class LanguageConfigConverter {
     final var languageConfig = new LanguageConfig();
 
     languageConfig.setCode(entity.getCode());
+    languageConfig.setLanguageAnalyzer(entity.getEsAnalyzer());
 
     return languageConfig;
   }
@@ -19,6 +20,7 @@ public class LanguageConfigConverter {
     final var languageConfig = new LanguageConfigEntity();
 
     languageConfig.setCode(dto.getCode());
+    languageConfig.setEsAnalyzer(dto.getLanguageAnalyzer());
 
     return languageConfig;
   }

--- a/src/main/java/org/folio/search/model/config/LanguageConfigEntity.java
+++ b/src/main/java/org/folio/search/model/config/LanguageConfigEntity.java
@@ -1,5 +1,6 @@
 package org.folio.search.model.config;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
@@ -13,6 +14,10 @@ import lombok.NoArgsConstructor;
 @Table(name = "language_config")
 @Entity
 public class LanguageConfigEntity {
+
   @Id
   private String code;
+
+  @Column(name = "es_analyzer")
+  private String esAnalyzer;
 }

--- a/src/main/java/org/folio/search/model/types/ErrorCode.java
+++ b/src/main/java/org/folio/search/model/types/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
   SERVICE_ERROR("service_error"),
   ELASTICSEARCH_ERROR("elasticsearch_error"),
   VALIDATION_ERROR("validation_error"),
+  NOT_FOUND_ERROR("not_found_error"),
   CONSTRAINT_VIOLATION("constraint_violation_error");
 
   @JsonValue

--- a/src/main/resources/changelog/changes/initial_schema.xml
+++ b/src/main/resources/changelog/changes/initial_schema.xml
@@ -17,4 +17,10 @@
     </preConditions>
     <dropTable tableName="system_user" cascadeConstraints="true"/>
   </changeSet>
+
+  <changeSet id="04_add_optional_analyzer_to_language_config_table" author="pavel_filippov@epam.com">
+    <addColumn tableName="language_config">
+      <column name="es_analyzer" type="varchar(255)"/>
+    </addColumn>
+  </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/elasticsearch/index-field-types.json
+++ b/src/main/resources/elasticsearch/index-field-types.json
@@ -75,7 +75,7 @@
         },
         "kor": {
           "type": "text",
-          "analyzer": "nori"
+          "analyzer": "seunjeon_analyzer"
         },
         "rus": {
           "type": "text",

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -149,7 +149,7 @@ paths:
   /config/languages:
     post:
       operationId: createLanguageConfig
-      description: Update language configuration that will be used for analyzers
+      description: Save languages that will be used for analyzers
       requestBody:
         content:
           application/json:

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -149,7 +149,7 @@ paths:
   /config/languages:
     post:
       operationId: createLanguageConfig
-      description: Save languages that will be used for analyzers
+      description: Update language configuration that will be used for analyzers
       requestBody:
         content:
           application/json:
@@ -180,6 +180,29 @@ paths:
                 $ref: schemas/languageConfigs.json
 
   /config/languages/{code}:
+    put:
+      operationId: updateLanguageConfig
+      description: Update language config settings
+      parameters:
+        - $ref: '#/components/parameters/language-code'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: schemas/languageConfig.json
+      responses:
+        '200':
+          description: Language support has been added.
+          content:
+            application/json:
+              schema:
+                $ref: schemas/languageConfig.json
+        '422':
+          description: Validation error for the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
     delete:
       operationId: deleteLanguageConfig
       description: Delete all supported languages

--- a/src/main/resources/swagger.api/schemas/languageConfig.json
+++ b/src/main/resources/swagger.api/schemas/languageConfig.json
@@ -7,6 +7,10 @@
       "type": "string",
       "description": "An ISO-639-2/B compatible language code.",
       "pattern": "[a-zA-Z]{3}"
+    },
+    "languageAnalyzer": {
+      "type": "string",
+      "description": "Custom elasticsearch analyzer for language."
     }
   },
   "additionalProperties": false,

--- a/src/test/java/org/folio/search/controller/ConfigControllerTest.java
+++ b/src/test/java/org/folio/search/controller/ConfigControllerTest.java
@@ -1,0 +1,67 @@
+package org.folio.search.controller;
+
+import static org.folio.search.utils.SearchUtils.X_OKAPI_TENANT_HEADER;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.folio.search.utils.TestUtils.asJsonString;
+import static org.folio.search.utils.TestUtils.languageConfig;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import javax.persistence.EntityNotFoundException;
+import org.folio.search.service.LanguageConfigService;
+import org.folio.search.support.base.ApiEndpoints;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@UnitTest
+@Import(ApiExceptionHandler.class)
+@WebMvcTest(ConfigController.class)
+class ConfigControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @MockBean private LanguageConfigService languageConfigService;
+
+  @Test
+  void updateLanguageConfig_positive() throws Exception {
+    var code = "eng";
+    var analyzer = "english";
+    var languageConfig = languageConfig(code, analyzer);
+    when(languageConfigService.update(code, languageConfig)).thenReturn(languageConfig(code, analyzer));
+
+    mockMvc.perform(put(ApiEndpoints.languageConfig() + "/eng")
+      .content(asJsonString(languageConfig))
+      .header(X_OKAPI_TENANT_HEADER, TENANT_ID)
+      .contentType(APPLICATION_JSON))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("code", is(code)))
+      .andExpect(jsonPath("languageAnalyzer", is(analyzer)));
+  }
+
+  @Test
+  void updateLanguageConfig_negative_codeByIdIsNotFound() throws Exception {
+    var code = "eng";
+    var languageConfig = languageConfig(code);
+    var errorMessage = "Language config not found for code: " + code;
+
+    when(languageConfigService.update(code, languageConfig)).thenThrow(new EntityNotFoundException(errorMessage));
+
+    mockMvc.perform(put(ApiEndpoints.languageConfig() + "/eng")
+      .content(asJsonString(languageConfig))
+      .header(X_OKAPI_TENANT_HEADER, TENANT_ID)
+      .contentType(APPLICATION_JSON))
+      .andExpect(status().isNotFound())
+      .andExpect(jsonPath("total_records", is(1)))
+      .andExpect(jsonPath("errors[0].code", is("not_found_error")))
+      .andExpect(jsonPath("errors[0].type", is("EntityNotFoundException")))
+      .andExpect(jsonPath("errors[0].message", is(errorMessage)));
+  }
+}

--- a/src/test/java/org/folio/search/service/LanguageConfigServiceTest.java
+++ b/src/test/java/org/folio/search/service/LanguageConfigServiceTest.java
@@ -1,11 +1,16 @@
 package org.folio.search.service;
 
+import static org.folio.search.utils.TestUtils.languageConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+import javax.persistence.EntityNotFoundException;
 import org.folio.search.domain.dto.LanguageConfig;
 import org.folio.search.exception.ValidationException;
 import org.folio.search.model.config.LanguageConfigEntity;
@@ -21,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 class LanguageConfigServiceTest {
+
   private static final String SUPPORTED_LANGUAGE_CODE = "supported";
   private static final String UNSUPPORTED_LANGUAGE_CODE = "unsupported";
   @Mock
@@ -35,7 +41,7 @@ class LanguageConfigServiceTest {
     when(configRepository.count()).thenReturn(0L);
     when(descriptionService.isSupportedLanguage(SUPPORTED_LANGUAGE_CODE)).thenReturn(true);
     when(configRepository.save(any(LanguageConfigEntity.class)))
-      .thenReturn(new LanguageConfigEntity(SUPPORTED_LANGUAGE_CODE));
+      .thenReturn(new LanguageConfigEntity(SUPPORTED_LANGUAGE_CODE, null));
 
     final var saveResult = configService.create(new LanguageConfig().code(SUPPORTED_LANGUAGE_CODE));
 
@@ -57,5 +63,42 @@ class LanguageConfigServiceTest {
     when(descriptionService.isSupportedLanguage(SUPPORTED_LANGUAGE_CODE)).thenReturn(true);
 
     assertThrows(ValidationException.class, () -> configService.create(languageConfig));
+  }
+
+  @Test
+  void update_positive() {
+    var analyzer = "custom-analyzer";
+    var languageConfig = languageConfig(SUPPORTED_LANGUAGE_CODE, analyzer);
+    var expectedEntity = new LanguageConfigEntity(SUPPORTED_LANGUAGE_CODE, analyzer);
+
+    var entityById = new LanguageConfigEntity(SUPPORTED_LANGUAGE_CODE, null);
+    when(configRepository.findById(SUPPORTED_LANGUAGE_CODE)).thenReturn(Optional.of(entityById));
+    when(configRepository.save(expectedEntity)).thenReturn(expectedEntity);
+
+    assertThat(configService.update(SUPPORTED_LANGUAGE_CODE, languageConfig), is(languageConfig));
+  }
+
+  @Test
+  void update_positive_doNothingBecauseEntitiesAreTheSame() {
+    var languageConfig = languageConfig(SUPPORTED_LANGUAGE_CODE, null);
+
+    var entityById = new LanguageConfigEntity(SUPPORTED_LANGUAGE_CODE, null);
+    when(configRepository.findById(SUPPORTED_LANGUAGE_CODE)).thenReturn(Optional.of(entityById));
+
+    assertThat(configService.update(SUPPORTED_LANGUAGE_CODE, languageConfig), is(languageConfig));
+    verify(configRepository, never()).save(any(LanguageConfigEntity.class));
+  }
+
+  @Test
+  void update_negative_entityByIdIsNotFound() {
+    var languageConfig = languageConfig(SUPPORTED_LANGUAGE_CODE);
+    when(configRepository.findById(SUPPORTED_LANGUAGE_CODE)).thenReturn(Optional.empty());
+    assertThrows(EntityNotFoundException.class, () -> configService.update(SUPPORTED_LANGUAGE_CODE, languageConfig));
+  }
+
+  @Test
+  void update_negative_diffLanguageCodes() {
+    var languageConfig = languageConfig(SUPPORTED_LANGUAGE_CODE);
+    assertThrows(ValidationException.class, () -> configService.update(UNSUPPORTED_LANGUAGE_CODE, languageConfig));
   }
 }

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -106,8 +107,22 @@ public abstract class BaseIntegrationTest {
   }
 
   @SneakyThrows
+  public ResultActions attemptPut(String uri, Object body) {
+    return mockMvc.perform(put(uri)
+      .content(asJsonString(body))
+      .headers(defaultHeaders())
+      .contentType(APPLICATION_JSON));
+  }
+
+  @SneakyThrows
   public ResultActions doPost(String uri, Object body) {
     return attemptPost(uri, body)
+      .andExpect(status().isOk());
+  }
+
+  @SneakyThrows
+  public ResultActions doPut(String uri, Object body) {
+    return attemptPut(uri, body)
       .andExpect(status().isOk());
   }
 

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -25,6 +25,8 @@ import org.folio.search.domain.dto.Facet;
 import org.folio.search.domain.dto.FacetItem;
 import org.folio.search.domain.dto.FacetResult;
 import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.LanguageConfig;
+import org.folio.search.domain.dto.LanguageConfigs;
 import org.folio.search.domain.dto.ResourceEventBody;
 import org.folio.search.domain.dto.SearchResult;
 import org.folio.search.model.SearchDocumentBody;
@@ -233,5 +235,17 @@ public class TestUtils {
 
   public static FacetResult facetResult(Map<String, Facet> facets) {
     return new FacetResult().facets(facets).totalRecords(facets.size());
+  }
+
+  public static LanguageConfig languageConfig(String code) {
+    return new LanguageConfig().code(code);
+  }
+
+  public static LanguageConfig languageConfig(String code, String analyzer) {
+    return new LanguageConfig().code(code).languageAnalyzer(analyzer);
+  }
+
+  public static LanguageConfigs languageConfigs(List<LanguageConfig> configs) {
+    return new LanguageConfigs().languageConfigs(configs).totalRecords(configs.size());
   }
 }


### PR DESCRIPTION
- Environment specific analyzer can be passed as part of language config entity
- Default analyzer for Korean language set to seunjeon_analyzer