### PR TITLE
MSEARCH-67: Replace asciifolding filter with icu_folding filter.

### DIFF
--- a/src/main/resources/elasticsearch/index/instance.json
+++ b/src/main/resources/elasticsearch/index/instance.json
@@ -17,7 +17,7 @@
     "analyzer": {
       "source_analyzer": {
         "tokenizer": "standard",
-        "filter": [ "lowercase", "asciifolding" ],
+        "filter": [ "lowercase", "icu_folding" ],
         "type": "custom"
       }
     },

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -66,6 +66,8 @@ class SearchInstanceIT extends BaseIntegrationTest {
         zeroResultConsumer()),
       arguments("search by title (ASCII folding, match origin)", "title=={value}", array("déjà vu"), null),
       arguments("search by title (ASCII folding)", "title=={value}", array("deja vu"), null),
+      arguments("search by title (Unicode folding, match origin)", "title all {value}", array("Algérie"), null),
+      arguments("search by title (Unicode folding)", "title all {value}", array("algerie"), null),
 
       arguments("search by instance title (and operator)", "title all {value}", array("system information"), null),
       arguments("search by instance title (zero results)", "title all {value}",

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -67,6 +67,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("search by title (ASCII folding, match origin)", "title=={value}", array("déjà vu"), null),
       arguments("search by title (ASCII folding)", "title=={value}", array("deja vu"), null),
       arguments("search by title (Unicode folding, match origin)", "title all {value}", array("Algérie"), null),
+      // e here should replace e + U+0301 (Combining Acute Accent)
       arguments("search by title (Unicode folding)", "title all {value}", array("algerie"), null),
 
       arguments("search by instance title (and operator)", "title all {value}", array("system information"), null),

--- a/src/test/resources/samples/semantic-web-primer/instance.json
+++ b/src/test/resources/samples/semantic-web-primer/instance.json
@@ -10,6 +10,9 @@
     },
     {
       "alternativeTitle": "déjà vu"
+    },
+    {
+      "alternativeTitle": "Le parler arabe de Cherchell, Algérie."
     }
   ],
   "editions": [],


### PR DESCRIPTION
Replace `asciifolding` filter with `icu_folding` filter as it also able to process accents for unicode characters.

## Links:
* [ICU Folding Token Filter](https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu-folding.html)
* [ASCII Folding Token Filter](https://www.elastic.co/guide/en/elasticsearch/reference/7.12/analysis-asciifolding-tokenfilter.html)