### PR TITLE
MSEARCH-121 Add ability to recreate index before starting reindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,15 @@ POST [OKAPI_URL]/search/index/inventory/reindex
 
 x-okapi-tenant: [tenant]
 x-okapi-token: [JWT_TOKEN]
+
+{
+  "recreateIndex": false
+}
 ```
+
+Optional parameter `recreateIndex` in request body can be set to true specified  to drop existing indices for tenant
+and create them again. Executing request with this parameter in query will erase all the tenant data in mod-search.
+
 
 ### Monitoring reindex process
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "indices",
-      "version": "0.2",
+      "version": "0.3",
       "handlers": [
         {
           "methods": [

--- a/src/main/java/org/folio/search/controller/IndexController.java
+++ b/src/main/java/org/folio/search/controller/IndexController.java
@@ -1,5 +1,7 @@
 package org.folio.search.controller;
 
+import static org.apache.commons.lang3.BooleanUtils.toBoolean;
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -44,8 +46,8 @@ public class IndexController implements IndexApi {
   }
 
   @Override
-  public ResponseEntity<ReindexJob> reindexInventoryRecords() {
-    log.info("Attempting to start reindex for inventory");
-    return ResponseEntity.ok(indexService.reindexInventory());
+  public ResponseEntity<ReindexJob> reindexInventoryRecords(String tenantId, Boolean recreateIndex) {
+    log.info("Attempting to start reindex for inventory [tenant: {}, recreateIndex: {}]", tenantId, recreateIndex);
+    return ResponseEntity.ok(indexService.reindexInventory(tenantId, toBoolean(recreateIndex)));
   }
 }

--- a/src/main/java/org/folio/search/controller/IndexController.java
+++ b/src/main/java/org/folio/search/controller/IndexController.java
@@ -1,7 +1,5 @@
 package org.folio.search.controller;
 
-import static org.apache.commons.lang3.BooleanUtils.toBoolean;
-
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -9,6 +7,7 @@ import org.folio.search.domain.dto.FolioCreateIndexResponse;
 import org.folio.search.domain.dto.FolioIndexOperationResponse;
 import org.folio.search.domain.dto.IndexRequestBody;
 import org.folio.search.domain.dto.ReindexJob;
+import org.folio.search.domain.dto.ReindexRequest;
 import org.folio.search.domain.dto.ResourceEventBody;
 import org.folio.search.rest.resource.IndexApi;
 import org.folio.search.service.IndexService;
@@ -46,8 +45,8 @@ public class IndexController implements IndexApi {
   }
 
   @Override
-  public ResponseEntity<ReindexJob> reindexInventoryRecords(String tenantId, Boolean recreateIndex) {
-    log.info("Attempting to start reindex for inventory [tenant: {}, recreateIndex: {}]", tenantId, recreateIndex);
-    return ResponseEntity.ok(indexService.reindexInventory(tenantId, toBoolean(recreateIndex)));
+  public ResponseEntity<ReindexJob> reindexInventoryRecords(String tenantId, ReindexRequest request) {
+    log.info("Attempting to start reindex for inventory [tenant: {}]", tenantId);
+    return ResponseEntity.ok(indexService.reindexInventory(tenantId, request));
   }
 }

--- a/src/main/java/org/folio/search/repository/IndexRepository.java
+++ b/src/main/java/org/folio/search/repository/IndexRepository.java
@@ -126,6 +126,7 @@ public class IndexRepository {
    *
    * @param index elasticsearch index name
    */
+  @CacheEvict(cacheNames = "esIndicesCache", key = "#index")
   public void dropIndex(String index) {
     var request = new DeleteIndexRequest(index);
 

--- a/src/main/java/org/folio/search/service/IndexService.java
+++ b/src/main/java/org/folio/search/service/IndexService.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toList;
 import static org.folio.search.model.types.IndexActionType.DELETE;
 import static org.folio.search.model.types.IndexActionType.INDEX;
 import static org.folio.search.utils.SearchResponseHelper.getSuccessIndexOperationResponse;
+import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
 import static org.folio.search.utils.SearchUtils.getElasticsearchIndexName;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -60,8 +61,8 @@ public class IndexService {
     var settings = settingsHelper.getSettings(resourceName);
     var mappings = mappingHelper.getMappings(resourceName);
 
-    log.info("Creating mappings for resource [resource: {}, tenant: {}, mappings: {}]",
-      resourceName, tenantId, mappings);
+    log.info("Creating index for resource [resource: {}, tenant: {}, mappings: {}, settings: {}]",
+      resourceName, tenantId, mappings, settings);
     return indexRepository.createIndex(index, settings, mappings);
   }
 
@@ -137,7 +138,11 @@ public class IndexService {
     }
   }
 
-  public ReindexJob reindexInventory() {
+  public ReindexJob reindexInventory(String tenantId, boolean recreateIndex) {
+    if (recreateIndex) {
+      dropIndex(INSTANCE_RESOURCE, tenantId);
+      createIndex(INSTANCE_RESOURCE, tenantId);
+    }
     return instanceStorageClient.submitReindex();
   }
 

--- a/src/main/java/org/folio/search/service/IndexService.java
+++ b/src/main/java/org/folio/search/service/IndexService.java
@@ -1,5 +1,6 @@
 package org.folio.search.service;
 
+import static java.lang.Boolean.TRUE;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.folio.search.model.types.IndexActionType.DELETE;
@@ -22,6 +23,7 @@ import org.folio.search.client.InstanceStorageClient;
 import org.folio.search.domain.dto.FolioCreateIndexResponse;
 import org.folio.search.domain.dto.FolioIndexOperationResponse;
 import org.folio.search.domain.dto.ReindexJob;
+import org.folio.search.domain.dto.ReindexRequest;
 import org.folio.search.domain.dto.ResourceEventBody;
 import org.folio.search.exception.SearchServiceException;
 import org.folio.search.integration.ResourceFetchService;
@@ -138,8 +140,9 @@ public class IndexService {
     }
   }
 
-  public ReindexJob reindexInventory(String tenantId, boolean recreateIndex) {
-    if (recreateIndex) {
+  public ReindexJob reindexInventory(String tenantId, ReindexRequest reindexRequest) {
+    if (reindexRequest != null && TRUE.equals(reindexRequest.getRecreateIndex())) {
+      log.info("Recreating indices during reindex operation [tenant: {}]", tenantId);
       dropIndex(INSTANCE_RESOURCE, tenantId);
       createIndex(INSTANCE_RESOURCE, tenantId);
     }

--- a/src/main/resources/swagger.api/examples/reindexRequest.sample
+++ b/src/main/resources/swagger.api/examples/reindexRequest.sample
@@ -1,0 +1,3 @@
+{
+  "recreateIndex": true
+}

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -136,8 +136,13 @@ paths:
     post:
       operationId: reindexInventoryRecords
       description: Initiates reindex for the inventory records
+      requestBody:
+        content:
+          application/json:
+            example: examples/reindexRequest.sample
+            schema:
+              $ref: '#/components/schemas/reindexRequest'
       parameters:
-        - $ref: '#/components/parameters/recreate-index'
         - $ref: '#/components/parameters/x-okapi-tenant-header'
       responses:
         '200':
@@ -247,6 +252,8 @@ components:
       $ref: schemas/request/cqlSearchRequest.json
     cqlFacetRequest:
       $ref: schemas/request/cqlFacetRequest.json
+    reindexRequest:
+      $ref: schemas/request/reindexRequest.json
 
   responses:
     badRequestResponse:
@@ -263,7 +270,6 @@ components:
           example: examples/unknownError.sample
 
   parameters:
-
     cql-query:
       name: query
       in: query
@@ -271,14 +277,6 @@ components:
       description: A CQL query string with search conditions.
       schema:
         type: string
-    recreate-index:
-      name: recreateIndex
-      in: query
-      required: false
-      description: A reindex request parameter (if it is set to true - index for tenant will be recreated).
-      schema:
-        type: boolean
-        default: false
     language-code:
       name: code
       in: path

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -136,6 +136,9 @@ paths:
     post:
       operationId: reindexInventoryRecords
       description: Initiates reindex for the inventory records
+      parameters:
+        - $ref: '#/components/parameters/recreate-index'
+        - $ref: '#/components/parameters/x-okapi-tenant-header'
       responses:
         '200':
           description: Reindex operation has been started
@@ -260,6 +263,7 @@ components:
           example: examples/unknownError.sample
 
   parameters:
+
     cql-query:
       name: query
       in: query
@@ -267,6 +271,14 @@ components:
       description: A CQL query string with search conditions.
       schema:
         type: string
+    recreate-index:
+      name: recreateIndex
+      in: query
+      required: false
+      description: A reindex request parameter (if it is set to true - index for tenant will be recreated).
+      schema:
+        type: boolean
+        default: false
     language-code:
       name: code
       in: path

--- a/src/main/resources/swagger.api/schemas/request/reindexRequest.json
+++ b/src/main/resources/swagger.api/schemas/request/reindexRequest.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Reindex Request body",
+  "type": "object",
+  "properties": {
+    "recreateIndex": {
+      "type": "boolean",
+      "default": false,
+      "description": "Boolean parameter, if set to true - tenant index must be recreated before reindex operation"
+    }
+  }
+}

--- a/src/test/java/org/folio/search/controller/IndexControllerTest.java
+++ b/src/test/java/org/folio/search/controller/IndexControllerTest.java
@@ -22,6 +22,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.index.Index;
 import org.folio.search.domain.dto.IndexRequestBody;
 import org.folio.search.domain.dto.ReindexJob;
+import org.folio.search.domain.dto.ReindexRequest;
 import org.folio.search.exception.SearchOperationException;
 import org.folio.search.service.IndexService;
 import org.folio.search.utils.types.UnitTest;
@@ -150,10 +151,11 @@ class IndexControllerTest {
   @Test
   void canSubmitReindex() throws Exception {
     var jobId = randomId();
-    when(indexService.reindexInventory(TENANT_ID, false)).thenReturn(new ReindexJob().id(jobId));
+    when(indexService.reindexInventory(TENANT_ID, null)).thenReturn(new ReindexJob().id(jobId));
 
     mockMvc.perform(post("/search/index/inventory/reindex")
-      .header(X_OKAPI_TENANT_HEADER, TENANT_ID))
+      .header(X_OKAPI_TENANT_HEADER, TENANT_ID)
+      .contentType(APPLICATION_JSON))
       .andExpect(status().isOk())
       .andExpect(jsonPath("id", is(jobId)));
   }
@@ -161,10 +163,13 @@ class IndexControllerTest {
   @Test
   void reindexInventoryRecords_positive_withRecreateIndexFlag() throws Exception {
     var jobId = randomId();
-    when(indexService.reindexInventory(TENANT_ID, true)).thenReturn(new ReindexJob().id(jobId));
+    var request = new ReindexRequest().recreateIndex(true);
+    when(indexService.reindexInventory(TENANT_ID, request)).thenReturn(new ReindexJob().id(jobId));
 
     mockMvc.perform(post("/search/index/inventory/reindex")
       .header(X_OKAPI_TENANT_HEADER, TENANT_ID)
+      .contentType(APPLICATION_JSON)
+      .content(asJsonString(request))
       .param("recreateIndex", "true"))
       .andExpect(status().isOk())
       .andExpect(jsonPath("id", is(jobId)));

--- a/src/test/java/org/folio/search/controller/IndexControllerTest.java
+++ b/src/test/java/org/folio/search/controller/IndexControllerTest.java
@@ -150,9 +150,22 @@ class IndexControllerTest {
   @Test
   void canSubmitReindex() throws Exception {
     var jobId = randomId();
-    when(indexService.reindexInventory()).thenReturn(new ReindexJob().id(jobId));
+    when(indexService.reindexInventory(TENANT_ID, false)).thenReturn(new ReindexJob().id(jobId));
 
-    mockMvc.perform(post("/search/index/inventory/reindex"))
+    mockMvc.perform(post("/search/index/inventory/reindex")
+      .header(X_OKAPI_TENANT_HEADER, TENANT_ID))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("id", is(jobId)));
+  }
+
+  @Test
+  void reindexInventoryRecords_positive_withRecreateIndexFlag() throws Exception {
+    var jobId = randomId();
+    when(indexService.reindexInventory(TENANT_ID, true)).thenReturn(new ReindexJob().id(jobId));
+
+    mockMvc.perform(post("/search/index/inventory/reindex")
+      .header(X_OKAPI_TENANT_HEADER, TENANT_ID)
+      .param("recreateIndex", "true"))
       .andExpect(status().isOk())
       .andExpect(jsonPath("id", is(jobId)));
   }

--- a/src/test/java/org/folio/search/service/IndexServiceTest.java
+++ b/src/test/java/org/folio/search/service/IndexServiceTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.List;
 import org.folio.search.client.InstanceStorageClient;
+import org.folio.search.domain.dto.ReindexRequest;
 import org.folio.search.exception.SearchServiceException;
 import org.folio.search.integration.ResourceFetchService;
 import org.folio.search.model.service.ResourceIdEvent;
@@ -136,7 +137,7 @@ class IndexServiceTest {
   }
 
   @Test
-  void reindexInventory_positive() {
+  void reindexInventory_positive_recreateIndexIsTrue() {
     var indexName = getElasticsearchIndexName(INSTANCE_RESOURCE, TENANT_ID);
     var createIndexResponse = getSuccessFolioCreateIndexResponse(List.of(indexName));
 
@@ -145,16 +146,21 @@ class IndexServiceTest {
     when(indexRepository.indexExists(indexName)).thenReturn(true, false);
     when(indexRepository.createIndex(indexName, EMPTY_OBJECT, EMPTY_OBJECT)).thenReturn(createIndexResponse);
 
-    indexService.reindexInventory(TENANT_ID, true);
+    indexService.reindexInventory(TENANT_ID, new ReindexRequest().recreateIndex(true));
 
     verify(instanceStorageClient).submitReindex();
     verify(indexRepository).dropIndex(indexName);
   }
 
   @Test
-  void reindexInventory_positive_recreateIndexIsTrue() {
-    indexService.reindexInventory(TENANT_ID, false);
+  void reindexInventory_positive_recreateIndexIsFalse() {
+    indexService.reindexInventory(TENANT_ID, new ReindexRequest());
+    verify(instanceStorageClient).submitReindex();
+  }
 
+  @Test
+  void reindexInventory_positive_recreateIndexIsNull() {
+    indexService.reindexInventory(TENANT_ID, null);
     verify(instanceStorageClient).submitReindex();
   }
 


### PR DESCRIPTION
Reindex endpoint `.../search/index/inventory/reindex` has been extended with bool query parameter `recreateIndex`, if it specified and equals to true - indices for tenant will be recreated. This parameter reduces the amount of API calls to the mod-search service to clean up indices and start reindex:
- `DELETE {elasticsearchBaseUrl}/instance_{tenantID}` to remove elasticsearch index
- `POST {modSearchBaseUrl}/search/index/indices -d '{"resourceName": "instance"}'` to create new index again with new mappings and settings