### PR TITLE
MSEARCH-129: Make consumer name different per environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ with less powerful configuration (see [High availability](https://www.elastic.co
 | INITIAL_LANGUAGES      | eng                       | Comma separated list of languages for multilang fields see [Multi-lang search support](#multi-language-search-support) |
 | SYSTEM_USER_PASSWORD   | -                         | Password for `mod-search` system user (not required for dev envs) |
 | OKAPI_URL              | -                         | OKAPI URL used to login system user, required                     |
+| ENV                    | folio                     | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments |
 
 The module uses system user to communicate with other modules from Kafka consumers.
 For production deployments you MUST specify the password for this system user via env variable:

--- a/src/main/java/org/folio/search/configuration/properties/FolioEnvironment.java
+++ b/src/main/java/org/folio/search/configuration/properties/FolioEnvironment.java
@@ -8,8 +8,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class FolioEnvironment {
   private final String okapiUrl;
+  private final String env;
 
-  public FolioEnvironment(@Value("${okapi.url}") String okapiUrl) {
+  public FolioEnvironment(@Value("${okapi.url}") String okapiUrl,
+    @Value("${env:folio}") String env) {
+
     this.okapiUrl = okapiUrl;
+    this.env = env;
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ application:
       events:
         concurrency: 1
         topics: inventory.instance,inventory.item,inventory.holdings-record
-        group-id: mod-search-events-group
+        group-id: ${ENV:folio}-mod-search-events-group
 
 server.port: 8081
 management.endpoints.web:

--- a/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
+++ b/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.folio.search.SearchApplication;
+import org.folio.search.configuration.properties.FolioKafkaProperties;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.ResourceEventBody;
 import org.folio.search.exception.TenantNotInitializedException;
@@ -75,6 +76,12 @@ class KafkaMessageListenerIT {
     assertThat(handledException)
       .isInstanceOf(TenantNotInitializedException.class)
       .hasMessage("Following tenants might not be initialized yet: [not_existent_tenant]");
+  }
+
+  @Test
+  void shouldAddEnvPrefixForConsumerGroup(@Autowired FolioKafkaProperties kafkaProperties) {
+    kafkaProperties.getListener().values().forEach(
+      listenerProperties -> assertThat(listenerProperties.getGroupId()).startsWith("folio-"));
   }
 
   private Exception runAndReturnException(Callable<?> job) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -35,4 +35,4 @@ application:
       events:
         concurrency: 1
         topics: inventory.instance,inventory.item,inventory.holdings-record
-        group-id: mod-search-events-group
+        group-id: ${ENV:folio}-mod-search-events-group


### PR DESCRIPTION
Introduce `ENV` variable to differentiate environments and build consumer group id appending the env name.