### PR TITLE
MSEARCH-105 Add TLS settings as environment variables for Kafka consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,24 +101,29 @@ with less powerful configuration (see [High availability](https://www.elastic.co
 
 ## Environment variables:
 
-| Name                   | Default value             | Description                                                       |
-| :----------------------| :------------------------:|:------------------------------------------------------------------|
-| DB_HOST                | postgres                  | Postgres hostname                                                 |
-| DB_PORT                | 5432                      | Postgres port                                                     |
-| DB_USERNAME            | folio_admin               | Postgres username                                                 |
-| DB_PASSWORD            | -                         | Postgres username password                                        |
-| DB_DATABASE            | okapi_modules             | Postgres database name                                            |
-| ~~ELASTICSEARCH_HOST~~ | elasticsearch             | (DEPRECATED, use ELASTICSEARCH_URL) Elasticsearch hostname        |
-| ~~ELASTICSEARCH_POR~~  | 9200                      | (DEPRECATED, use ELASTICSEARCH_URL) Elasticsearch port            |
-| ELASTICSEARCH_URL      | http://elasticsearch:9200 | Elasticsearch URL                                                 |
-| ELASTICSEARCH_USERNAME | -                         | Elasticsearch username (not required for dev envs)                |
-| ELASTICSEARCH_PASSWORD | -                         | Elasticsearch password (not required for dev envs)                |
-| KAFKA_HOST             | kafka                     | Kafka broker hostname                                             |
-| KAFKA_PORT             | 9092                      | Kafka broker port                                                 |
-| INITIAL_LANGUAGES      | eng                       | Comma separated list of languages for multilang fields see [Multi-lang search support](#multi-language-search-support) |
-| SYSTEM_USER_PASSWORD   | -                         | Password for `mod-search` system user (not required for dev envs) |
-| OKAPI_URL              | -                         | OKAPI URL used to login system user, required                     |
-| ENV                    | folio                     | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments |
+| Name                          | Default value             | Description                                                       |
+| :-----------------------------| :------------------------:|:------------------------------------------------------------------|
+| DB_HOST                       | postgres                  | Postgres hostname                                                 |
+| DB_PORT                       | 5432                      | Postgres port                                                     |
+| DB_USERNAME                   | folio_admin               | Postgres username                                                 |
+| DB_PASSWORD                   | -                         | Postgres username password                                        |
+| DB_DATABASE                   | okapi_modules             | Postgres database name                                            |
+| ~~ELASTICSEARCH_HOST~~        | elasticsearch             | (DEPRECATED, use ELASTICSEARCH_URL) Elasticsearch hostname        |
+| ~~ELASTICSEARCH_POR~~         | 9200                      | (DEPRECATED, use ELASTICSEARCH_URL) Elasticsearch port            |
+| ELASTICSEARCH_URL             | http://elasticsearch:9200 | Elasticsearch URL                                                 |
+| ELASTICSEARCH_USERNAME        | -                         | Elasticsearch username (not required for dev envs)                |
+| ELASTICSEARCH_PASSWORD        | -                         | Elasticsearch password (not required for dev envs)                |
+| KAFKA_HOST                    | kafka                     | Kafka broker hostname                                             |
+| KAFKA_PORT                    | 9092                      | Kafka broker port                                                 |
+| KAFKA_SECURITY_PROTOCOL       | PLAINTEXT                 | Kafka security protocol used to communicate with brokers (SSL or PLAINTEXT) |
+| KAFKA_SSL_KEYSTORE_LOCATION   | -                         | The location of the Kafka key store file. This is optional for client and can be used for two-way authentication for client. |
+| KAFKA_SSL_KEYSTORE_PASSWORD   | -                         | The store password for the Kafka key store file. This is optional for client and only needed if 'ssl.keystore.location' is configured. |
+| KAFKA_SSL_TRUSTSTORE_LOCATION | -                         | The location of the Kafka trust store file. |
+| KAFKA_SSL_TRUSTSTORE_PASSWORD | -                         | he password for the Kafka trust store file. If a password is not set, trust store file configured will still be used, but integrity checking is disabled. |
+| INITIAL_LANGUAGES             | eng                       | Comma separated list of languages for multilang fields see [Multi-lang search support](#multi-language-search-support) |
+| SYSTEM_USER_PASSWORD          | -                         | Password for `mod-search` system user (not required for dev envs) |
+| OKAPI_URL                     | -                         | OKAPI URL used to login system user, required                     |
+| ENV                           | folio                     | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments |
 
 The module uses system user to communicate with other modules from Kafka consumers.
 For production deployments you MUST specify the password for this system user via env variable:

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -240,6 +240,26 @@
         "value": "9092"
       },
       {
+        "name": "KAFKA_SECURITY_PROTOCOL",
+        "value": "PLAINTEXT"
+      },
+      {
+        "name": "KAFKA_SSL_KEYSTORE_LOCATION",
+        "value": ""
+      },
+      {
+        "name": "KAFKA_SSL_KEYSTORE_PASSWORD",
+        "value": ""
+      },
+      {
+        "name": "KAFKA_SSL_TRUSTSTORE_LOCATION",
+        "value": ""
+      },
+      {
+        "name": "KAFKA_SSL_TRUSTSTORE_PASSWORD",
+        "value": ""
+      },
+      {
         "name": "ELASTICSEARCH_HOST",
         "value": "elasticsearch"
       },

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,14 @@ spring:
     bootstrap-servers: ${KAFKA_HOST:kafka}:${KAFKA_PORT:9092}
     consumer:
       max-poll-records: 50
+    security:
+      protocol: ${KAFKA_SECURITY_PROTOCOL:PLAINTEXT}
+    ssl:
+      key-store-password: ${KAFKA_SSL_KEYSTORE_PASSWORD:}
+      key-store-location: ${KAFKA_SSL_KEYSTORE_LOCATION:}
+      trust-store-password: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:}
+      trust-store-location: ${KAFKA_SSL_TRUSTSTORE_LOCATION:}
+
   datasource:
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:postgres}


### PR DESCRIPTION
### Purpose / Overview
There were some concerns raised in the community regarding how secure the direct connection will be. To address these concerns, the new solution was designed: https://wiki.folio.org/display/DD/Temporary+Kafka+security+solution.
The solution was reviewed and approved by the Security group and Tech Council.

### Approach
Add the following environment variables to the application to handle Spring Boot properties:
- KAFKA_SECURITY_PROTOCOL (`spring.kafka.security.protocol`)
- KAFKA_SSL_KEYSTORE_PASSWORD (`spring.kafka.ssl.key-store-password`)
- KAFKA_SSL_KEYSTORE_LOCATION (`spring.kafka.ssl.key-store-location`)
- KAFKA_SSL_TRUSTSTORE_PASSWORD (`spring.kafka.ssl.trust-store-password`)
- KAFKA_SSL_TRUSTSTORE_LOCATION (`spring.kafka.ssl.trust-store-location`)