### PR TITLE
MSEARCH-95: Use ENV name as prefix for Elasticsearch index.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ with less powerful configuration (see [High availability](https://www.elastic.co
 | INITIAL_LANGUAGES             | eng                       | Comma separated list of languages for multilang fields see [Multi-lang search support](#multi-language-search-support) |
 | SYSTEM_USER_PASSWORD          | -                         | Password for `mod-search` system user (not required for dev envs) |
 | OKAPI_URL                     | -                         | OKAPI URL used to login system user, required                     |
-| ENV                           | folio                     | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments |
+| ENV                           | folio                     | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed|
 
 The module uses system user to communicate with other modules from Kafka consumers.
 For production deployments you MUST specify the password for this system user via env variable:

--- a/src/main/java/org/folio/search/configuration/properties/FolioEnvironment.java
+++ b/src/main/java/org/folio/search/configuration/properties/FolioEnvironment.java
@@ -2,22 +2,13 @@ package org.folio.search.configuration.properties;
 
 import static java.lang.System.getProperty;
 import static java.lang.System.getenv;
+import static lombok.AccessLevel.PRIVATE;
 import static org.apache.commons.lang3.StringUtils.firstNonBlank;
 
-import lombok.Getter;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import lombok.NoArgsConstructor;
 
-@Getter
-@Component
-public class FolioEnvironment {
-  private final String okapiUrl;
-  private final String env;
-
-  public FolioEnvironment(@Value("${okapi.url}") String okapiUrl) {
-    this.okapiUrl = okapiUrl;
-    this.env = getFolioEnvName();
-  }
+@NoArgsConstructor(access = PRIVATE)
+public final class FolioEnvironment {
 
   public static String getFolioEnvName() {
     return validateFolioEnv(firstNonBlank(getenv("ENV"), getProperty("env"), "folio"));

--- a/src/main/java/org/folio/search/configuration/properties/FolioEnvironment.java
+++ b/src/main/java/org/folio/search/configuration/properties/FolioEnvironment.java
@@ -1,5 +1,9 @@
 package org.folio.search.configuration.properties;
 
+import static java.lang.System.getProperty;
+import static java.lang.System.getenv;
+import static org.apache.commons.lang3.StringUtils.firstNonBlank;
+
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -10,10 +14,20 @@ public class FolioEnvironment {
   private final String okapiUrl;
   private final String env;
 
-  public FolioEnvironment(@Value("${okapi.url}") String okapiUrl,
-    @Value("${env:folio}") String env) {
-
+  public FolioEnvironment(@Value("${okapi.url}") String okapiUrl) {
     this.okapiUrl = okapiUrl;
-    this.env = env;
+    this.env = getFolioEnvName();
+  }
+
+  public static String getFolioEnvName() {
+    return validateFolioEnv(firstNonBlank(getenv("ENV"), getProperty("env"), "folio"));
+  }
+
+  private static String validateFolioEnv(String folioEnv) {
+    if (!folioEnv.matches("[\\w0-9\\-_]+")) {
+      throw new IllegalArgumentException("Folio ENV must contain alphanumeric and '-', '_' symbols only");
+    }
+
+    return folioEnv;
   }
 }

--- a/src/main/java/org/folio/search/configuration/properties/OkapiConfigurationProperties.java
+++ b/src/main/java/org/folio/search/configuration/properties/OkapiConfigurationProperties.java
@@ -1,0 +1,15 @@
+package org.folio.search.configuration.properties;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class OkapiConfigurationProperties {
+  private final String okapiUrl;
+
+  public OkapiConfigurationProperties(@Value("${okapi.url}") String okapiUrl) {
+    this.okapiUrl = okapiUrl;
+  }
+}

--- a/src/main/java/org/folio/search/service/systemuser/SystemUserService.java
+++ b/src/main/java/org/folio/search/service/systemuser/SystemUserService.java
@@ -2,8 +2,8 @@ package org.folio.search.service.systemuser;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.folio.search.configuration.properties.FolioEnvironment;
 import org.folio.search.configuration.properties.FolioSystemUserProperties;
+import org.folio.search.configuration.properties.OkapiConfigurationProperties;
 import org.folio.search.model.SystemUser;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -16,7 +16,7 @@ public class SystemUserService {
 
   private final PrepareSystemUserService prepareSystemUserService;
   private final FolioSystemUserProperties folioSystemUserConf;
-  private final FolioEnvironment folioEnvironment;
+  private final OkapiConfigurationProperties okapiProperties;
 
   public void prepareSystemUser() {
     log.info("Preparing system user...");
@@ -32,7 +32,7 @@ public class SystemUserService {
     var systemUser = SystemUser.builder()
       .tenantId(tenantId)
       .username(folioSystemUserConf.getUsername())
-      .okapiUrl(folioEnvironment.getOkapiUrl())
+      .okapiUrl(okapiProperties.getOkapiUrl())
       .build();
 
     var token = prepareSystemUserService.loginSystemUser(systemUser);

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -1,6 +1,7 @@
 package org.folio.search.utils;
 
 import static java.util.stream.Collectors.joining;
+import static org.folio.search.configuration.properties.FolioEnvironment.getFolioEnvName;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -77,7 +78,7 @@ public class SearchUtils {
    * @return generated index name.
    */
   public static String getElasticsearchIndexName(String resource, String tenantId) {
-    return resource + "_" + tenantId;
+    return getFolioEnvAndMakeValidEsIdentifier() + "_" + resource + "_" + tenantId;
   }
 
   /**
@@ -156,5 +157,9 @@ public class SearchUtils {
    */
   public static <T> Stream<T> toSafeStream(List<T> nullableList) {
     return CollectionUtils.isNotEmpty(nullableList) ? nullableList.stream() : Stream.empty();
+  }
+
+  private static String getFolioEnvAndMakeValidEsIdentifier() {
+    return getFolioEnvName().replace("-", "_").toLowerCase();
   }
 }

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -78,7 +78,7 @@ public class SearchUtils {
    * @return generated index name.
    */
   public static String getElasticsearchIndexName(String resource, String tenantId) {
-    return getFolioEnvAndMakeValidEsIdentifier() + "_" + resource + "_" + tenantId;
+    return getFolioEnvName().toLowerCase() + "_" + resource + "_" + tenantId;
   }
 
   /**
@@ -157,9 +157,5 @@ public class SearchUtils {
    */
   public static <T> Stream<T> toSafeStream(List<T> nullableList) {
     return CollectionUtils.isNotEmpty(nullableList) ? nullableList.stream() : Stream.empty();
-  }
-
-  private static String getFolioEnvAndMakeValidEsIdentifier() {
-    return getFolioEnvName().replace("-", "_").toLowerCase();
   }
 }

--- a/src/test/java/org/folio/search/configuration/properties/FolioEnvironmentTest.java
+++ b/src/test/java/org/folio/search/configuration/properties/FolioEnvironmentTest.java
@@ -1,0 +1,56 @@
+package org.folio.search.configuration.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.configuration.properties.FolioEnvironment.getFolioEnvName;
+import static org.folio.search.utils.TestUtils.removeEnvProperty;
+import static org.folio.search.utils.TestUtils.setEnvProperty;
+
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@UnitTest
+class FolioEnvironmentTest {
+  @AfterEach
+  void resetEnvPropertyValue() {
+    removeEnvProperty();
+  }
+
+  @Test
+  void shouldReturnFolioEnvFromProperties() {
+    setEnvProperty("test-env");
+
+    assertThat(getFolioEnvName()).isEqualTo("test-env");
+  }
+
+  @Test
+  void shouldReturnDefaultFolioEnvIfPropertyNotSet() {
+    assertThat(getFolioEnvName()).isEqualTo("folio");
+  }
+
+  @Test
+  void shouldReturnDefaultFolioEnvIfPropertyIsEmpty() {
+    setEnvProperty("   ");
+    assertThat(getFolioEnvName()).isEqualTo("folio");
+  }
+
+  @ValueSource(strings = {"a", "Z", "0", "9", "_", "-"})
+  @ParameterizedTest
+  void shouldNotThrowExceptionWhenEnvHasAllowedChars(String env) {
+    setEnvProperty(env);
+    assertThat(getFolioEnvName()).isEqualTo(env);
+  }
+
+  @ValueSource(strings = {"!", "@", "%$$#", "def qa"})
+  @ParameterizedTest
+  void shouldThrowExceptionWhenEnvHasDisallowedChars(String env) {
+    setEnvProperty(env);
+
+    assertThatThrownBy(FolioEnvironment::getFolioEnvName)
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Folio ENV must contain alphanumeric and '-', '_' symbols only");
+  }
+}

--- a/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
+++ b/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
@@ -59,7 +59,7 @@ class KafkaMessageListenerIT {
         new ResourceEventBody().type(CREATE)
           .tenant(tenantName)._new(Map.of("id", randomId()))));
 
-    when(indexRepository.indexExists("instance_" + tenantName)).thenReturn(true);
+    when(indexRepository.indexExists("folio_instance_" + tenantName)).thenReturn(true);
     when(inventoryViewClient.getInstances(any(), anyInt()))
       .thenReturn(asSinglePage(new InventoryViewClient.InstanceView(
         instance, emptyList(), emptyList())));

--- a/src/test/java/org/folio/search/repository/IndexRepositoryTest.java
+++ b/src/test/java/org/folio/search/repository/IndexRepositoryTest.java
@@ -84,7 +84,7 @@ class IndexRepositoryTest {
       .isInstanceOf(SearchOperationException.class)
       .hasCauseExactlyInstanceOf(IOException.class)
       .hasMessage("Failed to perform elasticsearch request "
-        + "[index=test-resource_test_tenant, type=createIndexApi, message: err]");
+        + "[index=folio_test-resource_test_tenant, type=createIndexApi, message: err]");
   }
 
   @Test
@@ -119,7 +119,7 @@ class IndexRepositoryTest {
       .isInstanceOf(SearchOperationException.class)
       .hasCauseExactlyInstanceOf(IOException.class)
       .hasMessage("Failed to perform elasticsearch request "
-        + "[index=test-resource_test_tenant, type=putMappingsApi, message: err]");
+        + "[index=folio_test-resource_test_tenant, type=putMappingsApi, message: err]");
   }
 
   @Test
@@ -169,7 +169,7 @@ class IndexRepositoryTest {
       .isInstanceOf(SearchOperationException.class)
       .hasCauseExactlyInstanceOf(IOException.class)
       .hasMessage("Failed to perform elasticsearch request "
-        + "[index=test-resource_test_tenant, type=bulkApi, message: err]");
+        + "[index=folio_test-resource_test_tenant, type=bulkApi, message: err]");
   }
 
   @Test

--- a/src/test/java/org/folio/search/utils/SearchUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchUtilsTest.java
@@ -10,7 +10,9 @@ import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.mapOf;
 import static org.folio.search.utils.TestUtils.randomId;
+import static org.folio.search.utils.TestUtils.removeEnvProperty;
 import static org.folio.search.utils.TestUtils.searchServiceRequest;
+import static org.folio.search.utils.TestUtils.setEnvProperty;
 
 import java.io.IOException;
 import java.util.List;
@@ -18,6 +20,7 @@ import org.folio.search.exception.SearchOperationException;
 import org.folio.search.model.service.ResourceIdEvent;
 import org.folio.search.model.types.IndexActionType;
 import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,6 +28,11 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 @UnitTest
 class SearchUtilsTest {
+
+  @AfterEach
+  void resetEnvPropertyValue() {
+    removeEnvProperty();
+  }
 
   @Test
   void performExceptionalOperation_positive() {
@@ -53,6 +61,14 @@ class SearchUtilsTest {
   void getElasticsearchIndexName_resourceNameAndTenantId_positive() {
     var actual = getElasticsearchIndexName(RESOURCE_NAME, TENANT_ID);
     assertThat(actual).isEqualTo(INDEX_NAME);
+  }
+
+  @Test
+  void getElasticsearchIndexName_resourceNameAndTenantId_replaceHyphenWithUnderscore() {
+    setEnvProperty("dev-qa");
+
+    var actual = getElasticsearchIndexName(RESOURCE_NAME, TENANT_ID);
+    assertThat(actual).isEqualTo("dev_qa_" + RESOURCE_NAME + "_" + TENANT_ID);
   }
 
   @Test

--- a/src/test/java/org/folio/search/utils/SearchUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchUtilsTest.java
@@ -64,14 +64,6 @@ class SearchUtilsTest {
   }
 
   @Test
-  void getElasticsearchIndexName_resourceNameAndTenantId_replaceHyphenWithUnderscore() {
-    setEnvProperty("dev-qa");
-
-    var actual = getElasticsearchIndexName(RESOURCE_NAME, TENANT_ID);
-    assertThat(actual).isEqualTo("dev_qa_" + RESOURCE_NAME + "_" + TENANT_ID);
-  }
-
-  @Test
   void getElasticsearchIndexName_positive_resourceIdEvent() {
     var idEvent = ResourceIdEvent.of(randomId(), RESOURCE_NAME, TENANT_ID, IndexActionType.INDEX);
     var actual = getElasticsearchIndexName(idEvent);

--- a/src/test/java/org/folio/search/utils/SearchUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchUtilsTest.java
@@ -12,7 +12,6 @@ import static org.folio.search.utils.TestUtils.mapOf;
 import static org.folio.search.utils.TestUtils.randomId;
 import static org.folio.search.utils.TestUtils.removeEnvProperty;
 import static org.folio.search.utils.TestUtils.searchServiceRequest;
-import static org.folio.search.utils.TestUtils.setEnvProperty;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/test/java/org/folio/search/utils/TestConstants.java
+++ b/src/test/java/org/folio/search/utils/TestConstants.java
@@ -12,7 +12,7 @@ public class TestConstants {
   public static final String RESOURCE_ID = "test_tenant";
   public static final String TENANT_ID = "test_tenant";
   public static final String RESOURCE_NAME = "test-resource";
-  public static final String INDEX_NAME = RESOURCE_NAME + "_" + TENANT_ID;
+  public static final String INDEX_NAME = "folio_" + RESOURCE_NAME + "_" + TENANT_ID;
   public static final String INVENTORY_INSTANCE_TOPIC = "inventory.instance";
   public static final String INVENTORY_HOLDING_TOPIC = "inventory.holdings-record";
   public static final String INVENTORY_ITEM_TOPIC = "inventory.item";

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -1,5 +1,7 @@
 package org.folio.search.utils;
 
+import static java.lang.System.clearProperty;
+import static java.lang.System.setProperty;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toCollection;
 import static org.folio.search.model.metadata.PlainFieldDescription.MULTILANG_FIELD_TYPE;
@@ -291,5 +293,13 @@ public class TestUtils {
 
   public static Instance instanceWithIdentifiers(InstanceIdentifiers... identifiers) {
     return new Instance().identifiers(identifiers != null ? asList(identifiers) : null);
+  }
+
+  public static void setEnvProperty(String value) {
+    setProperty("env", value);
+  }
+
+  public static void removeEnvProperty() {
+    clearProperty("env");
   }
 }


### PR DESCRIPTION
The `ENV` variable is used as a prefix for ES index, `ENV` value is restricted to contain alphanumeric and '_', '-' symbols only.