### PR TITLE
MSEARCH-134 Remove multi-language support from the contributors fields

### DIFF
--- a/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
@@ -14,7 +14,7 @@ import static org.elasticsearch.index.query.QueryBuilders.wildcardQuery;
 import static org.folio.search.utils.SearchQueryUtils.isBoolQuery;
 import static org.folio.search.utils.SearchQueryUtils.isDisjunctionFilterQuery;
 import static org.folio.search.utils.SearchQueryUtils.isFilterQuery;
-import static org.folio.search.utils.SearchUtils.updatePathForMultilangField;
+import static org.folio.search.utils.SearchUtils.updatePathForFulltextField;
 import static org.folio.search.utils.SearchUtils.updatePathForTermQueries;
 
 import java.io.IOException;
@@ -251,8 +251,8 @@ public class CqlSearchQueryConverter {
 
   private List<String> getFieldsForMultilangField(String fieldName, String resource) {
     return searchFieldProvider.getPlainFieldByPath(resource, fieldName)
-      .filter(PlainFieldDescription::isMultilang)
-      .map(plainFieldDescription -> updatePathForMultilangField(fieldName))
+      .filter(PlainFieldDescription::isFulltext)
+      .map(desc -> updatePathForFulltextField(desc, fieldName))
       .map(Collections::singletonList)
       .orElse(emptyList());
   }

--- a/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
@@ -108,7 +108,7 @@ public class CqlSearchQueryConverter {
   private QueryBuilder convertToTermQuery(CQLTermNode node, String resource) {
     var fieldName = node.getIndex();
     var fieldsGroup = searchFieldProvider.getFields(resource, fieldName);
-    var fieldList = fieldsGroup.isEmpty() ? getFieldsForMultilangField(fieldName, resource) : fieldsGroup;
+    var fieldList = fieldsGroup.isEmpty() ? getFieldsForFulltextField(fieldName, resource) : fieldsGroup;
 
     var term = getSearchTerm(node.getTerm(), fieldName, resource);
     if (term.contains(ASTERISKS_SIGN)) {
@@ -249,9 +249,9 @@ public class CqlSearchQueryConverter {
       .orElse(term);
   }
 
-  private List<String> getFieldsForMultilangField(String fieldName, String resource) {
+  private List<String> getFieldsForFulltextField(String fieldName, String resource) {
     return searchFieldProvider.getPlainFieldByPath(resource, fieldName)
-      .filter(PlainFieldDescription::isFulltext)
+      .filter(PlainFieldDescription::hasFulltextIndex)
       .map(desc -> updatePathForFulltextField(desc, fieldName))
       .map(Collections::singletonList)
       .orElse(emptyList());

--- a/src/main/java/org/folio/search/model/metadata/PlainFieldDescription.java
+++ b/src/main/java/org/folio/search/model/metadata/PlainFieldDescription.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.folio.search.model.types.SearchType;
@@ -19,7 +20,10 @@ import org.folio.search.model.types.SearchType;
 public class PlainFieldDescription extends FieldDescription {
 
   public static final String NONE_FIELD_TYPE = "none";
+
   public static final String MULTILANG_FIELD_TYPE = "multilang";
+  public static final String STANDARD_FIELD_TYPE = "standard";
+  public static final Set<String> FULLTEXT_FIELD_TYPES = Set.of(MULTILANG_FIELD_TYPE, STANDARD_FIELD_TYPE);
   public static final String PLAIN_MULTILANG_FIELD_TYPE = PLAIN_MULTILANG_PREFIX + "multilang";
 
   /**
@@ -66,17 +70,45 @@ public class PlainFieldDescription extends FieldDescription {
   @JsonProperty("default")
   private Object defaultValue;
 
+  /**
+   * Specifies if plain keyword value should be indexed with field or not. Works only for fulltext fields.
+   */
+  private boolean indexPlainValue = true;
+
+  /**
+   * Provides sort description for field. If not specified - standard rules will be applied for sort field.
+   */
   @JsonProperty("sort")
   private SortDescription sortDescription;
 
   /**
    * Checks if resource description field is multi-language.
    *
-   * @return true if field is must be indexed, false - otherwise
+   * @return true if field is multi-language, false - otherwise
    */
   @JsonIgnore
   public boolean isMultilang() {
     return MULTILANG_FIELD_TYPE.equals(index);
+  }
+
+  /**
+   * Checks if resource description field is standard full-text.
+   *
+   * @return true if field is standard full text, false - otherwise
+   */
+  @JsonIgnore
+  public boolean isStandardFulltext() {
+    return STANDARD_FIELD_TYPE.equals(index);
+  }
+
+  /**
+   * Checks if resource description field is full-text.
+   *
+   * @return true if field is standard full text, false - otherwise
+   */
+  @JsonProperty
+  public boolean isFulltext() {
+    return FULLTEXT_FIELD_TYPES.contains(index);
   }
 
   /**

--- a/src/main/java/org/folio/search/model/metadata/PlainFieldDescription.java
+++ b/src/main/java/org/folio/search/model/metadata/PlainFieldDescription.java
@@ -92,22 +92,12 @@ public class PlainFieldDescription extends FieldDescription {
   }
 
   /**
-   * Checks if resource description field is standard full-text.
+   * Checks if resource description field can be considered as fulltext.
    *
-   * @return true if field is standard full text, false - otherwise
-   */
-  @JsonIgnore
-  public boolean isStandardFulltext() {
-    return STANDARD_FIELD_TYPE.equals(index);
-  }
-
-  /**
-   * Checks if resource description field is full-text.
-   *
-   * @return true if field is standard full text, false - otherwise
+   * @return true if field can be considered as a fulltext, false - otherwise
    */
   @JsonProperty
-  public boolean isFulltext() {
+  public boolean hasFulltextIndex() {
     return FULLTEXT_FIELD_TYPES.contains(index);
   }
 

--- a/src/main/java/org/folio/search/service/converter/SearchDocumentConverter.java
+++ b/src/main/java/org/folio/search/service/converter/SearchDocumentConverter.java
@@ -1,13 +1,11 @@
 package org.folio.search.service.converter;
 
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
 import static org.folio.search.model.types.IndexActionType.INDEX;
 import static org.folio.search.utils.CollectionUtils.mergeSafely;
 import static org.folio.search.utils.CollectionUtils.nullIfEmpty;
 import static org.folio.search.utils.SearchUtils.getElasticsearchIndexName;
-import static org.folio.search.utils.SearchUtils.getMultilangValue;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -26,6 +24,7 @@ import org.folio.search.service.LanguageConfigService;
 import org.folio.search.service.metadata.ResourceDescriptionService;
 import org.folio.search.utils.JsonConverter;
 import org.folio.search.utils.SearchConverterUtils;
+import org.folio.search.utils.SearchUtils;
 import org.springframework.stereotype.Component;
 
 @Log4j2
@@ -123,9 +122,8 @@ public class SearchDocumentConverter {
     if (plainFieldValue == null) {
       return emptyMap();
     }
-    return desc.isMultilang()
-      ? getMultilangValue(fieldName, plainFieldValue, ctx.getLanguages())
-      : singletonMap(fieldName, plainFieldValue);
+
+    return SearchUtils.getPlainFieldValue(desc, fieldName, plainFieldValue, ctx.getLanguages());
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/org/folio/search/service/converter/SearchFieldsProcessor.java
+++ b/src/main/java/org/folio/search/service/converter/SearchFieldsProcessor.java
@@ -1,8 +1,6 @@
 package org.folio.search.service.converter;
 
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
-import static org.folio.search.utils.SearchUtils.getMultilangValue;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -13,6 +11,7 @@ import org.apache.commons.collections.MapUtils;
 import org.folio.search.model.metadata.SearchFieldDescriptor;
 import org.folio.search.service.setter.FieldProcessor;
 import org.folio.search.utils.JsonConverter;
+import org.folio.search.utils.SearchUtils;
 import org.springframework.stereotype.Component;
 
 @Log4j2
@@ -53,7 +52,7 @@ public class SearchFieldsProcessor {
     try {
       var value = fieldProcessor.getFieldValue(resource);
       if (value != null) {
-        return descriptor.isMultilang() ? getMultilangValue(name, value, languages) : singletonMap(name, value);
+        return SearchUtils.getPlainFieldValue(descriptor, name, value, languages);
       }
     } catch (Exception e) {
       log.warn("Failed to retrieve field value", e);

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -3,6 +3,7 @@ package org.folio.search.utils;
 import static java.util.stream.Collectors.joining;
 import static org.folio.search.configuration.properties.FolioEnvironment.getFolioEnvName;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.search.exception.SearchOperationException;
 import org.folio.search.model.ResourceRequest;
 import org.folio.search.model.SearchResource;
+import org.folio.search.model.metadata.PlainFieldDescription;
 import org.folio.search.model.service.CqlSearchServiceRequest;
 import org.folio.search.model.service.ResourceIdEvent;
 import org.folio.spring.integration.XOkapiHeaders;
@@ -93,10 +95,21 @@ public class SearchUtils {
   }
 
   /**
+   * Updates path for fulltext field.
+   *
+   * @param description plain field description as {@link PlainFieldDescription} object
+   * @param path path to field
+   * @return updated path as {@link String} object
+   */
+  public static String updatePathForFulltextField(PlainFieldDescription description, String path) {
+    return description.isMultilang() ? updatePathForMultilangField(path) : path;
+  }
+
+  /**
    * Updates path for multilang field.
    *
    * @param path path to field
-   * @return updated path as {@link String}
+   * @return updated path as {@link String} object
    */
   public static String updatePathForMultilangField(String path) {
     return path + ".*";
@@ -128,6 +141,17 @@ public class SearchUtils {
       .collect(joining(" "));
   }
 
+  public static Map<String, Object> getPlainFieldValue(
+    PlainFieldDescription description, String key, Object value, List<String> languages) {
+    if (description.isMultilang()) {
+      return getMultilangValue(key, value, languages);
+    }
+    if (description.isStandardFulltext()) {
+      return getStandardFulltextValue(key, value, description.isIndexPlainValue());
+    }
+    return Collections.singletonMap(key, value);
+  }
+
   /**
    * Generates multi-language field value for passed key, value and conversion context with supported languages.
    *
@@ -146,6 +170,25 @@ public class SearchUtils {
     resultMap.put(PLAIN_MULTILANG_PREFIX + key, value);
 
     return resultMap;
+  }
+
+  /**
+   * Generates standard fulltext field value for passed key, value and boolean flag for plain field.
+   *
+   * @param key name of multi-language field as {@link String} object
+   * @param value multi-language field value as {@link Object} object
+   * @param indexPlainField boolean flag that specifies if plain value must be indexed or not
+   * @return created standard fulltext value as {@link Map} object
+   */
+  public static Map<String, Object> getStandardFulltextValue(String key, Object value, boolean indexPlainField) {
+    if (!indexPlainField) {
+      return Collections.singletonMap(key, value);
+    }
+    var fulltextValue = new LinkedHashMap<String, Object>(2, CONST_SIZE_LOAD_FACTOR);
+    fulltextValue.put(key, value);
+    fulltextValue.put(PLAIN_MULTILANG_PREFIX + key, value);
+
+    return fulltextValue;
   }
 
   /**

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -142,15 +142,23 @@ public class SearchUtils {
       .collect(joining(" "));
   }
 
+  /**
+   * Returns plain field value for fulltext value.
+   * @param description plain field description as {@link PlainFieldDescription} object
+   * @param fieldName field name as {@link String} object
+   * @param fieldValue field value as {@link Object} object.
+   * @param languages list of supported languages for multi-language fields
+   * @return {@link Map} as a created field
+   */
   public static Map<String, Object> getPlainFieldValue(
-    PlainFieldDescription description, String key, Object value, List<String> languages) {
+    PlainFieldDescription description, String fieldName, Object fieldValue, List<String> languages) {
     if (description.isMultilang()) {
-      return getMultilangValue(key, value, languages);
+      return getMultilangValue(fieldName, fieldValue, languages);
     }
     if (STANDARD_FIELD_TYPE.equals(description.getIndex())) {
-      return getStandardFulltextValue(key, value, description.isIndexPlainValue());
+      return getStandardFulltextValue(fieldName, fieldValue, description.isIndexPlainValue());
     }
-    return Collections.singletonMap(key, value);
+    return Collections.singletonMap(fieldName, fieldValue);
   }
 
   /**

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -144,6 +144,7 @@ public class SearchUtils {
 
   /**
    * Returns plain field value for fulltext value.
+   *
    * @param description plain field description as {@link PlainFieldDescription} object
    * @param fieldName field name as {@link String} object
    * @param fieldValue field value as {@link Object} object.

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -2,6 +2,7 @@ package org.folio.search.utils;
 
 import static java.util.stream.Collectors.joining;
 import static org.folio.search.configuration.properties.FolioEnvironment.getFolioEnvName;
+import static org.folio.search.model.metadata.PlainFieldDescription.STANDARD_FIELD_TYPE;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -146,7 +147,7 @@ public class SearchUtils {
     if (description.isMultilang()) {
       return getMultilangValue(key, value, languages);
     }
-    if (description.isStandardFulltext()) {
+    if (STANDARD_FIELD_TYPE.equals(description.getIndex())) {
       return getStandardFulltextValue(key, value, description.isIndexPlainValue());
     }
     return Collections.singletonMap(key, value);

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -64,7 +64,7 @@
       "properties": {
         "name": {
           "inventorySearchTypes": [ "contributors", "keyword" ],
-          "index": "multilang",
+          "index": "standard",
           "showInResponse": true
         },
         "primary": {
@@ -339,7 +339,8 @@
       "type": "search",
       "processor": "isbnProcessor",
       "searchTermProcessor": "isbnSearchTermProcessor",
-      "index": "standard"
+      "index": "standard",
+      "indexPlainValue": false
     },
     "issn": {
       "type": "search",

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -89,6 +89,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
           .andExpect(jsonPath("instances[0].id", is(getSemanticWeb().getId())))
           .andExpect(jsonPath("instances[0].contributors[0].name", is("Antoniou, Grigoris")))
           .andExpect(jsonPath("instances[0].contributors[1].name", is("Van Harmelen, Frank")))),
+      arguments("search by contributors name", "contributors.name all {value}", array("franks"), zeroResultConsumer()),
       arguments("search by contributors alias", "contributors all {value}", array("grigoris"), null),
 
       arguments("search by hrid for exact match", "hrid={value}", array("inst000000000022"), null),

--- a/src/test/java/org/folio/search/cql/CqlSearchQueryConverterTest.java
+++ b/src/test/java/org/folio/search/cql/CqlSearchQueryConverterTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.index.query.MultiMatchQueryBuilder.Type.CROSS_FIELDS;
 import static org.elasticsearch.index.query.MultiMatchQueryBuilder.Type.PHRASE;
 import static org.elasticsearch.index.query.Operator.AND;
+import static org.elasticsearch.index.query.Operator.OR;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
@@ -301,8 +302,8 @@ class CqlSearchQueryConverterTest {
 
       arguments("id==" + resourceId, searchSource().query(termQuery("id", resourceId))),
 
-      arguments("keyword all \"test-query\"",
-        searchSource().query(matchQuery("keyword", "test-query").operator(AND))),
+      arguments("keyword all \"test-query\"", searchSource().query(matchQuery("keyword", "test-query").operator(AND))),
+      arguments("keyword any \"test-query\"", searchSource().query(matchQuery("keyword", "test-query").operator(OR))),
 
       arguments("(identifiers =/@value \"test-query\") sortby title",
         searchSource().query(matchQuery("identifiers", "test-query").operator(AND))),

--- a/src/test/java/org/folio/search/service/metadata/LocalSearchFieldProviderTest.java
+++ b/src/test/java/org/folio/search/service/metadata/LocalSearchFieldProviderTest.java
@@ -138,6 +138,13 @@ class LocalSearchFieldProviderTest {
     assertThat(actual).isEmpty();
   }
 
+  @Test
+  void getFieldByPath_negative_resourceDescriptionNotFound() {
+    when(localResourceProvider.getResourceDescription(RESOURCE_NAME)).thenReturn(Optional.empty());
+    var actual = searchFieldProvider.getFieldByPath(RESOURCE_NAME, "id");
+    assertThat(actual).isEmpty();
+  }
+
   private List<ResourceDescription> resourceDescriptions() {
     return List.of(converter.convert(
       resourceDescription(mapOf(

--- a/src/test/java/org/folio/search/utils/SearchUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchUtilsTest.java
@@ -1,17 +1,25 @@
 package org.folio.search.utils;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.model.metadata.PlainFieldDescription.STANDARD_FIELD_TYPE;
 import static org.folio.search.utils.SearchUtils.getElasticsearchIndexName;
 import static org.folio.search.utils.SearchUtils.getTotalPages;
 import static org.folio.search.utils.SearchUtils.performExceptionalOperation;
 import static org.folio.search.utils.TestConstants.INDEX_NAME;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.folio.search.utils.TestUtils.keywordField;
 import static org.folio.search.utils.TestUtils.mapOf;
+import static org.folio.search.utils.TestUtils.multilangField;
+import static org.folio.search.utils.TestUtils.plainField;
 import static org.folio.search.utils.TestUtils.randomId;
 import static org.folio.search.utils.TestUtils.removeEnvProperty;
 import static org.folio.search.utils.TestUtils.searchServiceRequest;
+import static org.folio.search.utils.TestUtils.standardFulltextField;
 
 import java.io.IOException;
 import java.util.List;
@@ -77,7 +85,6 @@ class SearchUtilsTest {
     assertThat(totalPages).isEqualTo(expected);
   }
 
-  @DisplayName("updatePathForTermQueries_parameterized")
   @CsvSource({
     "path,path",
     "object.value,object.value",
@@ -85,18 +92,19 @@ class SearchUtilsTest {
     "field1.field2.*,field1.plain_field2",
     "field1.field2.field3.*,field1.field2.plain_field3"
   })
+  @DisplayName("updatePathForTermQueries_parameterized")
   @ParameterizedTest(name = "[{index}] total={0}, expected={1}")
   void updatePathForTermQueries_parameterized(String given, String expected) {
     var actual = SearchUtils.updatePathForTermQueries(given);
     assertThat(actual).isEqualTo(expected);
   }
 
-  @DisplayName("getPathToPlainMultilangValue_parameterized")
   @CsvSource({
     "field,plain_field",
     "field1.field2,field1.plain_field2",
     "field1.field2.field3,field1.field2.plain_field3"
   })
+  @DisplayName("getPathToPlainMultilangValue_parameterized")
   @ParameterizedTest(name = "[{index}] total={0}, expected={1}")
   void getPathToPlainMultilangValue_parameterized(String given, String expected) {
     var actual = SearchUtils.getPathToPlainMultilangValue(given);
@@ -110,5 +118,86 @@ class SearchUtilsTest {
     assertThat(actual).isEqualTo(mapOf(
       "field", mapOf("eng", value, "ger", value, "src", value),
       "plain_field", value));
+  }
+
+  @Test
+  void toSafeStream_positive() {
+    var actual = SearchUtils.toSafeStream(List.of(1, 2)).collect(toList());
+    assertThat(actual).containsExactly(1, 2);
+  }
+
+  @Test
+  void toSafeStream_positive_nullValue() {
+    var actual = SearchUtils.toSafeStream(null).collect(toList());
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void toSafeStream_positive_emptyCollection() {
+    var actual = SearchUtils.toSafeStream(emptyList()).collect(toList());
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void getEffectiveCallNumber_positive() {
+    var actual = SearchUtils.getEffectiveCallNumber("prefix", "cn", null);
+    assertThat(actual).isEqualTo("prefix cn");
+  }
+
+  @Test
+  void updatePathForFulltextField_positive_multilangField() {
+    var actual = SearchUtils.updatePathForFulltextField(multilangField(), "field");
+    assertThat(actual).isEqualTo("field.*");
+  }
+
+  @Test
+  void updatePathForFulltextField_positive_standardFulltextField() {
+    var actual = SearchUtils.updatePathForFulltextField(standardFulltextField(), "field");
+    assertThat(actual).isEqualTo("field");
+  }
+
+  @Test
+  void updatePathForMultilangField_positive_multilangField() {
+    var actual = SearchUtils.updatePathForMultilangField("field");
+    assertThat(actual).isEqualTo("field.*");
+  }
+
+  @Test
+  void getStandardFulltextValue_positive_indexPlainFieldFalse() {
+    var actual = SearchUtils.getStandardFulltextValue("key", "value", false);
+    assertThat(actual).isEqualTo(singletonMap("key", "value"));
+  }
+
+  @Test
+  void getStandardFulltextValue_positive_indexPlainFieldTrue() {
+    var actual = SearchUtils.getStandardFulltextValue("key", "value", true);
+    assertThat(actual).isEqualTo(mapOf("key", "value", "plain_key", "value"));
+  }
+
+  @Test
+  void getPlainFieldValue_positive_multilangField() {
+    var actual = SearchUtils.getPlainFieldValue(multilangField(), "key", "v", List.of("eng"));
+    assertThat(actual).isEqualTo(mapOf("key", mapOf("eng", "v", "src", "v"), "plain_key", "v"));
+  }
+
+  @Test
+  void getPlainFieldValue_positive_standardFulltextField() {
+    var description = plainField(STANDARD_FIELD_TYPE);
+    var actual = SearchUtils.getPlainFieldValue(description, "key", "v", List.of("eng"));
+    assertThat(actual).isEqualTo(mapOf("key", "v", "plain_key", "v"));
+  }
+
+  @Test
+  void getPlainFieldValue_positive_standardFulltextField_doNotIndexPlainValue() {
+    var description = plainField(STANDARD_FIELD_TYPE);
+    description.setIndexPlainValue(false);
+    var actual = SearchUtils.getPlainFieldValue(description, "key", "v", List.of("eng"));
+    assertThat(actual).isEqualTo(singletonMap("key", "v"));
+  }
+
+  @Test
+  void getPlainFieldValue_positive_keywordFulltextField() {
+    var actual = SearchUtils.getPlainFieldValue(keywordField(), "key", "v", List.of("eng"));
+    assertThat(actual).isEqualTo(singletonMap("key", "v"));
   }
 }

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -3,8 +3,10 @@ package org.folio.search.utils;
 import static java.lang.System.clearProperty;
 import static java.lang.System.setProperty;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toCollection;
 import static org.folio.search.model.metadata.PlainFieldDescription.MULTILANG_FIELD_TYPE;
+import static org.folio.search.model.metadata.PlainFieldDescription.STANDARD_FIELD_TYPE;
 import static org.folio.search.model.types.FieldType.PLAIN;
 import static org.folio.search.model.types.FieldType.SEARCH;
 import static org.folio.search.model.types.IndexActionType.DELETE;
@@ -61,6 +63,8 @@ public class TestUtils {
     .setSerializationInclusion(Include.NON_NULL)
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+
+  public static final String KEYWORD_FIELD_TYPE = "keyword";
 
   @SneakyThrows
   public static String asJsonString(Object value) {
@@ -176,33 +180,25 @@ public class TestUtils {
   }
 
   public static PlainFieldDescription plainField(String index) {
-    var fieldDescription = new PlainFieldDescription();
-    fieldDescription.setType(PLAIN);
-    fieldDescription.setIndex(index);
-    return fieldDescription;
+    return plainField(PLAIN, index, emptyList());
   }
 
   public static PlainFieldDescription plainField(String index, ObjectNode mappings) {
-    var fieldDescription = new PlainFieldDescription();
-    fieldDescription.setType(PLAIN);
-    fieldDescription.setIndex(index);
+    var fieldDescription = plainField(PLAIN, index, emptyList());
     fieldDescription.setMappings(mappings);
     return fieldDescription;
   }
 
-  public static PlainFieldDescription keywordField() {
+  public static PlainFieldDescription plainField(FieldType type, String index, List<SearchType> searchTypes) {
     var fieldDescription = new PlainFieldDescription();
-    fieldDescription.setType(PLAIN);
-    fieldDescription.setIndex("keyword");
+    fieldDescription.setType(type);
+    fieldDescription.setIndex(index);
+    fieldDescription.setSearchTypes(searchTypes);
     return fieldDescription;
   }
 
   public static PlainFieldDescription keywordField(SearchType... searchTypes) {
-    var fieldDescription = new PlainFieldDescription();
-    fieldDescription.setType(PLAIN);
-    fieldDescription.setIndex("keyword");
-    fieldDescription.setSearchTypes(asList(searchTypes));
-    return fieldDescription;
+    return plainField(PLAIN, KEYWORD_FIELD_TYPE, asList(searchTypes));
   }
 
   public static PlainFieldDescription keywordFieldWithDefaultValue(Object defaultValue) {
@@ -212,16 +208,15 @@ public class TestUtils {
   }
 
   public static PlainFieldDescription filterField() {
-    var fieldDescription = keywordField();
-    fieldDescription.setSearchTypes(List.of(SearchType.FILTER));
-    return fieldDescription;
+    return plainField(PLAIN, KEYWORD_FIELD_TYPE, List.of(SearchType.FILTER));
   }
 
   public static PlainFieldDescription multilangField() {
-    var fieldDescription = new PlainFieldDescription();
-    fieldDescription.setType(PLAIN);
-    fieldDescription.setIndex(MULTILANG_FIELD_TYPE);
-    return fieldDescription;
+    return plainField(PLAIN, MULTILANG_FIELD_TYPE, emptyList());
+  }
+
+  public static PlainFieldDescription standardFulltextField() {
+    return plainField(PLAIN, STANDARD_FIELD_TYPE, emptyList());
   }
 
   public static ObjectFieldDescription objectField(Map<String, FieldDescription> props) {


### PR DESCRIPTION
### Purpose
While searching contributors =="carols" the search returns records with contributors Carole and Carol

### Acceptance criteria:
* in searches for `contributors == "<name>s"` is not treated as a plural form but as part of the name

### Approach

The main change is adding support for fields with index = `standard` as full-text fields. They will be recognized by the CQL query converter and the same rules as for the multilanguage fields will be applied.

Integration and unit tests are added to prove of added functionality