### PR TITLE
MSEARCH-132 Apply new topic naming convention

### DIFF
--- a/src/main/java/org/folio/search/configuration/KafkaConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/KafkaConfiguration.java
@@ -12,7 +12,6 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.folio.search.configuration.properties.FolioKafkaProperties;
 import org.folio.search.domain.dto.ResourceEventBody;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
@@ -30,7 +29,6 @@ import org.springframework.util.backoff.FixedBackOff;
 @Log4j2
 @Configuration
 @RequiredArgsConstructor
-@EnableConfigurationProperties({FolioKafkaProperties.class})
 public class KafkaConfiguration {
 
   private final KafkaProperties kafkaProperties;
@@ -52,9 +50,8 @@ public class KafkaConfiguration {
   }
 
   /**
-   * Constructs a batch handler that tries to deliver messages 10 times with
-   * configured interval, if exception is not resolved than messages will be redelivered
-   * by next poll() call.
+   * Constructs a batch handler that tries to deliver messages 10 times with configured interval, if exception is not
+   * resolved than messages will be redelivered by next poll() call.
    */
   private BatchErrorHandler kafkaFactoryErrorHandler() {
     return new RecoveringBatchErrorHandler(new FixedBackOff(

--- a/src/main/java/org/folio/search/configuration/properties/FolioKafkaProperties.java
+++ b/src/main/java/org/folio/search/configuration/properties/FolioKafkaProperties.java
@@ -3,11 +3,13 @@ package org.folio.search.configuration.properties;
 import java.util.Map;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
 
 /**
  * Application properties for kafka message consumer.
  */
 @Data
+@Component
 @ConfigurationProperties("application.kafka")
 public class FolioKafkaProperties {
 
@@ -27,6 +29,16 @@ public class FolioKafkaProperties {
   private long retryDeliveryAttempts;
 
   /**
+   * List of default topics to maintain backward compatibility.
+   */
+  private String topicsRegexp;
+
+  /**
+   * Default group id for message listener.
+   */
+  private String defaultGroupId;
+
+  /**
    * Contains set of settings for specific kafka listener.
    */
   @Data
@@ -35,12 +47,12 @@ public class FolioKafkaProperties {
     /**
      * List of topic to listen.
      */
-    private String topics;
+    private String topicPattern;
 
     /**
      * Number of concurrent consumers in service.
      */
-    private String concurrency;
+    private Integer concurrency = 5;
 
     /**
      * The group id.

--- a/src/main/java/org/folio/search/configuration/properties/FolioKafkaProperties.java
+++ b/src/main/java/org/folio/search/configuration/properties/FolioKafkaProperties.java
@@ -29,16 +29,6 @@ public class FolioKafkaProperties {
   private long retryDeliveryAttempts;
 
   /**
-   * List of default topics to maintain backward compatibility.
-   */
-  private String topicsRegexp;
-
-  /**
-   * Default group id for message listener.
-   */
-  private String defaultGroupId;
-
-  /**
    * Contains set of settings for specific kafka listener.
    */
   @Data

--- a/src/main/java/org/folio/search/controller/FolioTenantController.java
+++ b/src/main/java/org/folio/search/controller/FolioTenantController.java
@@ -30,6 +30,8 @@ public class FolioTenantController extends TenantController {
   @Override
   public ResponseEntity<String> postTenant(TenantAttributes tenantAttributes) {
     kafkaAdminService.createKafkaTopics();
+    kafkaAdminService.restartEventListeners();
+
     var tenantInit = super.postTenant(tenantAttributes);
 
     if (tenantInit.getStatusCode() == HttpStatus.OK) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,8 +43,8 @@ application:
     retry-delivery-attempts: 10
     listener:
       events:
-        concurrency: 1
-        topics: inventory.instance,inventory.item,inventory.holdings-record
+        concurrency: 2
+        topic-pattern: (${ENV:folio}\.)?(.*\.)?inventory.(instance|holdings-record|item)
         group-id: ${ENV:folio}-mod-search-events-group
 
 server.port: 8081

--- a/src/test/java/org/folio/search/configuration/FolioKafkaPropertiesTest.java
+++ b/src/test/java/org/folio/search/configuration/FolioKafkaPropertiesTest.java
@@ -14,8 +14,8 @@ class FolioKafkaPropertiesTest {
   @Test
   void constructorTest() {
     var kafkaListenerProperties = new KafkaListenerProperties();
-    kafkaListenerProperties.setConcurrency("1");
-    kafkaListenerProperties.setTopics("test-topic");
+    kafkaListenerProperties.setConcurrency(5);
+    kafkaListenerProperties.setTopicPattern("test-topic");
     kafkaListenerProperties.setGroupId("test-group");
 
     var folioKafkaProperties = new FolioKafkaProperties();

--- a/src/test/java/org/folio/search/controller/FolioTenantControllerTest.java
+++ b/src/test/java/org/folio/search/controller/FolioTenantControllerTest.java
@@ -32,6 +32,8 @@ class FolioTenantControllerTest {
     tenantController.postTenant(TENANT_ATTRIBUTES);
 
     verify(tenantService).initializeTenant();
+    verify(kafkaAdminService).createKafkaTopics();
+    verify(kafkaAdminService).restartEventListeners();
   }
 
   @Test

--- a/src/test/java/org/folio/search/service/KafkaAdminServiceTest.java
+++ b/src/test/java/org/folio/search/service/KafkaAdminServiceTest.java
@@ -1,46 +1,113 @@
 package org.folio.search.service;
 
-import static org.mockito.Mockito.doReturn;
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.service.KafkaAdminService.EVENT_LISTENER_ID;
+import static org.folio.search.utils.TestConstants.ENV;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.folio.search.service.KafkaAdminService.KafkaTopic;
 import org.folio.search.service.KafkaAdminService.KafkaTopics;
+import org.folio.search.service.KafkaAdminServiceTest.KafkaAdminServiceTestConfiguration;
+import org.folio.search.utils.TestUtils;
 import org.folio.search.utils.types.UnitTest;
+import org.folio.spring.DefaultFolioExecutionContext;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.listener.MessageListenerContainer;
 
 @UnitTest
-@ExtendWith(MockitoExtension.class)
+@Import(KafkaAdminServiceTestConfiguration.class)
+@SpringBootTest(classes = KafkaAdminService.class)
 class KafkaAdminServiceTest {
 
-  @InjectMocks private KafkaAdminService kafkaAdminService;
-  @Mock private ConfigurableBeanFactory beanFactory;
-  @Mock private LocalFileProvider localFileProvider;
-  @Mock private KafkaAdmin kafkaAdmin;
+  private final List<KafkaTopic> expectedTopics = List.of(
+    KafkaTopic.of("topic1", 20, (short) 1),
+    KafkaTopic.of("topic2", 50, (short) 3),
+    KafkaTopic.of("topic3", 40, (short) 2),
+    KafkaTopic.of("test.test_tenant.topic1", 20, (short) 1),
+    KafkaTopic.of("test.test_tenant.topic2", 50, (short) 3),
+    KafkaTopic.of("test.test_tenant.topic3", 40, (short) 2));
+
+  private final List<KafkaTopic> initialKafkaTopics = List.of(
+    expectedTopics.get(0), expectedTopics.get(1), expectedTopics.get(2));
+
+  @Autowired private KafkaAdminService kafkaAdminService;
+  @Autowired private ApplicationContext applicationContext;
+  @MockBean private KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
+  @MockBean private LocalFileProvider localFileProvider;
+  @MockBean private KafkaAdmin kafkaAdmin;
+
+  @BeforeAll
+  static void beforeAll() {
+    TestUtils.setEnvProperty(ENV);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    TestUtils.removeEnvProperty();
+  }
 
   @Test
   void createKafkaTopics() {
-    var topic1 = KafkaTopic.of("topic1", 20, (short) 1);
-    var topic2 = KafkaTopic.of("topic2", 50, (short) 1);
-    var topic3 = KafkaTopic.of("topic3", 40, (short) 1);
-    var kafkaTopics = KafkaTopics.of(List.of(topic1, topic2, topic3));
-
-    when(localFileProvider.readAsObject("kafka/kafka-topics.json", KafkaTopics.class)).thenReturn(kafkaTopics);
-    doReturn(true).when(beanFactory).containsBean("topic1.topic");
-    doReturn(false).when(beanFactory).containsBean("topic2.topic");
-    doReturn(false).when(beanFactory).containsBean("topic3.topic");
-
+    when(localFileProvider.readAsObject("kafka/kafka-topics.json", KafkaTopics.class))
+      .thenReturn(KafkaTopics.of(initialKafkaTopics));
     kafkaAdminService.createKafkaTopics();
 
-    verify(beanFactory).registerSingleton("topic2.topic", topic2.toKafkaTopic());
-    verify(beanFactory).registerSingleton("topic3.topic", topic3.toKafkaTopic());
     verify(kafkaAdmin).initialize();
+
+    var beansOfType = applicationContext.getBeansOfType(NewTopic.class);
+    var expectedNewTopics = expectedTopics.stream().map(KafkaTopic::toKafkaTopic).collect(toSet());
+    assertThat(beansOfType.values()).containsExactlyInAnyOrderElementsOf(expectedNewTopics);
+  }
+
+  @Test
+  void getTenantKafkaTopics() {
+    when(localFileProvider.readAsObject("kafka/kafka-topics.json", KafkaTopics.class))
+      .thenReturn(KafkaTopics.of(initialKafkaTopics));
+    var tenantKafkaTopics = kafkaAdminService.getDefaultTenantKafkaTopics();
+    assertThat(tenantKafkaTopics).isEqualTo(List.of(
+      "test.test_tenant.topic1", "test.test_tenant.topic2", "test.test_tenant.topic3"));
+  }
+
+  @Test
+  void restartEventListeners() {
+    var mockListenerContainer = mock(MessageListenerContainer.class);
+    when(kafkaListenerEndpointRegistry.getListenerContainer(EVENT_LISTENER_ID)).thenReturn(mockListenerContainer);
+    kafkaAdminService.restartEventListeners();
+    verify(mockListenerContainer).start();
+    verify(mockListenerContainer).stop();
+  }
+
+  @TestConfiguration
+  static class KafkaAdminServiceTestConfiguration {
+
+    @Bean(name = "topic1.topic")
+    NewTopic firstTopic() {
+      return new NewTopic("topic1", 20, (short) 1);
+    }
+
+    @Bean
+    FolioExecutionContext folioExecutionContext() {
+      return new DefaultFolioExecutionContext(null, Map.of(XOkapiHeaders.TENANT, List.of(TENANT_ID)));
+    }
   }
 }

--- a/src/test/java/org/folio/search/support/api/InventoryApi.java
+++ b/src/test/java/org/folio/search/support/api/InventoryApi.java
@@ -3,9 +3,9 @@ package org.folio.search.support.api;
 import static java.util.Collections.emptyMap;
 import static org.folio.search.domain.dto.ResourceEventBody.TypeEnum.DELETE;
 import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
-import static org.folio.search.utils.TestConstants.INVENTORY_HOLDING_TOPIC;
-import static org.folio.search.utils.TestConstants.INVENTORY_INSTANCE_TOPIC;
-import static org.folio.search.utils.TestConstants.INVENTORY_ITEM_TOPIC;
+import static org.folio.search.utils.TestConstants.getInventoryHoldingTopic;
+import static org.folio.search.utils.TestConstants.getInventoryInstanceTopic;
+import static org.folio.search.utils.TestConstants.getInventoryItemTopic;
 import static org.folio.search.utils.TestUtils.eventBody;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
@@ -35,7 +35,7 @@ public class InventoryApi {
     INSTANCE_STORE.computeIfAbsent(tenantName, k -> new HashMap<>())
       .put(instance.getId(), instance);
 
-    kafkaTemplate.send(INVENTORY_INSTANCE_TOPIC, instance.getId(),
+    kafkaTemplate.send(getInventoryInstanceTopic(tenantName), instance.getId(),
       eventBody(INSTANCE_RESOURCE, instance).tenant(tenantName));
 
     if (instance.getHoldings() != null) {
@@ -56,7 +56,7 @@ public class InventoryApi {
     HOLDING_STORE.computeIfAbsent(tenant, k -> new HashMap<>())
       .put(holding.getId(), event);
 
-    kafkaTemplate.send(INVENTORY_HOLDING_TOPIC, instanceId,
+    kafkaTemplate.send(getInventoryHoldingTopic(tenant), instanceId,
       eventBody(INSTANCE_RESOURCE, event).tenant(tenant));
   }
 
@@ -65,28 +65,28 @@ public class InventoryApi {
     ITEM_STORE.computeIfAbsent(tenant, k -> new HashMap<>())
       .put(item.getId(), event);
 
-    kafkaTemplate.send(INVENTORY_ITEM_TOPIC, instanceId,
+    kafkaTemplate.send(getInventoryItemTopic(tenant), instanceId,
       eventBody(INSTANCE_RESOURCE, event).tenant(tenant));
   }
 
   public void deleteItem(String tenant, String id) {
     var item = ITEM_STORE.get(tenant).remove(id);
 
-    kafkaTemplate.send(INVENTORY_ITEM_TOPIC, item.getInstanceId(),
+    kafkaTemplate.send(getInventoryItemTopic(tenant), item.getInstanceId(),
       eventBody(INSTANCE_RESOURCE, null).old(item).tenant(tenant).type(DELETE));
   }
 
   public void deleteHolding(String tenant, String id) {
     var hr = HOLDING_STORE.get(tenant).remove(id);
 
-    kafkaTemplate.send(INVENTORY_HOLDING_TOPIC, hr.getInstanceId(),
+    kafkaTemplate.send(getInventoryHoldingTopic(tenant), hr.getInstanceId(),
       eventBody(INSTANCE_RESOURCE, null).old(hr).tenant(tenant).type(DELETE));
   }
 
   public void deleteInstance(String tenant, String id) {
     var instance = INSTANCE_STORE.get(tenant).remove(id);
 
-    kafkaTemplate.send(INVENTORY_INSTANCE_TOPIC, instance.getId(),
+    kafkaTemplate.send(getInventoryInstanceTopic(tenant), instance.getId(),
       eventBody(INSTANCE_RESOURCE, null).old(instance).tenant(tenant).type(DELETE));
   }
 

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -56,7 +56,6 @@ public abstract class BaseIntegrationTest {
   @BeforeAll
   static void setUpDefaultTenant(@Autowired MockMvc mockMvc,
     @Autowired KafkaTemplate<String, Object> kafkaTemplate) {
-
     inventoryApi = new InventoryApi(kafkaTemplate);
     setUpTenant(TENANT_ID, mockMvc, getSemanticWeb());
   }

--- a/src/test/java/org/folio/search/utils/TestConstants.java
+++ b/src/test/java/org/folio/search/utils/TestConstants.java
@@ -1,5 +1,6 @@
 package org.folio.search.utils;
 
+import static org.folio.search.configuration.properties.FolioEnvironment.getFolioEnvName;
 import static org.folio.search.utils.TestUtils.randomId;
 
 import lombok.AccessLevel;
@@ -10,6 +11,7 @@ public class TestConstants {
 
   public static final String EMPTY_OBJECT = "{}";
   public static final String RESOURCE_ID = "test_tenant";
+  public static final String ENV = "test";
   public static final String TENANT_ID = "test_tenant";
   public static final String RESOURCE_NAME = "test-resource";
   public static final String INDEX_NAME = "folio_" + RESOURCE_NAME + "_" + TENANT_ID;
@@ -20,4 +22,20 @@ public class TestConstants {
   public static final String INVALID_ISBN_IDENTIFIER_TYPE_ID = randomId();
   public static final String ISSN_IDENTIFIER_TYPE_ID = randomId();
   public static final String INVALID_ISSN_IDENTIFIER_TYPE_ID = randomId();
+
+  public static String getInventoryInstanceTopic(String tenantId) {
+    return getTopicName(tenantId, INVENTORY_INSTANCE_TOPIC);
+  }
+
+  public static String getInventoryItemTopic(String tenantId) {
+    return getTopicName(tenantId, INVENTORY_ITEM_TOPIC);
+  }
+
+  public static String getInventoryHoldingTopic(String tenantId) {
+    return getTopicName(tenantId, INVENTORY_HOLDING_TOPIC);
+  }
+
+  private static String getTopicName(String tenantId, String topic) {
+    return String.format("%s.%s.%s", getFolioEnvName(), tenantId, topic);
+  }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -33,6 +33,6 @@ application:
   kafka:
     listener:
       events:
-        concurrency: 1
-        topics: inventory.instance,inventory.item,inventory.holdings-record
+        concurrency: 2
+        topic-pattern: (${ENV:folio}\.)?(.*\.)?inventory.(instance|holdings-record|item)
         group-id: ${ENV:folio}-mod-search-events-group


### PR DESCRIPTION
### Purpose

Many modules that use Kafka use ENV variable and tenant id in their naming convention for topics.

For example topics in Bugfest have names that include ENV (ibf3) in addition to tenant id (fs09000000) - such as the following topic example

`ibf3.Default.fs09000000.DI_COMPLETED`

It would be helpful if ENV and tenant id settings were used in the topic naming convention. This would allow a Kafka instance to be shared by multiple environments that have the same tenant id.

https://github.com/folio-org/mod-search/blob/master/src/main/resources/kafka/kafka-topics.json

Required topic pattern - `{env}.{tenant}.{topicname}`

### Approach

A new approach listens to the topics patterns instead of a list of provided topics. This will allow to mod-search receive messages from topics starting from the `ENV` variable and following any tenant name. A batch request to Elasticsearch will be formed for all tenants, but data will be separate at different indices.