### PR TITLE
MSEARCH-136 Adjust sorting by title to use indexTitle if possible

### DIFF
--- a/src/main/java/org/folio/search/service/setter/instance/SortTitleProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/SortTitleProcessor.java
@@ -1,0 +1,20 @@
+package org.folio.search.service.setter.instance;
+
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.service.setter.FieldProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public final class SortTitleProcessor implements FieldProcessor<Instance, String> {
+
+  @Override
+  public String getFieldValue(Instance instance) {
+    var indexTitle = instance.getIndexTitle();
+    return isNotBlank(indexTitle) ? indexTitle : defaultIfBlank(instance.getTitle(), null);
+  }
+}

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -25,10 +25,7 @@
       "searchTypes": "sort",
       "inventorySearchTypes": [ "title", "keyword" ],
       "index": "multilang",
-      "showInResponse": true,
-      "mappings": {
-        "copy_to": [ "sort_title" ]
-      }
+      "showInResponse": true
     },
     "alternativeTitles": {
       "type": "object",
@@ -324,6 +321,12 @@
     }
   },
   "searchFields": {
+    "sort_title": {
+      "searchTypes": "sort",
+      "type": "search",
+      "index": "lowercase_sort",
+      "processor": "sortTitleProcessor"
+    },
     "sort_contributors": {
       "searchTypes": "sort",
       "type": "search",
@@ -378,12 +381,5 @@
       "processor": "holdingsCallNumberComponentsProcessor"
     }
   },
-  "indexMappings": {
-    "sort_title": {
-      "type": "keyword",
-      "normalizer": "keyword_lowercase",
-      "index": false,
-      "doc_values": true
-    }
-  }
+  "indexMappings": {}
 }

--- a/src/test/java/org/folio/search/controller/SortInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SortInstanceIT.java
@@ -65,10 +65,10 @@ class SortInstanceIT extends BaseIntegrationTest {
       .headers(defaultHeaders(TENANT)))
       .andExpect(status().isOk())
       .andExpect(jsonPath("totalRecords", is(4)))
-      .andExpect(jsonPath("instances[0].title", is("Aaa")))
-      .andExpect(jsonPath("instances[1].title", is("Ccc")))
-      .andExpect(jsonPath("instances[2].title", is("www")))
-      .andExpect(jsonPath("instances[3].title", is("Zzz")));
+      .andExpect(jsonPath("instances[0].title", is("Calling Me Home")))
+      .andExpect(jsonPath("instances[1].title", is("Animal farm")))
+      .andExpect(jsonPath("instances[2].title", is("Walk in My Soul")))
+      .andExpect(jsonPath("instances[3].title", is("Zero Minus Ten")));
   }
 
   @Test
@@ -77,10 +77,10 @@ class SortInstanceIT extends BaseIntegrationTest {
       .headers(defaultHeaders(TENANT)))
       .andExpect(status().isOk())
       .andExpect(jsonPath("totalRecords", is(4)))
-      .andExpect(jsonPath("instances[0].title", is("Zzz")))
-      .andExpect(jsonPath("instances[1].title", is("www")))
-      .andExpect(jsonPath("instances[2].title", is("Ccc")))
-      .andExpect(jsonPath("instances[3].title", is("Aaa")));
+      .andExpect(jsonPath("instances[0].title", is("Zero Minus Ten")))
+      .andExpect(jsonPath("instances[1].title", is("Walk in My Soul")))
+      .andExpect(jsonPath("instances[2].title", is("Animal farm")))
+      .andExpect(jsonPath("instances[3].title", is("Calling Me Home")));
   }
 
   private static Instance[] createFourInstances() {
@@ -91,20 +91,24 @@ class SortInstanceIT extends BaseIntegrationTest {
       getSemanticWeb().id(randomId()).contributors(new ArrayList<>())};
 
     instances[0]
-      .title("Aaa")
+      .title("Animal farm")
+      .indexTitle("B1 Animal farm")
       .addContributorsItem(new InstanceContributors().name("yyy zzz"));
 
     instances[1]
-      .title("Zzz")
+      .title("Zero Minus Ten")
+      .indexTitle(null)
       .addContributorsItem(new InstanceContributors().name("aaa bbb").primary(false))
       .addContributorsItem(new InstanceContributors().name("bbb ccc").primary(true));
 
     instances[2]
-      .title("Ccc")
+      .title("Calling Me Home")
+      .indexTitle("A1 Calling Me Home")
       .addContributorsItem(new InstanceContributors().name("bcc ccc"));
 
     instances[3]
-      .title("www")
+      .title("Walk in My Soul")
+      .indexTitle(null)
       .addContributorsItem(new InstanceContributors().name("1111 2222").primary(true));
 
     return instances;

--- a/src/test/java/org/folio/search/service/setter/instance/SortTitleProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/instance/SortTitleProcessorTest.java
@@ -1,0 +1,41 @@
+package org.folio.search.service.setter.instance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@UnitTest
+class SortTitleProcessorTest {
+  private final SortTitleProcessor sortTitleProcessor = new SortTitleProcessor();
+
+  @MethodSource("instanceDataProvider")
+  @DisplayName("getFieldValue_parameterized")
+  @ParameterizedTest(name = "[{index}] instance with {0}, expected={2}")
+  void getFieldValue_parameterized(@SuppressWarnings("unused") String name, Instance eventBody, String expected) {
+    var actual = sortTitleProcessor.getFieldValue(eventBody);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> instanceDataProvider() {
+    var title = "test-title";
+    var indexTitle = "index-title";
+    return Stream.of(
+      arguments("title=null, indexTitle=null", instance(null, null), null),
+      arguments("title=emptyValue, indexTitle=null", instance("", null), null),
+      arguments("title=blankValue, indexTitle=null", instance("  ", null), null),
+      arguments("title='test-title', indexTitle=blankValue", instance(title, ""), title),
+      arguments("title='test-title', indexTitle=emptyValue", instance(title, "  "), title),
+      arguments("title='test-value', indexTitle='index-title'", instance(title, indexTitle), indexTitle));
+  }
+
+  private static Instance instance(String title, String indexTitle) {
+    return new Instance().title(title).indexTitle(indexTitle);
+  }
+}


### PR DESCRIPTION
### Purpose

The current implementation sorts by `instance.title` property but the preferred behavior is to sort by `instance.indexTitle`

### Requirements/Scope
The sorting by title should behave as follows:

- if `instance.indexTitle` is populated, it is used for sorting
- if `instance.indexTitle` is not populated, sort by `instance.title` field

### Approach

Implement new `SortTitleProcessor` which will chose one of titles - `indexTitle` or `title`. If `indexTitle` is blank, `title` will be analyzed and if it is not empty - it will be used for sorting. If `indexTitle` is not blank - it will be used for sorting.
Integration and unit tests are added to prove developed functionality.