### PR TITLE
MSEARCH-117 Support full text search for notes of linked holding-records

### DIFF
--- a/src/main/java/org/folio/search/service/setter/holding/HoldingPublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/holding/HoldingPublicNotesProcessor.java
@@ -1,0 +1,24 @@
+package org.folio.search.service.setter.holding;
+
+import static org.folio.search.utils.SearchUtils.toSafeStream;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+import org.apache.commons.collections.CollectionUtils;
+import org.folio.search.domain.dto.Holding;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Note;
+import org.folio.search.service.setter.instance.AbstractPublicNotesProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HoldingPublicNotesProcessor extends AbstractPublicNotesProcessor {
+
+  @Override
+  protected Stream<Note> getNotes(Instance instance) {
+    return toSafeStream(instance.getHoldings())
+      .map(Holding::getNotes)
+      .filter(CollectionUtils::isNotEmpty)
+      .flatMap(Collection::stream);
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/holding/HoldingPublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/holding/HoldingPublicNotesProcessor.java
@@ -1,6 +1,6 @@
 package org.folio.search.service.setter.holding;
 
-import static org.folio.search.utils.SearchUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toSafeStream;
 
 import java.util.Collection;
 import java.util.stream.Stream;

--- a/src/main/java/org/folio/search/service/setter/holding/HoldingPublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/holding/HoldingPublicNotesProcessor.java
@@ -1,6 +1,6 @@
 package org.folio.search.service.setter.holding;
 
-import static org.folio.search.utils.CollectionUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 
 import java.util.Collection;
 import java.util.stream.Stream;
@@ -16,7 +16,7 @@ public class HoldingPublicNotesProcessor extends AbstractPublicNotesProcessor {
 
   @Override
   protected Stream<Note> getNotes(Instance instance) {
-    return toSafeStream(instance.getHoldings())
+    return toStreamSafe(instance.getHoldings())
       .map(Holding::getNotes)
       .filter(CollectionUtils::isNotEmpty)
       .flatMap(Collection::stream);

--- a/src/main/java/org/folio/search/service/setter/holding/HoldingTagsProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/holding/HoldingTagsProcessor.java
@@ -1,6 +1,6 @@
 package org.folio.search.service.setter.holding;
 
-import static org.folio.search.utils.SearchUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toSafeStream;
 
 import java.util.stream.Stream;
 import org.folio.search.domain.dto.Holding;

--- a/src/main/java/org/folio/search/service/setter/holding/HoldingTagsProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/holding/HoldingTagsProcessor.java
@@ -1,6 +1,6 @@
 package org.folio.search.service.setter.holding;
 
-import static org.folio.search.utils.CollectionUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 
 import java.util.stream.Stream;
 import org.folio.search.domain.dto.Holding;
@@ -14,6 +14,6 @@ public class HoldingTagsProcessor extends AbstractTagsProcessor {
 
   @Override
   protected Stream<Tags> getTags(Instance instance) {
-    return toSafeStream(instance.getHoldings()).map(Holding::getTags);
+    return toStreamSafe(instance.getHoldings()).map(Holding::getTags);
   }
 }

--- a/src/main/java/org/folio/search/service/setter/holding/HoldingsCallNumberComponentsProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/holding/HoldingsCallNumberComponentsProcessor.java
@@ -1,18 +1,16 @@
 package org.folio.search.service.setter.holding;
 
 import static java.util.stream.Collectors.toSet;
+import static org.folio.search.utils.CollectionUtils.toSafeStream;
 import static org.folio.search.utils.SearchUtils.getEffectiveCallNumber;
-import static org.folio.search.utils.SearchUtils.toSafeStream;
 
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.service.setter.FieldProcessor;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class HoldingsCallNumberComponentsProcessor implements FieldProcessor<Instance, Set<String>> {
 
   @Override

--- a/src/main/java/org/folio/search/service/setter/holding/HoldingsCallNumberComponentsProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/holding/HoldingsCallNumberComponentsProcessor.java
@@ -1,7 +1,7 @@
 package org.folio.search.service.setter.holding;
 
 import static java.util.stream.Collectors.toSet;
-import static org.folio.search.utils.CollectionUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 import static org.folio.search.utils.SearchUtils.getEffectiveCallNumber;
 
 import java.util.Set;
@@ -15,7 +15,7 @@ public class HoldingsCallNumberComponentsProcessor implements FieldProcessor<Ins
 
   @Override
   public Set<String> getFieldValue(Instance instance) {
-    return toSafeStream(instance.getHoldings())
+    return toStreamSafe(instance.getHoldings())
       .map(hr -> getEffectiveCallNumber(hr.getCallNumberPrefix(), hr.getCallNumber(), hr.getCallNumberSuffix()))
       .filter(StringUtils::isNotBlank)
       .collect(toSet());

--- a/src/main/java/org/folio/search/service/setter/instance/AbstractIdentifierProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/AbstractIdentifierProcessor.java
@@ -1,7 +1,7 @@
 package org.folio.search.service.setter.instance;
 
 import static java.util.stream.Collectors.toList;
-import static org.folio.search.utils.SearchUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toSafeStream;
 
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/org/folio/search/service/setter/instance/AbstractIdentifierProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/AbstractIdentifierProcessor.java
@@ -1,7 +1,7 @@
 package org.folio.search.service.setter.instance;
 
 import static java.util.stream.Collectors.toList;
-import static org.folio.search.utils.CollectionUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 
 import java.util.List;
 import java.util.Set;
@@ -24,7 +24,7 @@ public abstract class AbstractIdentifierProcessor implements FieldProcessor<Inst
    */
   protected List<InstanceIdentifiers> getInstanceIdentifiers(Instance instance) {
     var identifierTypeIds = identifierTypeCache.fetchIdentifierIds(getIdentifierNames());
-    return toSafeStream(instance.getIdentifiers())
+    return toStreamSafe(instance.getIdentifiers())
       .filter(identifier -> identifierTypeIds.contains(identifier.getIdentifierTypeId()))
       .collect(toList());
   }

--- a/src/main/java/org/folio/search/service/setter/instance/AbstractPublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/AbstractPublicNotesProcessor.java
@@ -1,0 +1,32 @@
+package org.folio.search.service.setter.instance;
+
+import static java.util.stream.Collectors.toCollection;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Note;
+import org.folio.search.service.setter.FieldProcessor;
+
+public abstract class AbstractPublicNotesProcessor implements FieldProcessor<Instance, Set<String>> {
+
+  @Override
+  public Set<String> getFieldValue(Instance instance) {
+    return getNotes(instance)
+      .filter(Objects::nonNull)
+      .filter(note -> note.getStaffOnly() == null || !note.getStaffOnly())
+      .map(Note::getNote)
+      .filter(Objects::nonNull)
+      .collect(toCollection(LinkedHashSet::new));
+  }
+
+  /**
+   * Returns {@link Stream} with {@link Note} objects from instance/holding/item.
+   *
+   * @param instance instance object to analyze
+   * @return {@link Stream} with {@link Note} object
+   */
+  protected abstract Stream<Note> getNotes(Instance instance);
+}

--- a/src/main/java/org/folio/search/service/setter/instance/PublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/PublicNotesProcessor.java
@@ -1,6 +1,6 @@
 package org.folio.search.service.setter.instance;
 
-import static org.folio.search.utils.CollectionUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 
 import java.util.stream.Stream;
 import org.folio.search.domain.dto.Instance;
@@ -12,6 +12,6 @@ public class PublicNotesProcessor extends AbstractPublicNotesProcessor {
 
   @Override
   protected Stream<Note> getNotes(Instance instance) {
-    return toSafeStream(instance.getNotes());
+    return toStreamSafe(instance.getNotes());
   }
 }

--- a/src/main/java/org/folio/search/service/setter/instance/PublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/PublicNotesProcessor.java
@@ -1,28 +1,17 @@
 package org.folio.search.service.setter.instance;
 
-import static java.util.stream.Collectors.toCollection;
 import static org.folio.search.utils.SearchUtils.toSafeStream;
 
-import java.util.LinkedHashSet;
-import java.util.Objects;
-import java.util.Set;
-import lombok.RequiredArgsConstructor;
+import java.util.stream.Stream;
 import org.folio.search.domain.dto.Instance;
-import org.folio.search.domain.dto.InstanceNotes;
-import org.folio.search.service.setter.FieldProcessor;
+import org.folio.search.domain.dto.Note;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
-public class PublicNotesProcessor implements FieldProcessor<Instance, Set<String>> {
+public class PublicNotesProcessor extends AbstractPublicNotesProcessor {
 
   @Override
-  public Set<String> getFieldValue(Instance instance) {
-    return toSafeStream(instance.getNotes())
-      .filter(Objects::nonNull)
-      .filter(note -> note.getStaffOnly() == null || !note.getStaffOnly())
-      .map(InstanceNotes::getNote)
-      .filter(Objects::nonNull)
-      .collect(toCollection(LinkedHashSet::new));
+  protected Stream<Note> getNotes(Instance instance) {
+    return toSafeStream(instance.getNotes());
   }
 }

--- a/src/main/java/org/folio/search/service/setter/instance/PublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/PublicNotesProcessor.java
@@ -1,6 +1,6 @@
 package org.folio.search.service.setter.instance;
 
-import static org.folio.search.utils.SearchUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toSafeStream;
 
 import java.util.stream.Stream;
 import org.folio.search.domain.dto.Instance;

--- a/src/main/java/org/folio/search/service/setter/item/EffectiveCallNumberComponentsProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/EffectiveCallNumberComponentsProcessor.java
@@ -1,8 +1,8 @@
 package org.folio.search.service.setter.item;
 
 import static java.util.stream.Collectors.toSet;
+import static org.folio.search.utils.CollectionUtils.toSafeStream;
 import static org.folio.search.utils.SearchUtils.getEffectiveCallNumber;
-import static org.folio.search.utils.SearchUtils.toSafeStream;
 
 import java.util.Objects;
 import java.util.Set;

--- a/src/main/java/org/folio/search/service/setter/item/EffectiveCallNumberComponentsProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/EffectiveCallNumberComponentsProcessor.java
@@ -1,7 +1,7 @@
 package org.folio.search.service.setter.item;
 
 import static java.util.stream.Collectors.toSet;
-import static org.folio.search.utils.CollectionUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 import static org.folio.search.utils.SearchUtils.getEffectiveCallNumber;
 
 import java.util.Objects;
@@ -17,7 +17,7 @@ public class EffectiveCallNumberComponentsProcessor implements FieldProcessor<In
 
   @Override
   public Set<String> getFieldValue(Instance instance) {
-    return toSafeStream(instance.getItems())
+    return toStreamSafe(instance.getItems())
       .map(Item::getEffectiveCallNumberComponents)
       .filter(Objects::nonNull)
       .map(cn -> getEffectiveCallNumber(cn.getPrefix(), cn.getCallNumber(), cn.getSuffix()))

--- a/src/main/java/org/folio/search/service/setter/item/ItemPublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemPublicNotesProcessor.java
@@ -1,0 +1,24 @@
+package org.folio.search.service.setter.item;
+
+import static org.folio.search.utils.SearchUtils.toSafeStream;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+import org.apache.commons.collections.CollectionUtils;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Item;
+import org.folio.search.domain.dto.Note;
+import org.folio.search.service.setter.instance.AbstractPublicNotesProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ItemPublicNotesProcessor extends AbstractPublicNotesProcessor {
+
+  @Override
+  protected Stream<Note> getNotes(Instance instance) {
+    return toSafeStream(instance.getItems())
+      .map(Item::getNotes)
+      .filter(CollectionUtils::isNotEmpty)
+      .flatMap(Collection::stream);
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/item/ItemPublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemPublicNotesProcessor.java
@@ -1,6 +1,6 @@
 package org.folio.search.service.setter.item;
 
-import static org.folio.search.utils.SearchUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toSafeStream;
 
 import java.util.Collection;
 import java.util.stream.Stream;

--- a/src/main/java/org/folio/search/service/setter/item/ItemPublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemPublicNotesProcessor.java
@@ -1,6 +1,6 @@
 package org.folio.search.service.setter.item;
 
-import static org.folio.search.utils.CollectionUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 
 import java.util.Collection;
 import java.util.stream.Stream;
@@ -16,7 +16,7 @@ public class ItemPublicNotesProcessor extends AbstractPublicNotesProcessor {
 
   @Override
   protected Stream<Note> getNotes(Instance instance) {
-    return toSafeStream(instance.getItems())
+    return toStreamSafe(instance.getItems())
       .map(Item::getNotes)
       .filter(CollectionUtils::isNotEmpty)
       .flatMap(Collection::stream);

--- a/src/main/java/org/folio/search/service/setter/item/ItemTagsProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemTagsProcessor.java
@@ -1,6 +1,6 @@
 package org.folio.search.service.setter.item;
 
-import static org.folio.search.utils.CollectionUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 
 import java.util.stream.Stream;
 import org.folio.search.domain.dto.Instance;
@@ -14,6 +14,6 @@ public class ItemTagsProcessor extends AbstractTagsProcessor {
 
   @Override
   protected Stream<Tags> getTags(Instance instance) {
-    return toSafeStream(instance.getItems()).map(Item::getTags);
+    return toStreamSafe(instance.getItems()).map(Item::getTags);
   }
 }

--- a/src/main/java/org/folio/search/service/setter/item/ItemTagsProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemTagsProcessor.java
@@ -1,6 +1,6 @@
 package org.folio.search.service.setter.item;
 
-import static org.folio.search.utils.SearchUtils.toSafeStream;
+import static org.folio.search.utils.CollectionUtils.toSafeStream;
 
 import java.util.stream.Stream;
 import org.folio.search.domain.dto.Instance;

--- a/src/main/java/org/folio/search/utils/CollectionUtils.java
+++ b/src/main/java/org/folio/search/utils/CollectionUtils.java
@@ -53,7 +53,7 @@ public final class CollectionUtils {
    * @param <T> generic type for value
    * @return nullableList if it is not null or empty, defaultList otherwise.
    */
-  public static <T> Stream<T> toSafeStream(List<T> nullableList) {
-    return org.apache.commons.collections.CollectionUtils.isNotEmpty(nullableList) ? nullableList.stream() : empty();
+  public static <T> Stream<T> toStreamSafe(List<T> nullableList) {
+    return (nullableList != null && !nullableList.isEmpty()) ? nullableList.stream() : empty();
   }
 }

--- a/src/main/java/org/folio/search/utils/CollectionUtils.java
+++ b/src/main/java/org/folio/search/utils/CollectionUtils.java
@@ -1,8 +1,11 @@
 package org.folio.search.utils;
 
+import static java.util.stream.Stream.empty;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.commons.collections4.MapUtils;
@@ -41,5 +44,16 @@ public final class CollectionUtils {
     }
     var startIndex = addToTop ? 0 : initial.size();
     initial.addAll(startIndex, sourceValues);
+  }
+
+  /**
+   * Returns nullableList if it is not null or empty, defaultList otherwise.
+   *
+   * @param nullableList nullable value to check
+   * @param <T> generic type for value
+   * @return nullableList if it is not null or empty, defaultList otherwise.
+   */
+  public static <T> Stream<T> toSafeStream(List<T> nullableList) {
+    return org.apache.commons.collections.CollectionUtils.isNotEmpty(nullableList) ? nullableList.stream() : empty();
   }
 }

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -12,7 +12,6 @@ import java.util.concurrent.Callable;
 import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.search.exception.SearchOperationException;
 import org.folio.search.model.ResourceRequest;
@@ -201,14 +200,4 @@ public class SearchUtils {
     return fulltextValue;
   }
 
-  /**
-   * Returns nullableList if it is not null or empty, defaultList otherwise.
-   *
-   * @param nullableList nullable value to check
-   * @param <T> generic type for value
-   * @return nullableList if it is not null or empty, defaultList otherwise.
-   */
-  public static <T> Stream<T> toSafeStream(List<T> nullableList) {
-    return CollectionUtils.isNotEmpty(nullableList) ? nullableList.stream() : Stream.empty();
-  }
 }

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -154,7 +154,7 @@
       "type": "object",
       "properties": {
         "note": {
-          "index": "source"
+          "index": "multilang"
         },
         "staffOnly": {
           "index": "bool"
@@ -269,6 +269,17 @@
               "index": "multilang"
             }
           }
+        },
+        "notes": {
+          "type": "object",
+          "properties": {
+            "note": {
+              "index": "multilang"
+            },
+            "staffOnly": {
+              "index": "bool"
+            }
+          }
         }
       }
     },
@@ -316,6 +327,17 @@
               "index": "multilang"
             }
           }
+        },
+        "notes": {
+          "type": "object",
+          "properties": {
+            "note": {
+              "index": "multilang"
+            },
+            "staffOnly": {
+              "index": "bool"
+            }
+          }
         }
       }
     }
@@ -337,6 +359,16 @@
       "type": "search",
       "index": "multilang",
       "processor": "publicNotesProcessor"
+    },
+    "itemPublicNotes": {
+      "type": "search",
+      "index": "multilang",
+      "processor": "itemPublicNotesProcessor"
+    },
+    "holdingPublicNotes": {
+      "type": "search",
+      "index": "multilang",
+      "processor": "holdingPublicNotesProcessor"
     },
     "isbn": {
       "type": "search",

--- a/src/main/resources/swagger.api/schemas/holding.json
+++ b/src/main/resources/swagger.api/schemas/holding.json
@@ -41,6 +41,13 @@
       "items": {
         "$ref": "electronicAccess.json"
       }
+    },
+    "notes": {
+      "type": "array",
+      "description": "Notes about action, copy, binding etc.",
+      "items": {
+        "$ref": "note.json"
+      }
     }
   }
 }

--- a/src/main/resources/swagger.api/schemas/instance.json
+++ b/src/main/resources/swagger.api/schemas/instance.json
@@ -170,18 +170,7 @@
       "type": "array",
       "description": "Bibliographic notes (e.g. general notes, specialized notes), and administrative notes",
       "items": {
-        "type": "object",
-        "properties": {
-          "note": {
-            "type": "string",
-            "description": "Text content of the note"
-          },
-          "staffOnly": {
-            "type": "boolean",
-            "description": "If true, determines that the note should not be visible for others than staff",
-            "default": false
-          }
-        }
+        "$ref": "note.json"
       }
     },
     "items": {

--- a/src/main/resources/swagger.api/schemas/item.json
+++ b/src/main/resources/swagger.api/schemas/item.json
@@ -65,6 +65,13 @@
       "items": {
         "$ref": "electronicAccess.json"
       }
+    },
+    "notes": {
+      "type": "array",
+      "description": "Notes about action, copy, binding etc.",
+      "items": {
+        "$ref": "note.json"
+      }
     }
   }
 }

--- a/src/main/resources/swagger.api/schemas/note.json
+++ b/src/main/resources/swagger.api/schemas/note.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Bibliographic or administrative note for instance/item/holding",
+  "type": "object",
+  "properties": {
+    "note": {
+      "type": "string",
+      "description": "Text content of the note"
+    },
+    "staffOnly": {
+      "type": "boolean",
+      "description": "If true, determines that the note should not be visible for others than staff",
+      "default": false
+    }
+  }
+}

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -118,8 +118,23 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("search by electronic access (public note)",
         "electronicAccess.publicNote all {value}", array("online"), null),
 
-      arguments("search by notes.note", "publicNotes all {value}", array("development"), null),
-      arguments("search by notes.note", "publicNotes all {value}", array("librarian"), zeroResultConsumer()),
+      arguments("search by public notes.note", "publicNotes all {value}", array("development"), null),
+      arguments("search by public notes.note", "publicNotes all {value}", array("librarian"), zeroResultConsumer()),
+      arguments("search by private notes.note", "notes.note == {value}", array("Librarian private note"), null),
+
+      arguments("search by public holdings.notes.note", "holdingPublicNotes all {value}",
+        array("bibliographical references"), null),
+      arguments("search by private holdings.notes.note using holdingPublicNotes", "holdingPublicNotes == {value}",
+        array("librarian private note"), zeroResultConsumer()),
+      arguments("search by private holdings.notes.note", "holdings.notes.note == {value}",
+        array("Librarian private note for holding"), null),
+
+      arguments("search by public items.notes.note", "itemPublicNotes all {value}",
+        array("bibliographical references"), null),
+      arguments("search by private items.notes.note using itemPublicNotes", "itemPublicNotes == {value}",
+        array("librarian private note for item"), zeroResultConsumer()),
+      arguments("search by private items.notes.note", "items.notes.note == {value}",
+        array("Librarian private note for item"), null),
 
       arguments("search by isbn10", "isbn = {value}", array("047144250X"), null),
       arguments("search by isbn10(wildcard)", "isbn = {value}", array("04714*"), null),

--- a/src/test/java/org/folio/search/service/setter/holding/HoldingPublicNotesProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/holding/HoldingPublicNotesProcessorTest.java
@@ -1,0 +1,60 @@
+package org.folio.search.service.setter.holding;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.folio.search.domain.dto.Holding;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Note;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@UnitTest
+class HoldingPublicNotesProcessorTest {
+  private final HoldingPublicNotesProcessor holdingPublicNotesProcessor = new HoldingPublicNotesProcessor();
+
+  @MethodSource("notesDataProvider")
+  @DisplayName("getFieldValue_parameterized")
+  @ParameterizedTest(name = "[{index}] instance with {0}, expected={2}")
+  void getFieldValue_parameterized(@SuppressWarnings("unused") String name, Instance eventBody, List<String> expected) {
+    var actual = holdingPublicNotesProcessor.getFieldValue(eventBody);
+    assertThat(actual).containsExactlyElementsOf(expected);
+  }
+
+  private static Stream<Arguments> notesDataProvider() {
+    return Stream.of(
+      arguments("all empty fields", new Instance(), emptyList()),
+      arguments("empty holdings", instance(), emptyList()),
+      arguments("holding with note(staffOnly=null)", instance(holding(note("value", null))), List.of("value")),
+      arguments("holding with note(staffOnly=false)", instance(holding(note("value", false))), List.of("value")),
+      arguments("holding with null note", instance(holding((Note) null)), emptyList()),
+      arguments("holding with null value in notes", instance(holding((Note[]) null)), emptyList()),
+      arguments("holding with empty list in note", instance(new Holding().notes(emptyList())), emptyList()),
+      arguments("2 holdings with notes(staffOnly=false and null)",
+        instance(holding(note("value1", null)), holding(note("value2", false))), List.of("value1", "value2")),
+      arguments("holding with note(staffOnly=true)", instance(holding(note("value", true))), emptyList()),
+      arguments("holding with note(value=null,staffOnly=false)", instance(holding(note(null, false))), emptyList()),
+      arguments("holdings with duplicated notes", instance(
+        holding(note("note", false)), holding(note("note", false)), holding(note("note", true))), List.of("note"))
+    );
+  }
+
+  private static Instance instance(Holding... holdings) {
+    return new Instance().holdings(holdings != null ? Arrays.asList(holdings) : null);
+  }
+
+  private static Holding holding(Note... notes) {
+    return new Holding().notes(notes != null ? Arrays.asList(notes) : null);
+  }
+
+  private static Note note(String value, Boolean staffOnly) {
+    return new Note().note(value).staffOnly(staffOnly);
+  }
+}

--- a/src/test/java/org/folio/search/service/setter/instance/PublicNotesProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/instance/PublicNotesProcessorTest.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import org.folio.search.domain.dto.Instance;
-import org.folio.search.domain.dto.InstanceNotes;
+import org.folio.search.domain.dto.Note;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 @UnitTest
 class PublicNotesProcessorTest {
+
   private final PublicNotesProcessor publicNotesProcessor = new PublicNotesProcessor();
 
   @MethodSource("notesDataProvider")
@@ -31,8 +32,8 @@ class PublicNotesProcessorTest {
     return Stream.of(
       arguments("all empty fields", new Instance(), emptyList()),
       arguments("empty notes", instanceWithNotes(), emptyList()),
-      arguments("null notes", instanceWithNotes((InstanceNotes) null), emptyList()),
-      arguments("null value in notes", instanceWithNotes((InstanceNotes[]) null), emptyList()),
+      arguments("null notes", instanceWithNotes((Note) null), emptyList()),
+      arguments("null value in notes", instanceWithNotes((Note[]) null), emptyList()),
       arguments("note(staffOnly=null)", instanceWithNotes(note("value", null)), List.of("value")),
       arguments("note(staffOnly=false)", instanceWithNotes(note("value", false)), List.of("value")),
       arguments("2 notes(staffOnly=false and null)",
@@ -42,11 +43,11 @@ class PublicNotesProcessorTest {
     );
   }
 
-  private static Instance instanceWithNotes(InstanceNotes... notes) {
+  private static Instance instanceWithNotes(Note... notes) {
     return new Instance().notes(notes != null ? Arrays.asList(notes) : null);
   }
 
-  private static InstanceNotes note(String value, Boolean staffOnly) {
-    return new InstanceNotes().note(value).staffOnly(staffOnly);
+  private static Note note(String value, Boolean staffOnly) {
+    return new Note().note(value).staffOnly(staffOnly);
   }
 }

--- a/src/test/java/org/folio/search/service/setter/item/ItemPublicNotesProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemPublicNotesProcessorTest.java
@@ -1,0 +1,60 @@
+package org.folio.search.service.setter.item;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Item;
+import org.folio.search.domain.dto.Note;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@UnitTest
+class ItemPublicNotesProcessorTest {
+  private final ItemPublicNotesProcessor itemPublicNotesProcessor = new ItemPublicNotesProcessor();
+
+  @MethodSource("notesDataProvider")
+  @DisplayName("getFieldValue_parameterized")
+  @ParameterizedTest(name = "[{index}] instance with {0}, expected={2}")
+  void getFieldValue_parameterized(@SuppressWarnings("unused") String name, Instance eventBody, List<String> expected) {
+    var actual = itemPublicNotesProcessor.getFieldValue(eventBody);
+    assertThat(actual).containsExactlyElementsOf(expected);
+  }
+
+  private static Stream<Arguments> notesDataProvider() {
+    return Stream.of(
+      arguments("all empty fields", new Instance(), emptyList()),
+      arguments("empty items", instance(), emptyList()),
+      arguments("item with note(staffOnly=null)", instance(item(note("value", null))), List.of("value")),
+      arguments("item with note(staffOnly=false)", instance(item(note("value", false))), List.of("value")),
+      arguments("item with null note", instance(item((Note) null)), emptyList()),
+      arguments("item with null value in notes", instance(item((Note[]) null)), emptyList()),
+      arguments("item with empty list in note", instance(new Item().notes(emptyList())), emptyList()),
+      arguments("2 items with notes(staffOnly=false and null)",
+        instance(item(note("value1", null)), item(note("value2", false))), List.of("value1", "value2")),
+      arguments("item with note(staffOnly=true)", instance(item(note("value", true))), emptyList()),
+      arguments("item with note(value=null,staffOnly=false)", instance(item(note(null, false))), emptyList()),
+      arguments("items with duplicated notes", instance(
+        item(note("note", false)), item(note("note", false)), item(note("note", true))), List.of("note"))
+    );
+  }
+
+  private static Instance instance(Item... items) {
+    return new Instance().items(items != null ? Arrays.asList(items) : null);
+  }
+
+  private static Item item(Note... notes) {
+    return new Item().notes(notes != null ? Arrays.asList(notes) : null);
+  }
+
+  private static Note note(String value, Boolean staffOnly) {
+    return new Note().note(value).staffOnly(staffOnly);
+  }
+}

--- a/src/test/java/org/folio/search/utils/CollectionUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/CollectionUtilsTest.java
@@ -87,19 +87,19 @@ class CollectionUtilsTest {
 
   @Test
   void toSafeStream_positive() {
-    var actual = CollectionUtils.toSafeStream(List.of(1, 2)).collect(toList());
+    var actual = CollectionUtils.toStreamSafe(List.of(1, 2)).collect(toList());
     assertThat(actual).containsExactly(1, 2);
   }
 
   @Test
   void toSafeStream_positive_nullValue() {
-    var actual = CollectionUtils.toSafeStream(null).collect(toList());
+    var actual = CollectionUtils.toStreamSafe(null).collect(toList());
     assertThat(actual).isEmpty();
   }
 
   @Test
   void toSafeStream_positive_emptyCollection() {
-    var actual = CollectionUtils.toSafeStream(emptyList()).collect(toList());
+    var actual = CollectionUtils.toStreamSafe(emptyList()).collect(toList());
     assertThat(actual).isEmpty();
   }
 }

--- a/src/test/java/org/folio/search/utils/CollectionUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/CollectionUtilsTest.java
@@ -1,6 +1,8 @@
 package org.folio.search.utils;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.utils.CollectionUtils.addToList;
 import static org.folio.search.utils.CollectionUtils.mergeSafely;
@@ -81,5 +83,23 @@ class CollectionUtilsTest {
     List<Integer> initial = new ArrayList<>(List.of(3, 5));
     addToList(initial, null, true);
     assertThat(initial).contains(3, 5);
+  }
+
+  @Test
+  void toSafeStream_positive() {
+    var actual = CollectionUtils.toSafeStream(List.of(1, 2)).collect(toList());
+    assertThat(actual).containsExactly(1, 2);
+  }
+
+  @Test
+  void toSafeStream_positive_nullValue() {
+    var actual = CollectionUtils.toSafeStream(null).collect(toList());
+    assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void toSafeStream_positive_emptyCollection() {
+    var actual = CollectionUtils.toSafeStream(emptyList()).collect(toList());
+    assertThat(actual).isEmpty();
   }
 }

--- a/src/test/java/org/folio/search/utils/SearchUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchUtilsTest.java
@@ -1,8 +1,6 @@
 package org.folio.search.utils;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.search.model.metadata.PlainFieldDescription.STANDARD_FIELD_TYPE;
@@ -118,24 +116,6 @@ class SearchUtilsTest {
     assertThat(actual).isEqualTo(mapOf(
       "field", mapOf("eng", value, "ger", value, "src", value),
       "plain_field", value));
-  }
-
-  @Test
-  void toSafeStream_positive() {
-    var actual = SearchUtils.toSafeStream(List.of(1, 2)).collect(toList());
-    assertThat(actual).containsExactly(1, 2);
-  }
-
-  @Test
-  void toSafeStream_positive_nullValue() {
-    var actual = SearchUtils.toSafeStream(null).collect(toList());
-    assertThat(actual).isEmpty();
-  }
-
-  @Test
-  void toSafeStream_positive_emptyCollection() {
-    var actual = SearchUtils.toSafeStream(emptyList()).collect(toList());
-    assertThat(actual).isEmpty();
   }
 
   @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -36,3 +36,7 @@ application:
         concurrency: 2
         topic-pattern: (${ENV:folio}\.)?(.*\.)?inventory.(instance|holdings-record|item)
         group-id: ${ENV:folio}-mod-search-events-group
+
+logging:
+  level:
+    org.apache.kafka.clients.consumer.*: warn

--- a/src/test/resources/samples/semantic-web-primer/holdings.json
+++ b/src/test/resources/samples/semantic-web-primer/holdings.json
@@ -41,7 +41,23 @@
         "relationshipId": "3b430592-2e09-4b48-9a0c-0636d66b9fb3"
       }
     ],
-    "notes": [],
+    "notes": [
+      {
+        "note": "Includes bibliographical references and index of holdings.",
+        "staffOnly": false,
+        "holdingsNoteTypeId": "6a2533a7-4de2-4e64-8466-074c2fa9308c"
+      },
+      {
+        "note": "Librarian public note for holding",
+        "staffOnly": false,
+        "holdingsNoteTypeId": "6a2533a7-4de2-4e64-8466-074c2fa9308c"
+      },
+      {
+        "note": "Librarian private note for holding",
+        "staffOnly": true,
+        "holdingsNoteTypeId": "6a2533a7-4de2-4e64-8466-074c2fa9308c"
+      }
+    ],
     "holdingsStatements": [],
     "holdingsStatementsForIndexes": [],
     "holdingsStatementsForSupplements": [],

--- a/src/test/resources/samples/semantic-web-primer/items.json
+++ b/src/test/resources/samples/semantic-web-primer/items.json
@@ -64,7 +64,23 @@
     "enumeration": "",
     "chronology": "",
     "yearCaption": [],
-    "notes": [],
+    "notes": [
+      {
+        "note": "Includes bibliographical references and index of item.",
+        "staffOnly": false,
+        "itemNoteTypeId": "6a2533a7-4de2-4e64-8466-074c2fa9308c"
+      },
+      {
+        "note": "Librarian public note for item",
+        "staffOnly": false,
+        "itemNoteTypeId": "6a2533a7-4de2-4e64-8466-074c2fa9308c"
+      },
+      {
+        "note": "Librarian private note for item",
+        "staffOnly": true,
+        "itemNoteTypeId": "6a2533a7-4de2-4e64-8466-074c2fa9308c"
+      }
+    ],
     "circulationNotes": [],
     "status": {
       "name": "Available",


### PR DESCRIPTION
### Purpose
The purpose of this pull request is to allow the user a full-text search within the instance/item/holdings record's notes field. Search should support using public only and all `notes.note` values.

### Acceptance criteria

- Existing search by public notes of instance only is preserved
- Additional search option notes (all) is added
- Query returns accurate hit count
- User can search by any word that is a part of the field's value
- Results are ranked based on term frequency, inverse document frequency, and field length
- Stemming according to with configured on the tenant language tokenizers

### Approach
Since the approach for implementing full-text search support for the following fields `notes.note`, `items.notes.note`, `holdings.notes.note` is similar, all 3 stories are merged into a single pull request.
Integration and unit test are added to prove implemented functionality

### Related stories, that are implemented within this pull request:
- [MSEARCH-116 Instance - support full-text search notes field](https://issues.folio.org/browse/MSEARCH-116)
- [MSEARCH-118 Item- support full-text search notes field](https://issues.folio.org/browse/MSEARCH-118)