### PR TITLE
MSEARCH-160 Failed to create index: Limit of total fields [250] has been exceeded

### DIFF
--- a/src/main/resources/elasticsearch/index/instance.json
+++ b/src/main/resources/elasticsearch/index/instance.json
@@ -4,7 +4,7 @@
     "number_of_replicas": 2,
     "refresh_interval": "1s",
     "codec": "best_compression",
-    "mapping.total_fields.limit": 250
+    "mapping.total_fields.limit": 1000
   },
   "analysis": {
     "char_filter": { },

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -28,7 +28,7 @@ folio.tenant.validation.enabled: true
 
 application:
   search-config:
-    initial-languages: eng,fre,ita,spa
+    initial-languages: eng,fre,ita,spa,ger
   system-user:
     username: mod-search
     password: Mod-search-1-0-0


### PR DESCRIPTION
### Purpose/Overview:

The current configuration has a value for the number of fields limitation as 250. With 5 assigned languages it raised an error for the previous version of mapping. 

### Approach
- Change mapping.total_fields.limit property to 1000
- Add 5th language to the test configuration to cover the maximum number of fields