### PR TITLE
MSEARCH-152/153 Add Identifiers (all) search option for holding and items

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,27 +294,29 @@ Here is a table with supported search options.
 | `holdings.electronicAccess.publicNote`             | full text | `holdings.electronicAccess.publicNote="a rare book"`       | Search by electronic access public note |
 | `holdings.notes.note`                              | full text | `holdings.notes.note all "librarian note"`                 | Search by holdings notes |
 | `holdingPublicNotes`                               | full text | `holdingPublicNotes all "public note"`                     | Search by holdings public notes |
+| `holdingIdentifiers`                               | term      | `holdingIdentifiers == "ho00000000006"`                    | Search by holdings Identifiers (all) |
 
 
 #### Items search options
 
-| Option                                          | Type      |Example                                                  | Description                  |
-| :-----------------------------------------------|:---------:| :-------------------------------------------------------|:------------------------------|
-| `items.id`                                      | term      | `items.id=="1234567"`                                   | Matches instances that have an item with the id |
-| `items.hrid`                                    | term      | `items.hrid=="it001"`                                   | Matches instances that have an item with the HRID |
-| `items.barcode`                                 | term      | `items.barcode=="10011"`                                | Matches instances that have an item with the barcode |
-| `items.effectiveLocationId`                     | term      | `items.effectiveLocationId=="1212"`                     | Matches instances that have items with the effective location |
-| `items.status.name`                             | term      | `items.status.name=="Available"`                        | Matches instances that have items with given status |
-| `items.materialTypeId`                          | term      | `items.materialTypeId="23434"`                          | Matches instances that have items with given material type |
-| `items.discoverySuppress`                       | term      | `items.discoverySuppress=true`                          | Matches instances that have items suppressed/not suppressed from discovery |
-| `itemsFullCallNumbers`                          | term      | `itemsFullCallNumbers="cn*434"`                         | Matches instances that have items with given call number string (prefix + call number + suffix) |
-| `itemTags`                                      | term      | `itemTags="important"`                                  | Matches instances that have items with given tag |
-| `items.electronicAccess`                        | full text | `items.electronicAccess any "resource"`                 | An alias for all `electronicAccess` fields - `uri`, `linkText`, `materialsSpecification`, `publicNote`|
-| `items.electronicAccess.uri`                    | term      | `items.electronicAccess.uri="http://folio.org*"`        | Search by electronic access URI|
-| `items.electronicAccess.linkText`               | full text | `items.electronicAccess.linkText="Folio website"`       | Search by electronic access link text |
-| `items.electronicAccess.publicNote`             | full text | `items.electronicAccess.publicNote="a rare book"`       | Search by electronic access public note |
-| `items.notes.note`                              | full text | `items.notes.note all "librarian note"`                 | Search by item notes |
-| `itemPublicNotes`                               | full text | `itemPublicNotes all "public note"`                     | Search by item public notes |
+| Option                                          | Type      |Example                                                       | Description                  |
+| :-----------------------------------------------|:---------:| :------------------------------------------------------------|:------------------------------|
+| `items.id`                                      | term      | `items.id=="1234567"`                                        | Matches instances that have an item with the id |
+| `items.hrid`                                    | term      | `items.hrid=="it001"`                                        | Matches instances that have an item with the HRID |
+| `items.barcode`                                 | term      | `items.barcode=="10011"`                                     | Matches instances that have an item with the barcode |
+| `items.effectiveLocationId`                     | term      | `items.effectiveLocationId=="1212"`                          | Matches instances that have items with the effective location |
+| `items.status.name`                             | term      | `items.status.name=="Available"`                             | Matches instances that have items with given status |
+| `items.materialTypeId`                          | term      | `items.materialTypeId="23434"`                               | Matches instances that have items with given material type |
+| `items.discoverySuppress`                       | term      | `items.discoverySuppress=true`                               | Matches instances that have items suppressed/not suppressed from discovery |
+| `itemsFullCallNumbers`                          | term      | `itemsFullCallNumbers="cn*434"`                              | Matches instances that have items with given call number string (prefix + call number + suffix) |
+| `itemTags`                                      | term      | `itemTags="important"`                                       | Matches instances that have items with given tag |
+| `items.electronicAccess`                        | full text | `items.electronicAccess any "resource"`                      | An alias for all `electronicAccess` fields - `uri`, `linkText`, `materialsSpecification`, `publicNote`|
+| `items.electronicAccess.uri`                    | term      | `items.electronicAccess.uri="http://folio.org*"`             | Search by electronic access URI|
+| `items.electronicAccess.linkText`               | full text | `items.electronicAccess.linkText="Folio website"`            | Search by electronic access link text |
+| `items.electronicAccess.publicNote`             | full text | `items.electronicAccess.publicNote="a rare book"`            | Search by electronic access public note |
+| `items.notes.note`                              | full text | `items.notes.note all "librarian note"`                      | Search by item notes |
+| `itemPublicNotes`                               | full text | `itemPublicNotes all "public note"`                          | Search by item public notes |
+| `itemIdentifiers`                               | term      | `itemIdentifiers all "81ae0f60-f2bc-450c-84c8-5a21096daed9"` | Search by item Identifiers (all) |
 
 
 ### Search Facets

--- a/src/main/java/org/folio/search/service/setter/holding/HoldingIdentifiersProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/holding/HoldingIdentifiersProcessor.java
@@ -1,0 +1,23 @@
+package org.folio.search.service.setter.holding;
+
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.service.setter.FieldProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HoldingIdentifiersProcessor implements FieldProcessor<Instance, Set<String>> {
+
+  @Override
+  public Set<String> getFieldValue(Instance instance) {
+    return toStreamSafe(instance.getHoldings())
+      .flatMap(holding -> Stream.concat(toStreamSafe(holding.getFormerIds()), Stream.of(holding.getHrid())))
+      .filter(StringUtils::isNotEmpty)
+      .collect(Collectors.toSet());
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/item/ItemIdentifiersProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemIdentifiersProcessor.java
@@ -1,0 +1,23 @@
+package org.folio.search.service.setter.item;
+
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.service.setter.FieldProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ItemIdentifiersProcessor implements FieldProcessor<Instance, Set<String>> {
+
+  @Override
+  public Set<String> getFieldValue(Instance instance) {
+    return toStreamSafe(instance.getItems())
+      .flatMap(item -> Stream.concat(toStreamSafe(item.getFormerIds()), Stream.of(item.getHrid())))
+      .filter(StringUtils::isNotEmpty)
+      .collect(Collectors.toSet());
+  }
+}

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -199,6 +199,9 @@
         "hrid": {
           "index": "keyword"
         },
+        "formerIds": {
+          "index": "source"
+        },
         "barcode": {
           "index": "keyword"
         },
@@ -299,6 +302,9 @@
         },
         "hrid": {
           "index": "keyword"
+        },
+        "formerIds": {
+          "index": "source"
         },
         "tags": {
           "type": "object",
@@ -411,6 +417,16 @@
       "index": "keyword",
       "inventorySearchTypes": "holdings.fullCallNumber",
       "processor": "holdingsCallNumberComponentsProcessor"
+    },
+    "holdingIdentifiers": {
+      "type": "search",
+      "index": "keyword",
+      "processor": "holdingIdentifiersProcessor"
+    },
+    "itemIdentifiers": {
+      "type": "search",
+      "index": "keyword",
+      "processor": "itemIdentifiersProcessor"
     },
     "uniformTitle": {
       "type": "search",

--- a/src/main/resources/swagger.api/schemas/holding.json
+++ b/src/main/resources/swagger.api/schemas/holding.json
@@ -19,6 +19,13 @@
       "type": "string",
       "description": "the human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"
     },
+    "formerIds": {
+      "type": "array",
+      "description": "Previous identifiers assigned to the holding",
+      "items": {
+        "type": "string"
+      }
+    },
     "tags": {
       "description": "arbitrary tags associated with this holding",
       "$ref": "tags.json"

--- a/src/main/resources/swagger.api/schemas/item.json
+++ b/src/main/resources/swagger.api/schemas/item.json
@@ -11,6 +11,13 @@
       "type": "string",
       "description": "The human readable ID, also called eye readable ID. A system-assigned sequential alternate ID"
     },
+    "formerIds": {
+      "type": "array",
+      "description": "Previous identifiers assigned to the item",
+      "items": {
+        "type": "string"
+      }
+    },
     "barcode": {
       "type": "string",
       "description": "Unique inventory control number for physical resources, used largely for circulation purposes"

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -29,7 +29,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
   @MethodSource("positiveSearchTestDataProvider")
   @DisplayName("can search by instances (index with only 1 instance)")
   void canSearchByInstances(String testName, String query, Object[] queryArguments,
-    ThrowingConsumer<ResultActions> extendedSearchResultMatcher) throws Throwable {
+                            ThrowingConsumer<ResultActions> extendedSearchResultMatcher) throws Throwable {
     var searchResult = mockMvc.perform(get(searchInstancesByQuery(query), queryArguments).headers(defaultHeaders()));
     if (extendedSearchResultMatcher != null) {
       extendedSearchResultMatcher.accept(searchResult);
@@ -185,7 +185,19 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("search by items electronic access (materials specification)",
         "holdings.electronicAccess.materialsSpecification all {value}", array("specification"), zeroResultConsumer()),
       arguments("search by items electronic access (public note)",
-        "holdings.electronicAccess.publicNote all {value}", array("note"), null)
+        "holdings.electronicAccess.publicNote all {value}", array("note"), null),
+
+      arguments("search by holding Identifiers hrId (All)",
+        "holdingIdentifiers all {value}", array("hold000000000009"), null),
+      arguments("search by holding Identifiers formerIds (All)",
+        "holdingIdentifiers == {value}", array("1d76ee84-d776-48d2-ab96-140c24e39ac5"), null),
+      arguments("search by holding Identifiers formerIds multiple (All)",
+        "holdingIdentifiers all {value}", array("9b8ec096-fa2e-451b-8e7a-6d1c977ee946"), null),
+
+      arguments("search by item Identifiers hrId (All)",
+        "itemIdentifiers all {value}", array("item000000000014"), null),
+      arguments("search by item Identifiers formerId (All)",
+        "itemIdentifiers all {value}", array("81ae0f60-f2bc-450c-84c8-5a21096daed9"), null)
     );
   }
 

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -29,7 +29,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
   @MethodSource("positiveSearchTestDataProvider")
   @DisplayName("can search by instances (index with only 1 instance)")
   void canSearchByInstances(String testName, String query, Object[] queryArguments,
-                            ThrowingConsumer<ResultActions> extendedSearchResultMatcher) throws Throwable {
+    ThrowingConsumer<ResultActions> extendedSearchResultMatcher) throws Throwable {
     var searchResult = mockMvc.perform(get(searchInstancesByQuery(query), queryArguments).headers(defaultHeaders()));
     if (extendedSearchResultMatcher != null) {
       extendedSearchResultMatcher.accept(searchResult);

--- a/src/test/resources/samples/semantic-web-primer/holdings.json
+++ b/src/test/resources/samples/semantic-web-primer/holdings.json
@@ -3,7 +3,9 @@
     "id": "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19",
     "hrid": "hold000000000009",
     "holdingsTypeId": "03c9c400-b9e3-4a07-ac0e-05ab470233ed",
-    "formerIds": [],
+    "formerIds": [
+      "1d76ee84-d776-48d2-ab96-140c24e39ac5"
+    ],
     "instanceId": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",
     "permanentLocationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
     "electronicAccess": [],
@@ -29,7 +31,10 @@
     "id": "9550c935-401a-4a85-875e-4d1fe7678870",
     "_version": 1,
     "hrid": "ho00000000006",
-    "formerIds": [],
+    "formerIds": [
+      "ac727d8c-f422-4c3f-815e-e85694095e71",
+      "9b8ec096-fa2e-451b-8e7a-6d1c977ee946"
+    ],
     "instanceId": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",
     "permanentLocationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
     "electronicAccess": [

--- a/src/test/resources/samples/semantic-web-primer/items.json
+++ b/src/test/resources/samples/semantic-web-primer/items.json
@@ -3,7 +3,10 @@
     "id": "7212ba6a-8dcf-45a1-be9a-ffaa847c4423",
     "hrid": "item000000000014",
     "holdingsRecordId": "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19",
-    "formerIds": [],
+    "formerIds": [
+      "207b9372-127f-4bdd-83e0-147c9fe9bc16",
+      "81ae0f60-f2bc-450c-84c8-5a21096daed9"
+    ],
     "barcode": "10101",
     "itemLevelCallNumber": "TK5105.88815 . A58 2004 FT MEADE",
     "effectiveCallNumberComponents": {


### PR DESCRIPTION
### Purpose/Overview:

The current implementation supports holdings search by HRID but librarians also need to search by holdings and items by their former Id.  While searching it is not always clear if the provided value is a current or a former HRID.  For those cases, there need to be an option to cover both in one search

### Requirements/Scope:

- Add Identifiers (all) option for holdings and items
- The search should include matches from hrid and fromerIds (array of strings)

### Approach
-Added new search fields: itemIdentifiers and holdingIdentifiers. These fields should support searching by hrId and former ids