### PR TITLE
MSEARCH-158 Item - support circulation notes search

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Here is a table with supported search options.
 
 #### Items search options
 
-| Option                                          | Type      |Example                                                       | Description                  |
+| Option                                          | Type      |Example                                                       | Description                   |
 | :-----------------------------------------------|:---------:| :------------------------------------------------------------|:------------------------------|
 | `items.id`                                      | term      | `items.id=="1234567"`                                        | Matches instances that have an item with the id |
 | `items.hrid`                                    | term      | `items.hrid=="it001"`                                        | Matches instances that have an item with the HRID |
@@ -315,6 +315,7 @@ Here is a table with supported search options.
 | `items.electronicAccess.linkText`               | full text | `items.electronicAccess.linkText="Folio website"`            | Search by electronic access link text |
 | `items.electronicAccess.publicNote`             | full text | `items.electronicAccess.publicNote="a rare book"`            | Search by electronic access public note |
 | `items.notes.note`                              | full text | `items.notes.note all "librarian note"`                      | Search by item notes |
+| `items.circulationNotes.note`                   | full text | `items.circulationNotes.note all "circulation note"`         | Search by item circulation notes |
 | `itemPublicNotes`                               | full text | `itemPublicNotes all "public note"`                          | Search by item public notes |
 | `itemIdentifiers`                               | term      | `itemIdentifiers all "81ae0f60-f2bc-450c-84c8-5a21096daed9"` | Search by item Identifiers (all) |
 

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -284,6 +284,14 @@
               "index": "bool"
             }
           }
+        },
+        "circulationNotes": {
+          "type": "object",
+          "properties": {
+            "note": {
+              "index": "multilang"
+            }
+          }
         }
       }
     },

--- a/src/main/resources/swagger.api/schemas/circulationNote.json
+++ b/src/main/resources/swagger.api/schemas/circulationNote.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Circulations note for item",
+  "type": "object",
+  "properties": {
+    "note": {
+      "type": "string",
+      "description": "Text to display"
+    }
+  }
+}

--- a/src/main/resources/swagger.api/schemas/item.json
+++ b/src/main/resources/swagger.api/schemas/item.json
@@ -79,6 +79,13 @@
       "items": {
         "$ref": "note.json"
       }
+    },
+    "circulationNotes": {
+      "type": "array",
+      "description": "Notes to be displayed in circulation processes.",
+      "items": {
+        "$ref": "circulationNote.json"
+      }
     }
   }
 }

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -197,7 +197,18 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("search by item Identifiers hrId (All)",
         "itemIdentifiers all {value}", array("item000000000014"), null),
       arguments("search by item Identifiers formerId (All)",
-        "itemIdentifiers all {value}", array("81ae0f60-f2bc-450c-84c8-5a21096daed9"), null)
+        "itemIdentifiers all {value}", array("81ae0f60-f2bc-450c-84c8-5a21096daed9"), null),
+
+      arguments("search by items circulation notes wildcard",
+        "items.circulationNotes.note all {value}", array("*Note"), null),
+      arguments("search by items circulation notes wildcard",
+        "items.circulationNotes.note all {value}", array("test*"), null),
+      arguments("search by items circulation notes",
+        "items.circulationNotes.note == {value}", array("testNote"), null),
+      arguments("search by items circulation notes hyphens are treated",
+        "items.circulationNotes.note all {value}", array("first-record"), null),
+      arguments("search by items circulation notes case insensitive",
+        "items.circulationNotes.note all {value}", array("secondrecord"), null)
     );
   }
 

--- a/src/test/resources/samples/semantic-web-primer/items.json
+++ b/src/test/resources/samples/semantic-web-primer/items.json
@@ -21,7 +21,11 @@
     "yearCaption": [],
     "copyNumber": "Copy 2",
     "notes": [],
-    "circulationNotes": [],
+    "circulationNotes": [
+      {
+        "note": "testNote"
+      }
+    ],
     "status": {
       "name": "Available",
       "date": "2020-12-08T15:47:21.327+00:00"
@@ -84,7 +88,14 @@
         "itemNoteTypeId": "6a2533a7-4de2-4e64-8466-074c2fa9308c"
       }
     ],
-    "circulationNotes": [],
+    "circulationNotes": [
+      {
+        "note": "first-record"
+      },
+      {
+        "note": "SecondRecord"
+      }
+    ],
     "status": {
       "name": "Available",
       "date": "2020-12-08T15:47:22.827+00:00"


### PR DESCRIPTION
### Purpose/Overview:

The purpose of this story is to allow the user a full-text search within the item's circulation notes field.

### Requirements/Scope:

- Case insensitive
- Word match in the Inventory item's Notes[].note (array of strings)
- Search by public notes when staff only note is set to false 
- Search by all item notes 
- Supports search in other than English languages (including CKJ languages, Arabic, Hebrew)

### Approach
-Added new search fields for items.circulationNotes.note