### PR TITLE
MSEARCH-162: Forbid to add language = 'src' for tenant configuration

### DIFF
--- a/src/main/java/org/folio/search/service/metadata/ResourceDescriptionService.java
+++ b/src/main/java/org/folio/search/service/metadata/ResourceDescriptionService.java
@@ -6,6 +6,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 import static org.folio.search.model.metadata.PlainFieldDescription.MULTILANG_FIELD_TYPE;
+import static org.folio.search.utils.SearchUtils.MULTILANG_SOURCE_SUBFIELD;
 import static org.springframework.core.ResolvableType.forClass;
 
 import java.util.ArrayList;
@@ -96,7 +97,11 @@ public class ResourceDescriptionService {
     var indexFieldType = localSearchFieldProvider.getSearchFieldType(MULTILANG_FIELD_TYPE);
     var supportedLanguagesSet = new HashSet<String>();
     var mapping = indexFieldType.getMapping();
-    mapping.path("properties").fieldNames().forEachRemaining(supportedLanguagesSet::add);
+    mapping.path("properties").fieldNames().forEachRemaining(field -> {
+      if (!field.equals(MULTILANG_SOURCE_SUBFIELD)) {
+        supportedLanguagesSet.add(field);
+      }
+    });
     return supportedLanguagesSet;
   }
 

--- a/src/test/java/org/folio/search/service/LanguageConfigServiceTest.java
+++ b/src/test/java/org/folio/search/service/LanguageConfigServiceTest.java
@@ -16,6 +16,7 @@ import org.folio.search.exception.ValidationException;
 import org.folio.search.model.config.LanguageConfigEntity;
 import org.folio.search.repository.LanguageConfigRepository;
 import org.folio.search.service.metadata.ResourceDescriptionService;
+import org.folio.search.utils.SearchUtils;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,6 +52,13 @@ class LanguageConfigServiceTest {
   @Test
   void cannotAddConfigIfLanguageIsNotSupported() {
     final var languageConfig = new LanguageConfig().code(UNSUPPORTED_LANGUAGE_CODE);
+
+    assertThrows(ValidationException.class, () -> configService.create(languageConfig));
+  }
+
+  @Test
+  void cannotAddConfigIfLanguageIsSRC() {
+    final var languageConfig = new LanguageConfig().code(SearchUtils.MULTILANG_SOURCE_SUBFIELD);
 
     assertThrows(ValidationException.class, () -> configService.create(languageConfig));
   }

--- a/src/test/java/org/folio/search/service/LanguageConfigServiceTest.java
+++ b/src/test/java/org/folio/search/service/LanguageConfigServiceTest.java
@@ -57,7 +57,7 @@ class LanguageConfigServiceTest {
   }
 
   @Test
-  void cannotAddConfigIfLanguageIsSRC() {
+  void cannotAddConfigIfLanguageIsSrc() {
     final var languageConfig = new LanguageConfig().code(SearchUtils.MULTILANG_SOURCE_SUBFIELD);
 
     assertThrows(ValidationException.class, () -> configService.create(languageConfig));


### PR DESCRIPTION
### Purpose/Overview:

Tenant is able to create a language with name = src. This behavior is not correct and must be forbidden. 

src is the system field that is used only internally for all full-text values where there is no language specified or to enable searching by fields using icu_folding char filter. There is no need to specify it manually by the tenant.

### Requirements/Scope:

- The tenant cannot create a language config

### Approach 
Language with name = src excluded from the list of supported languages