### PR TITLE
MSEARCH-171 Update Dockerfile to use folioci java Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,11 @@
-#--------------------------------------------------------
-# 1. image with extracted application layers
-#--------------------------------------------------------
-FROM adoptopenjdk/openjdk11:alpine-jre as builder
-# should be a single jar file
-ARG JAR_FILE=target/*.jar
+FROM folioci/alpine-jre-openjdk11:latest
 
-COPY ${JAR_FILE} application.jar
-RUN java -Djarmode=layertools -jar application.jar extract
-
-#--------------------------------------------------------
-# 2. target image
-#--------------------------------------------------------
-FROM adoptopenjdk/openjdk11:alpine-jre
-
-ENV JAVA_APP_DIR=/opt/folio
-RUN mkdir -p ${JAVA_APP_DIR}
-
-COPY --from=builder dependencies/ ${JAVA_APP_DIR}/
-COPY --from=builder snapshot-dependencies/ ${JAVA_APP_DIR}/
-COPY --from=builder spring-boot-loader/ ${JAVA_APP_DIR}/
-COPY --from=builder application/ ${JAVA_APP_DIR}/
-
-COPY run.sh ${JAVA_APP_DIR}/
-RUN chmod 755 ${JAVA_APP_DIR}/run.sh
+# Copy your fat jar to the container
+ENV APP_FILE mod-search-fat.jar
+# - should be a single jar file
+ARG JAR_FILE=./target/*.jar
+# - copy
+COPY ${JAR_FILE} ${JAVA_APP_DIR}/${APP_FILE}
 
 # Expose this port locally in the container.
 EXPOSE 8081
-
-WORKDIR $JAVA_APP_DIR
-
-ENTRYPOINT ["sh", "./run.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,12 +1,22 @@
 version: "3.8"
 
 services:
+  mod-search:
+    container_name: mod-search
+    image: dev.folio/mod-search:latest
+    ports:
+      - "8081:8081"
+    environment:
+      DB_HOST: db
+      JAVA_OPTIONS: -Xmx120m -Xms120m
+      okapi.url: http://okapi:9130
+
   elasticsearch:
     container_name: elasticsearch
-    image: org.folio/elasticsearch:latest
+    image: dev.folio/elasticsearch:latest
     ports:
-      - 9200:9200
-      - 9300:9300
+      - "9200:9200"
+      - "9300:9300"
     volumes:
       - es-data:/usr/share/elasticsearch/data
     environment:
@@ -23,8 +33,8 @@ services:
     image: zookeeper:3.6.2
     container_name: zookeeper
     ports:
-      - 2181:2181
-      - 8080:8080
+      - "2181:2181"
+      - "8080:8080"
     environment:
       ZOOKEEPER_SERVER_ID: 1
       ZOO_PORT_NUMBER: 2181
@@ -36,7 +46,7 @@ services:
     depends_on:
       - zookeeper
     ports:
-      - 9092:9092
+      - "9092:9092"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_LISTENERS: INSIDE://:9091,OUTSIDE://:9092
@@ -51,5 +61,16 @@ services:
       KAFKA_CREATE_TOPICS: >-
         inventory.instance:4:1
 
+  db:
+    container_name: db
+    image: postgres:13.4-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: okapi_modules
+
 volumes:
   es-data: { }
+  db-data: { }

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-echo "APP_OPTS=${APP_OPTS}"
-
-exec java org.springframework.boot.loader.JarLauncher ${APP_OPTS}


### PR DESCRIPTION
### Purpose
Using the existing Dockerfile configuration is not efficient and does not allow to unify environment variables like `JAVA_OPTIONS`. Also, other folio Spring-based modules are using `folioci/alpine-jre-openjdk11:latest` as the root Docker image.

### Approach
- Update `Dockerfile` to use `folioci/alpine-jre-openjdk11:latest` as the root Docker image
- Remove redundant `run.sh` file
- Update Docker compose file to run the application locally using Docker image
- Add to docker-compose PostgreSQL as service