### PR TITLE
MSEARCH-172 Make ENV varialbe required and update kafka listening pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ with less powerful configuration (see [High availability](https://www.elastic.co
 | INITIAL_LANGUAGES             | eng                       | Comma separated list of languages for multilang fields see [Multi-lang search support](#multi-language-search-support) |
 | SYSTEM_USER_PASSWORD          | -                         | Password for `mod-search` system user (not required for dev envs) |
 | OKAPI_URL                     | -                         | OKAPI URL used to login system user, required                     |
-| ENV                           | folio                     | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed|
+| ENV                           | folio                     | Logical name of the deployment, must be unique across the all deployment using the same shared Kafka/Elasticsearch clusters, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed |
 
 The module uses system user to communicate with other modules from Kafka consumers.
 For production deployments you MUST specify the password for this system user via env variable:

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ with less powerful configuration (see [High availability](https://www.elastic.co
 | INITIAL_LANGUAGES             | eng                       | Comma separated list of languages for multilang fields see [Multi-lang search support](#multi-language-search-support) |
 | SYSTEM_USER_PASSWORD          | -                         | Password for `mod-search` system user (not required for dev envs) |
 | OKAPI_URL                     | -                         | OKAPI URL used to login system user, required                     |
-| ENV                           | folio                     | Logical name of the deployment, must be unique across the all deployment using the same shared Kafka/Elasticsearch clusters, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed |
+| ENV                           | folio                     | The logical name of the deployment must be unique across all deployments using the same shared Kafka/Elasticsearch clusters, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed |
 
 The module uses system user to communicate with other modules from Kafka consumers.
 For production deployments you MUST specify the password for this system user via env variable:

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ with less powerful configuration (see [High availability](https://www.elastic.co
 | INITIAL_LANGUAGES             | eng                       | Comma separated list of languages for multilang fields see [Multi-lang search support](#multi-language-search-support) |
 | SYSTEM_USER_PASSWORD          | -                         | Password for `mod-search` system user (not required for dev envs) |
 | OKAPI_URL                     | -                         | OKAPI URL used to login system user, required                     |
-| ENV                           | folio                     | The logical name of the deployment must be unique across all deployments using the same shared Kafka/Elasticsearch clusters, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed |
+| ENV                           | -                         | The logical name of the deployment, must be unique across all environments using the same shared Kafka/Elasticsearch clusters, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed |
 
 The module uses system user to communicate with other modules from Kafka consumers.
 For production deployments you MUST specify the password for this system user via env variable:

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-openfeign</artifactId>
       <version>${spring-cloud-starter-openfeign.version}</version>
@@ -441,6 +447,11 @@
               <groupId>org.mapstruct</groupId>
               <artifactId>mapstruct-processor</artifactId>
               <version>${mapstruct.version}</version>
+            </path>
+            <path>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-configuration-processor</artifactId>
+              <version>${project.parent.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/src/main/java/org/folio/search/configuration/properties/FolioEnvironment.java
+++ b/src/main/java/org/folio/search/configuration/properties/FolioEnvironment.java
@@ -2,23 +2,35 @@ package org.folio.search.configuration.properties;
 
 import static java.lang.System.getProperty;
 import static java.lang.System.getenv;
-import static lombok.AccessLevel.PRIVATE;
 import static org.apache.commons.lang3.StringUtils.firstNonBlank;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
 
-@NoArgsConstructor(access = PRIVATE)
-public final class FolioEnvironment {
+@Data
+@Validated
+@Configuration
+@NoArgsConstructor
+@AllArgsConstructor(staticName = "of")
+@ConfigurationProperties(prefix = "application")
+public class FolioEnvironment {
 
+  @NotEmpty
+  @Pattern(regexp = "[\\w0-9\\-_]+", message = "Value must follow the pattern: '[\\w0-9\\-_]+'")
+  private String environment;
+
+  /**
+   * Return folio env name from environment or system properties as {@link String} object.
+   *
+   * @return folio env name.
+   */
   public static String getFolioEnvName() {
-    return validateFolioEnv(firstNonBlank(getenv("ENV"), getProperty("env"), "folio"));
-  }
-
-  private static String validateFolioEnv(String folioEnv) {
-    if (!folioEnv.matches("[\\w0-9\\-_]+")) {
-      throw new IllegalArgumentException("Folio ENV must contain alphanumeric and '-', '_' symbols only");
-    }
-
-    return folioEnv;
+    return firstNonBlank(getenv("ENV"), getProperty("env"));
   }
 }

--- a/src/main/java/org/folio/search/configuration/properties/SearchConfigurationProperties.java
+++ b/src/main/java/org/folio/search/configuration/properties/SearchConfigurationProperties.java
@@ -1,0 +1,22 @@
+package org.folio.search.configuration.properties;
+
+import static java.util.Collections.emptySet;
+
+import java.util.Set;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@Validated
+@Configuration
+@ConfigurationProperties(prefix = "application.search-config")
+public class SearchConfigurationProperties {
+
+  @NotEmpty
+  @Size(max = 5)
+  private Set<String> initialLanguages = emptySet();
+}

--- a/src/main/java/org/folio/search/service/SearchTenantService.java
+++ b/src/main/java/org/folio/search/service/SearchTenantService.java
@@ -1,41 +1,32 @@
 package org.folio.search.service;
 
-import java.util.Set;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.folio.search.configuration.properties.SearchConfigurationProperties;
 import org.folio.search.domain.dto.LanguageConfig;
 import org.folio.search.model.SearchResource;
 import org.folio.search.service.systemuser.SystemUserService;
 import org.folio.spring.FolioExecutionContext;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Log4j2
 @Service
+@RequiredArgsConstructor
 public class SearchTenantService {
+
   private final IndexService indexService;
   private final FolioExecutionContext context;
-  private final Set<String> initialLanguages;
-  private final LanguageConfigService languageConfigService;
   private final SystemUserService systemUserService;
-
-  public SearchTenantService(IndexService indexService, FolioExecutionContext context,
-    @Value("${application.search-config.initial-languages}") Set<String> initialLanguages,
-    LanguageConfigService languageConfigService, SystemUserService systemUserService) {
-
-    this.indexService = indexService;
-    this.context = context;
-    this.initialLanguages = initialLanguages;
-    this.languageConfigService = languageConfigService;
-    this.systemUserService = systemUserService;
-  }
+  private final LanguageConfigService languageConfigService;
+  private final SearchConfigurationProperties searchConfigurationProperties;
 
   public void initializeTenant() {
     systemUserService.prepareSystemUser();
 
     var existingLanguages = languageConfigService.getAllLanguageCodes();
 
-    log.info("Initializing tenant [initialLanguages={}, existingLanguages={}]",
-      initialLanguages, existingLanguages);
+    var initialLanguages = searchConfigurationProperties.getInitialLanguages();
+    log.info("Initializing tenant [initialLanguages={}, existingLanguages={}]", initialLanguages, existingLanguages);
 
     initialLanguages.stream()
       .filter(code -> !existingLanguages.contains(code))

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -1,5 +1,6 @@
 package org.folio.search.utils;
 
+import static java.util.Locale.ROOT;
 import static java.util.stream.Collectors.joining;
 import static org.folio.search.configuration.properties.FolioEnvironment.getFolioEnvName;
 import static org.folio.search.model.metadata.PlainFieldDescription.STANDARD_FIELD_TYPE;
@@ -80,7 +81,7 @@ public class SearchUtils {
    * @return generated index name.
    */
   public static String getElasticsearchIndexName(String resource, String tenantId) {
-    return getFolioEnvName().toLowerCase() + "_" + resource + "_" + tenantId;
+    return getFolioEnvName().toLowerCase(ROOT) + "_" + resource + "_" + tenantId;
   }
 
   /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,7 @@ spring:
       spec: maximumSize=500,expireAfterAccess=3600s
 
 application:
+  environment: ${ENV:}
   search-config:
     initial-languages: ${INITIAL_LANGUAGES:eng}
   system-user:
@@ -48,8 +49,8 @@ application:
     listener:
       events:
         concurrency: 2
-        topic-pattern: ${KAFKA_EVENTS_CONSUMER_PATTERN:(${ENV:folio}\.)?(.*\.)?inventory.(instance|holdings-record|item)}
-        group-id: ${ENV:folio}-mod-search-events-group
+        topic-pattern: ${KAFKA_EVENTS_CONSUMER_PATTERN:(${application.environment}\.)(.*\.)inventory\.(instance|holdings-record|item)}
+        group-id: ${application.environment}-mod-search-events-group
 
 server.port: 8081
 management.endpoints.web:

--- a/src/test/java/org/folio/search/configuration/properties/FolioEnvironmentTest.java
+++ b/src/test/java/org/folio/search/configuration/properties/FolioEnvironmentTest.java
@@ -1,11 +1,12 @@
 package org.folio.search.configuration.properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.search.configuration.properties.FolioEnvironment.getFolioEnvName;
 import static org.folio.search.utils.TestUtils.removeEnvProperty;
 import static org.folio.search.utils.TestUtils.setEnvProperty;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 @UnitTest
 class FolioEnvironmentTest {
+
   @AfterEach
   void resetEnvPropertyValue() {
     removeEnvProperty();
@@ -22,19 +24,18 @@ class FolioEnvironmentTest {
   @Test
   void shouldReturnFolioEnvFromProperties() {
     setEnvProperty("test-env");
-
     assertThat(getFolioEnvName()).isEqualTo("test-env");
   }
 
   @Test
   void shouldReturnDefaultFolioEnvIfPropertyNotSet() {
-    assertThat(getFolioEnvName()).isEqualTo("folio");
+    assertThat(getFolioEnvName()).isNull();
   }
 
   @Test
   void shouldReturnDefaultFolioEnvIfPropertyIsEmpty() {
     setEnvProperty("   ");
-    assertThat(getFolioEnvName()).isEqualTo("folio");
+    assertThat(getFolioEnvName()).isNull();
   }
 
   @ValueSource(strings = {"a", "Z", "0", "9", "_", "-"})
@@ -44,13 +45,14 @@ class FolioEnvironmentTest {
     assertThat(getFolioEnvName()).isEqualTo(env);
   }
 
-  @ValueSource(strings = {"!", "@", "%$$#", "def qa"})
   @ParameterizedTest
+  @ValueSource(strings = {"!", "@", "%$$#", "def qa"})
   void shouldThrowExceptionWhenEnvHasDisallowedChars(String env) {
-    setEnvProperty(env);
-
-    assertThatThrownBy(FolioEnvironment::getFolioEnvName)
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("Folio ENV must contain alphanumeric and '-', '_' symbols only");
+    var validator = Validation.buildDefaultValidatorFactory().getValidator();
+    var folioEnvironment = FolioEnvironment.of(env);
+    var validationResponse = validator.validate(folioEnvironment);
+    assertThat(validationResponse).isNotEmpty()
+      .map(ConstraintViolation::getMessage)
+      .containsExactly("Value must follow the pattern: '[\\w0-9\\-_]+'");
   }
 }

--- a/src/test/java/org/folio/search/controller/IndexingIT.java
+++ b/src/test/java/org/folio/search/controller/IndexingIT.java
@@ -2,6 +2,8 @@ package org.folio.search.controller;
 
 import static java.util.stream.Collectors.toList;
 import static org.awaitility.Awaitility.await;
+import static org.awaitility.Duration.FIVE_HUNDRED_MILLISECONDS;
+import static org.awaitility.Duration.ONE_MINUTE;
 import static org.folio.search.client.cql.CqlQuery.exactMatchAny;
 import static org.folio.search.support.base.ApiEndpoints.searchInstancesByQuery;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
@@ -75,8 +77,9 @@ class IndexingIT extends BaseIntegrationTest {
   }
 
   private void assertCountByQuery(String query, Object value, int expectedCount) {
-    await().untilAsserted(() -> doGet(searchInstancesByQuery(query), value)
-      .andExpect(jsonPath("totalRecords", is(expectedCount))));
+    await().atMost(ONE_MINUTE).pollInterval(FIVE_HUNDRED_MILLISECONDS).untilAsserted(() ->
+      doGet(searchInstancesByQuery(query), value)
+        .andExpect(jsonPath("totalRecords", is(expectedCount))));
   }
 
   private static List<String> getRandomIds(int count) {

--- a/src/test/java/org/folio/search/repository/IndexRepositoryTest.java
+++ b/src/test/java/org/folio/search/repository/IndexRepositoryTest.java
@@ -76,15 +76,14 @@ class IndexRepositoryTest {
   @Test
   void createIndex_negative_throwsException() throws IOException {
     when(restHighLevelClient.indices()).thenReturn(indices);
-    when(indices.create(any(CreateIndexRequest.class), eq(DEFAULT)))
-      .thenThrow(new IOException("err"));
+    when(indices.create(any(CreateIndexRequest.class), eq(DEFAULT))).thenThrow(new IOException("err"));
 
     assertThatThrownBy(
       () -> indexRepository.createIndex(INDEX_NAME, EMPTY_OBJECT, EMPTY_OBJECT))
       .isInstanceOf(SearchOperationException.class)
       .hasCauseExactlyInstanceOf(IOException.class)
       .hasMessage("Failed to perform elasticsearch request "
-        + "[index=folio_test-resource_test_tenant, type=createIndexApi, message: err]");
+        + "[index=test_test-resource_test_tenant, type=createIndexApi, message: err]");
   }
 
   @Test
@@ -119,7 +118,7 @@ class IndexRepositoryTest {
       .isInstanceOf(SearchOperationException.class)
       .hasCauseExactlyInstanceOf(IOException.class)
       .hasMessage("Failed to perform elasticsearch request "
-        + "[index=folio_test-resource_test_tenant, type=putMappingsApi, message: err]");
+        + "[index=test_test-resource_test_tenant, type=putMappingsApi, message: err]");
   }
 
   @Test
@@ -162,14 +161,13 @@ class IndexRepositoryTest {
   void indexResources_negative_throwsException() throws IOException {
     var documentBody = searchDocumentBody();
     var documentBodies = singletonList(documentBody);
-    when(restHighLevelClient.bulk(any(BulkRequest.class), eq(DEFAULT)))
-      .thenThrow(new IOException("err"));
+    when(restHighLevelClient.bulk(any(BulkRequest.class), eq(DEFAULT))).thenThrow(new IOException("err"));
 
     assertThatThrownBy(() -> indexRepository.indexResources(documentBodies))
       .isInstanceOf(SearchOperationException.class)
       .hasCauseExactlyInstanceOf(IOException.class)
       .hasMessage("Failed to perform elasticsearch request "
-        + "[index=folio_test-resource_test_tenant, type=bulkApi, message: err]");
+        + "[index=test_test-resource_test_tenant, type=bulkApi, message: err]");
   }
 
   @Test

--- a/src/test/java/org/folio/search/repository/SearchRepositoryTest.java
+++ b/src/test/java/org/folio/search/repository/SearchRepositoryTest.java
@@ -35,9 +35,8 @@ import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
-import org.folio.search.domain.dto.Instance;
-import org.folio.search.domain.dto.SearchResult;
 import org.folio.search.model.service.CqlResourceIdsRequest;
+import org.folio.search.utils.EnvironmentUnitTest;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,7 +46,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-class SearchRepositoryTest {
+class SearchRepositoryTest extends EnvironmentUnitTest {
 
   private static final String SCROLL_ID = randomId();
   private static final TimeValue KEEP_ALIVE_INTERVAL = timeValueMinutes(1L);
@@ -58,15 +57,10 @@ class SearchRepositoryTest {
 
   @Test
   void search_positive() throws IOException {
-    var totalResults = 20;
     var searchSource = searchSource();
     var esSearchRequest = new SearchRequest().indices(INDEX_NAME).routing(TENANT_ID).source(searchSource);
 
     when(esClient.search(esSearchRequest, DEFAULT)).thenReturn(searchResponse);
-
-    var expectedResult = new SearchResult();
-    expectedResult.setTotalRecords(totalResults);
-    expectedResult.setInstances(List.of(new Instance()));
 
     var searchRequest = searchServiceRequest(RESOURCE_NAME, "query");
     var actual = searchRepository.search(searchRequest, searchSource);

--- a/src/test/java/org/folio/search/service/IndexServiceTest.java
+++ b/src/test/java/org/folio/search/service/IndexServiceTest.java
@@ -38,6 +38,7 @@ import org.folio.search.repository.IndexRepository;
 import org.folio.search.service.converter.MultiTenantSearchDocumentConverter;
 import org.folio.search.service.es.SearchMappingsHelper;
 import org.folio.search.service.es.SearchSettingsHelper;
+import org.folio.search.utils.EnvironmentUnitTest;
 import org.folio.search.utils.TestUtils;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-class IndexServiceTest {
+class IndexServiceTest extends EnvironmentUnitTest {
 
   private static final String INDEX_NOT_EXISTS_MESSAGE = String.format(INDEX_NOT_EXISTS_ERROR, List.of(INDEX_NAME));
 

--- a/src/test/java/org/folio/search/service/KafkaAdminServiceTest.java
+++ b/src/test/java/org/folio/search/service/KafkaAdminServiceTest.java
@@ -3,7 +3,6 @@ package org.folio.search.service;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.service.KafkaAdminService.EVENT_LISTENER_ID;
-import static org.folio.search.utils.TestConstants.ENV;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -12,16 +11,15 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.folio.search.configuration.properties.FolioEnvironment;
 import org.folio.search.service.KafkaAdminService.KafkaTopic;
 import org.folio.search.service.KafkaAdminService.KafkaTopics;
 import org.folio.search.service.KafkaAdminServiceTest.KafkaAdminServiceTestConfiguration;
-import org.folio.search.utils.TestUtils;
+import org.folio.search.utils.EnvironmentUnitTest;
 import org.folio.search.utils.types.UnitTest;
 import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.integration.XOkapiHeaders;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,7 +35,7 @@ import org.springframework.kafka.listener.MessageListenerContainer;
 @UnitTest
 @Import(KafkaAdminServiceTestConfiguration.class)
 @SpringBootTest(classes = KafkaAdminService.class)
-class KafkaAdminServiceTest {
+class KafkaAdminServiceTest extends EnvironmentUnitTest {
 
   private final List<KafkaTopic> expectedTopics = List.of(
     KafkaTopic.of("topic1", 20, (short) 1),
@@ -55,16 +53,6 @@ class KafkaAdminServiceTest {
   @MockBean private KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
   @MockBean private LocalFileProvider localFileProvider;
   @MockBean private KafkaAdmin kafkaAdmin;
-
-  @BeforeAll
-  static void beforeAll() {
-    TestUtils.setEnvProperty(ENV);
-  }
-
-  @AfterAll
-  static void afterAll() {
-    TestUtils.removeEnvProperty();
-  }
 
   @Test
   void createKafkaTopics() {
@@ -108,6 +96,13 @@ class KafkaAdminServiceTest {
     @Bean
     FolioExecutionContext folioExecutionContext() {
       return new DefaultFolioExecutionContext(null, Map.of(XOkapiHeaders.TENANT, List.of(TENANT_ID)));
+    }
+
+    @Bean
+    FolioEnvironment appConfigurationProperties() {
+      var config = new FolioEnvironment();
+      config.setEnvironment("folio");
+      return config;
     }
   }
 }

--- a/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
+++ b/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
@@ -1,56 +1,58 @@
 package org.folio.search.service;
 
 import static org.folio.search.model.SearchResource.INSTANCE;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Set;
+import org.folio.search.configuration.properties.SearchConfigurationProperties;
 import org.folio.search.domain.dto.LanguageConfig;
 import org.folio.search.service.systemuser.SystemUserService;
 import org.folio.search.utils.types.UnitTest;
 import org.folio.spring.FolioExecutionContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 class SearchTenantServiceTest {
-  private static final String TENANT_NAME = "tenant";
-  @Mock
-  private IndexService indexService;
-  @Mock
-  private FolioExecutionContext context;
-  @Mock
-  private LanguageConfigService languageConfigService;
-  @Mock
-  private SystemUserService systemUserService;
+
+  @InjectMocks private SearchTenantService searchTenantService;
+  @Mock private IndexService indexService;
+  @Mock private FolioExecutionContext context;
+  @Mock private SystemUserService systemUserService;
+  @Mock private LanguageConfigService languageConfigService;
+  @Mock private SearchConfigurationProperties searchConfigurationProperties;
 
   @Test
   void initializeTenant_positive() {
-    var service = new SearchTenantService(indexService, context, Set.of("eng"),
-      languageConfigService, systemUserService);
-    when(context.getTenantId()).thenReturn(TENANT_NAME);
+    when(searchConfigurationProperties.getInitialLanguages()).thenReturn(Set.of("eng"));
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    doNothing().when(systemUserService).prepareSystemUser();
 
-    service.initializeTenant();
+    searchTenantService.initializeTenant();
 
     verify(languageConfigService).create(new LanguageConfig().code("eng"));
-    verify(indexService).createIndexIfNotExist(INSTANCE.getName(), TENANT_NAME);
+    verify(indexService).createIndexIfNotExist(INSTANCE.getName(), TENANT_ID);
   }
 
   @Test
   void initializeTenant_shouldNotCreateLanguageIfAlreadyExist() {
-    var service = new SearchTenantService(indexService, context, Set.of("eng", "fre"),
-      languageConfigService, systemUserService);
-    when(context.getTenantId()).thenReturn(TENANT_NAME);
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(searchConfigurationProperties.getInitialLanguages()).thenReturn(Set.of("eng", "fre"));
     when(languageConfigService.getAllLanguageCodes()).thenReturn(Set.of("eng"));
+    doNothing().when(systemUserService).prepareSystemUser();
 
-    service.initializeTenant();
+    searchTenantService.initializeTenant();
 
     verify(languageConfigService, times(0)).create(new LanguageConfig().code("eng"));
     verify(languageConfigService).create(new LanguageConfig().code("fre"));
-    verify(indexService).createIndexIfNotExist(INSTANCE.getName(), TENANT_NAME);
+    verify(indexService).createIndexIfNotExist(INSTANCE.getName(), TENANT_ID);
   }
 }

--- a/src/test/java/org/folio/search/service/converter/MultiTenantSearchDocumentConverterTest.java
+++ b/src/test/java/org/folio/search/service/converter/MultiTenantSearchDocumentConverterTest.java
@@ -27,6 +27,7 @@ import org.folio.search.model.SearchDocumentBody;
 import org.folio.search.model.service.ResourceIdEvent;
 import org.folio.search.model.types.IndexActionType;
 import org.folio.search.service.TenantScopedExecutionService;
+import org.folio.search.utils.EnvironmentUnitTest;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,7 +37,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-class MultiTenantSearchDocumentConverterTest {
+class MultiTenantSearchDocumentConverterTest extends EnvironmentUnitTest {
+
   @Mock private SearchDocumentConverter searchDocumentConverter;
   @Mock private TenantScopedExecutionService executionService;
   @InjectMocks private MultiTenantSearchDocumentConverter multiTenantConverter;

--- a/src/test/java/org/folio/search/service/converter/SearchDocumentConverterTest.java
+++ b/src/test/java/org/folio/search/service/converter/SearchDocumentConverterTest.java
@@ -34,6 +34,7 @@ import org.folio.search.model.SearchDocumentBody;
 import org.folio.search.model.metadata.FieldDescription;
 import org.folio.search.service.LanguageConfigService;
 import org.folio.search.service.metadata.ResourceDescriptionService;
+import org.folio.search.utils.EnvironmentUnitTest;
 import org.folio.search.utils.JsonConverter;
 import org.folio.search.utils.TestUtils;
 import org.folio.search.utils.types.UnitTest;
@@ -46,7 +47,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-class SearchDocumentConverterTest {
+class SearchDocumentConverterTest extends EnvironmentUnitTest {
 
   @InjectMocks private SearchDocumentConverter documentMapper;
   @Mock private ResourceDescriptionService descriptionService;

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -46,9 +46,9 @@ import org.springframework.test.web.servlet.ResultActions;
 @EnableOkapi
 @EnableKafka
 @EnablePostgres
+@SpringBootTest
 @EnableElasticSearch
 @AutoConfigureMockMvc
-@SpringBootTest(properties = {"ENV=folio"})
 public abstract class BaseIntegrationTest {
   protected static InventoryApi inventoryApi;
   private static OkapiConfiguration okapi;
@@ -57,7 +57,7 @@ public abstract class BaseIntegrationTest {
   @BeforeAll
   static void setUpDefaultTenant(@Autowired MockMvc mockMvc,
     @Autowired KafkaTemplate<String, Object> kafkaTemplate) {
-    setEnvProperty("folio");
+    setEnvProperty("folio-test");
     inventoryApi = new InventoryApi(kafkaTemplate);
     setUpTenant(TENANT_ID, mockMvc, getSemanticWeb());
   }

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -1,11 +1,13 @@
 package org.folio.search.support.base;
 
 import static org.awaitility.Awaitility.await;
+import static org.awaitility.Duration.ONE_MINUTE;
+import static org.awaitility.Duration.TWO_HUNDRED_MILLISECONDS;
 import static org.folio.search.sample.SampleInstances.getSemanticWeb;
-import static org.folio.search.support.base.ApiEndpoints.searchInstancesByQuery;
 import static org.folio.search.utils.SearchUtils.X_OKAPI_TENANT_HEADER;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.asJsonString;
+import static org.folio.search.utils.TestUtils.setEnvProperty;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -19,7 +21,6 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
-import org.awaitility.Duration;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.support.api.InventoryApi;
 import org.folio.search.support.extension.EnableElasticSearch;
@@ -42,12 +43,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @Log4j2
-@SpringBootTest
-@AutoConfigureMockMvc
-@EnablePostgres
-@EnableKafka
-@EnableElasticSearch
 @EnableOkapi
+@EnableKafka
+@EnablePostgres
+@EnableElasticSearch
+@AutoConfigureMockMvc
+@SpringBootTest(properties = {"ENV=folio"})
 public abstract class BaseIntegrationTest {
   protected static InventoryApi inventoryApi;
   private static OkapiConfiguration okapi;
@@ -56,6 +57,7 @@ public abstract class BaseIntegrationTest {
   @BeforeAll
   static void setUpDefaultTenant(@Autowired MockMvc mockMvc,
     @Autowired KafkaTemplate<String, Object> kafkaTemplate) {
+    setEnvProperty("folio");
     inventoryApi = new InventoryApi(kafkaTemplate);
     setUpTenant(TENANT_ID, mockMvc, getSemanticWeb());
   }
@@ -86,15 +88,12 @@ public abstract class BaseIntegrationTest {
     return httpHeaders;
   }
 
-  private static void checkThatElasticsearchAcceptResourcesFromKafka(
-    String tenant, MockMvc mockMvc, String id) {
-
-    await().atMost(Duration.ONE_MINUTE).pollInterval(Duration.ONE_SECOND).untilAsserted(() ->
-      mockMvc.perform(get(searchInstancesByQuery("id={value}"), id)
-        .headers(defaultHeaders(tenant)))
+  private static void checkThatElasticsearchAcceptResourcesFromKafka(String tenant, MockMvc mockMvc, int size) {
+    await().atMost(ONE_MINUTE).pollInterval(TWO_HUNDRED_MILLISECONDS).untilAsserted(() ->
+      mockMvc.perform(get("/search/instances").param("query", "id=*").param("limit", "1")
+          .headers(defaultHeaders(tenant)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("totalRecords", is(1)))
-        .andExpect(jsonPath("instances[0].id", is(id))));
+        .andExpect(jsonPath("$.totalRecords", is(size))));
   }
 
   @SneakyThrows
@@ -163,8 +162,7 @@ public abstract class BaseIntegrationTest {
     }
 
     if (instances.length > 0) {
-      checkThatElasticsearchAcceptResourcesFromKafka(tenantName, mockMvc,
-        instances[instances.length - 1].getId());
+      checkThatElasticsearchAcceptResourcesFromKafka(tenantName, mockMvc, instances.length);
     }
   }
 

--- a/src/test/java/org/folio/search/utils/EnvironmentUnitTest.java
+++ b/src/test/java/org/folio/search/utils/EnvironmentUnitTest.java
@@ -7,7 +7,7 @@ import static org.folio.search.utils.TestUtils.setEnvProperty;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
-public class EnvironmentUnitTest {
+public abstract class EnvironmentUnitTest {
 
   @BeforeAll
   static void beforeAll() {

--- a/src/test/java/org/folio/search/utils/EnvironmentUnitTest.java
+++ b/src/test/java/org/folio/search/utils/EnvironmentUnitTest.java
@@ -1,0 +1,21 @@
+package org.folio.search.utils;
+
+import static org.folio.search.utils.TestConstants.ENV;
+import static org.folio.search.utils.TestUtils.removeEnvProperty;
+import static org.folio.search.utils.TestUtils.setEnvProperty;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public class EnvironmentUnitTest {
+
+  @BeforeAll
+  static void beforeAll() {
+    setEnvProperty(ENV);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    removeEnvProperty();
+  }
+}

--- a/src/test/java/org/folio/search/utils/SearchUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchUtilsTest.java
@@ -15,7 +15,6 @@ import static org.folio.search.utils.TestUtils.mapOf;
 import static org.folio.search.utils.TestUtils.multilangField;
 import static org.folio.search.utils.TestUtils.plainField;
 import static org.folio.search.utils.TestUtils.randomId;
-import static org.folio.search.utils.TestUtils.removeEnvProperty;
 import static org.folio.search.utils.TestUtils.searchServiceRequest;
 import static org.folio.search.utils.TestUtils.standardFulltextField;
 
@@ -25,19 +24,13 @@ import org.folio.search.exception.SearchOperationException;
 import org.folio.search.model.service.ResourceIdEvent;
 import org.folio.search.model.types.IndexActionType;
 import org.folio.search.utils.types.UnitTest;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 @UnitTest
-class SearchUtilsTest {
-
-  @AfterEach
-  void resetEnvPropertyValue() {
-    removeEnvProperty();
-  }
+class SearchUtilsTest extends EnvironmentUnitTest {
 
   @Test
   void performExceptionalOperation_positive() {

--- a/src/test/java/org/folio/search/utils/TestConstants.java
+++ b/src/test/java/org/folio/search/utils/TestConstants.java
@@ -9,15 +9,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TestConstants {
 
-  public static final String EMPTY_OBJECT = "{}";
-  public static final String RESOURCE_ID = "test_tenant";
   public static final String ENV = "test";
   public static final String TENANT_ID = "test_tenant";
+  public static final String RESOURCE_ID = "test_tenant";
+  public static final String EMPTY_OBJECT = "{}";
   public static final String RESOURCE_NAME = "test-resource";
-  public static final String INDEX_NAME = "folio_" + RESOURCE_NAME + "_" + TENANT_ID;
+  public static final String INDEX_NAME = String.join("_", ENV, RESOURCE_NAME, TENANT_ID);
+
+  public static final String INVENTORY_ITEM_TOPIC = "inventory.item";
   public static final String INVENTORY_INSTANCE_TOPIC = "inventory.instance";
   public static final String INVENTORY_HOLDING_TOPIC = "inventory.holdings-record";
-  public static final String INVENTORY_ITEM_TOPIC = "inventory.item";
+
   public static final String ISBN_IDENTIFIER_TYPE_ID = randomId();
   public static final String UNIFORM_ALTERNATIVE_TITLE_ID = randomId();
   public static final String INVALID_ISBN_IDENTIFIER_TYPE_ID = randomId();

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -24,9 +24,9 @@ spring:
       spec: maximumSize=500,expireAfterAccess=3600s
 
 server.port: 8081
-folio.tenant.validation.enabled: true
 
 application:
+  environment: folio
   search-config:
     initial-languages: eng,fre,ita,spa,ger
   system-user:
@@ -38,8 +38,8 @@ application:
     listener:
       events:
         concurrency: 2
-        topic-pattern: ${KAFKA_EVENTS_CONSUMER_PATTERN:(${ENV:folio}\.)?(.*\.)?inventory.(instance|holdings-record|item)}
-        group-id: ${ENV:folio}-mod-search-events-group
+        topic-pattern: ${KAFKA_EVENTS_CONSUMER_PATTERN:(${application.environment}\.)(.*\.)inventory\.(instance|holdings-record|item)}
+        group-id: ${application.environment}-mod-search-events-group
 
 logging:
   level:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -26,7 +26,7 @@ spring:
 server.port: 8081
 
 application:
-  environment: folio
+  environment: folio-test
   search-config:
     initial-languages: eng,fre,ita,spa,ger
   system-user:


### PR DESCRIPTION
### Purpose
Backward compatible solutions bring to Falcon a lot of problems with shared Kafka. Removing it would affect previous releases, but in the future, it will guarantee that the specified environment can receive only correct messages. Also, making the `ENV` variable mandatory can be signal for dev-ops team that something is not set up correctly.

### Approach

- Remove optional ENV variable with a default value and rewrite validation to use Spring Validation instead of an imperative solution
- Remove backward-compatible approach for Kafka consumers
- Update documentation for `ENV` variable
- Add Spring configuration processor to make the configuration more developer-friendly
- Refactor configuration properties to unify with existing solutions
- Update unit tests after refactoring ENV variable
- Fix integration tests and refactor validation for uploaded resources