### PR TITLE
MSEARCH-163 Unhandled error when reindex has empty request body

### DIFF
--- a/src/main/java/org/folio/search/controller/ApiExceptionHandler.java
+++ b/src/main/java/org/folio/search/controller/ApiExceptionHandler.java
@@ -34,6 +34,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -153,6 +154,8 @@ public class ApiExceptionHandler {
   @ExceptionHandler(ValidationException.class)
   public ResponseEntity<ErrorResponse> handleValidationException(ValidationException exception) {
     var error = new Error()
+      .type(ValidationException.class.getSimpleName())
+      .code(VALIDATION_ERROR.getValue())
       .message(exception.getMessage())
       .parameters(List.of(new Parameter().key(exception.getKey()).value(exception.getValue())));
     var errorResponse = new ErrorResponse().errors(List.of(error)).totalRecords(1);
@@ -160,7 +163,7 @@ public class ApiExceptionHandler {
   }
 
   /**
-   * Catches and handles all exceptions of type {@link IllegalArgumentException}.
+   * Catches and handles all {@link IllegalArgumentException} exceptions.
    *
    * @param exception {@link IllegalArgumentException} to process
    * @return {@link ResponseEntity} with {@link ValidationException} body
@@ -172,15 +175,27 @@ public class ApiExceptionHandler {
   }
 
   /**
-   * Handles all uncaught exceptions.
+   * Handles all {@link EntityNotFoundException} exceptions.
    *
-   * @param exception {@link Exception} object
+   * @param exception {@link EntityNotFoundException} object
    * @return {@link ResponseEntity} with {@link ErrorResponse} body.
    */
   @ExceptionHandler(EntityNotFoundException.class)
   public ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException exception) {
     logException(WARN, exception);
     return buildResponseEntity(exception, NOT_FOUND, NOT_FOUND_ERROR);
+  }
+
+  /**
+   * Handles all {@link HttpMediaTypeNotSupportedException} exceptions.
+   *
+   * @param e {@link HttpMediaTypeNotSupportedException} object
+   * @return {@link ResponseEntity} with {@link ErrorResponse} body.
+   */
+  @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+  public ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException e) {
+    logException(DEBUG, e);
+    return buildResponseEntity(e, BAD_REQUEST, VALIDATION_ERROR);
   }
 
   /**

--- a/src/test/java/org/folio/search/service/LocalFileProviderTest.java
+++ b/src/test/java/org/folio/search/service/LocalFileProviderTest.java
@@ -1,5 +1,6 @@
 package org.folio.search.service;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.utils.JsonConverter.MAP_TYPE_REFERENCE;
 import static org.folio.search.utils.JsonUtils.jsonObject;
@@ -8,16 +9,20 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.io.IOUtils;
 import org.folio.search.utils.JsonConverter;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -60,6 +65,17 @@ class LocalFileProviderTest {
     var actual = resourceService.readAsObject("test-resources/test-json.json", MAP_TYPE_REFERENCE);
     assertThat(actual).isEqualTo(Map.of("key", "value"));
     verify(jsonConverter).readJson(any(InputStream.class), eq(MAP_TYPE_REFERENCE));
+  }
+
+  @Test
+  void readString_negative_throwsException() {
+    var url = LocalFileProvider.class.getClassLoader().getResource("test-resources/test-file.txt");
+    assertThat(url).isNotNull();
+    try (var utilities = Mockito.mockStatic(IOUtils.class)) {
+      utilities.when(() -> IOUtils.toString(any(URL.class), eq(UTF_8))).thenThrow(new IOException("error"));
+      var result = resourceService.read("test-resources/test-file.txt");
+      assertThat(result).isNull();
+    }
   }
 
   @Data

--- a/src/test/java/org/folio/search/service/TenantScopedExecutionServiceTest.java
+++ b/src/test/java/org/folio/search/service/TenantScopedExecutionServiceTest.java
@@ -1,0 +1,54 @@
+package org.folio.search.service;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.Callable;
+import org.folio.search.model.SystemUser;
+import org.folio.search.service.context.FolioExecutionContextBuilder;
+import org.folio.search.service.systemuser.SystemUserService;
+import org.folio.search.utils.types.UnitTest;
+import org.folio.spring.DefaultFolioExecutionContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class TenantScopedExecutionServiceTest {
+
+  @InjectMocks private TenantScopedExecutionService tenantScopedExecutionService;
+  @Mock private FolioExecutionContextBuilder contextBuilder;
+  @Mock private SystemUserService systemUserService;
+
+  @Test
+  void executeTenantScoped_positive() {
+    var systemUser = SystemUser.builder().build();
+    when(systemUserService.getSystemUser(TENANT_ID)).thenReturn(systemUser);
+    when(contextBuilder.forSystemUser(systemUser)).thenReturn(new DefaultFolioExecutionContext(null, emptyMap()));
+
+    var actual = tenantScopedExecutionService.executeTenantScoped(TENANT_ID, () -> "result");
+
+    assertThat(actual).isEqualTo("result");
+  }
+
+  @Test
+  void executeTenantScoped_negative_throwsException() {
+    var systemUser = SystemUser.builder().build();
+    when(systemUserService.getSystemUser(TENANT_ID)).thenReturn(systemUser);
+    when(contextBuilder.forSystemUser(systemUser)).thenReturn(new DefaultFolioExecutionContext(null, emptyMap()));
+
+    Callable<Object> callable = () -> {
+      throw new Exception("error");
+    };
+
+    assertThatThrownBy(() -> tenantScopedExecutionService.executeTenantScoped(TENANT_ID, callable))
+      .isInstanceOf(Exception.class)
+      .hasMessage("error");
+  }
+}

--- a/src/test/java/org/folio/search/service/setter/holding/HoldingIdentifiersProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/holding/HoldingIdentifiersProcessorTest.java
@@ -1,0 +1,56 @@
+package org.folio.search.service.setter.holding;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.TestUtils.randomId;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.folio.search.domain.dto.Holding;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@UnitTest
+class HoldingIdentifiersProcessorTest {
+
+  private static final List<String> FORMER_IDS = List.of(randomId(), randomId());
+  private final HoldingIdentifiersProcessor itemIdentifiersProcessor = new HoldingIdentifiersProcessor();
+
+  @MethodSource("testDataProvider")
+  @DisplayName("getFieldValue_parameterized")
+  @ParameterizedTest(name = "[{index}] instance with {0}, expected={2}")
+  void getFieldValue_parameterized(@SuppressWarnings("unused") String name, Instance eventBody, List<String> expected) {
+    var actual = itemIdentifiersProcessor.getFieldValue(eventBody);
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  private static Stream<Arguments> testDataProvider() {
+    return Stream.of(
+      arguments("all empty fields", new Instance(), emptyList()),
+      arguments("empty items", instance(), emptyList()),
+      arguments("holding with nullable identifier fields", instance(holding(null, null)), emptyList()),
+      arguments("holding with hrid only", instance(holding("h01", null)), List.of("h01")),
+      arguments("holding with empty identifiers", instance(holding("", emptyList())), emptyList()),
+      arguments("holding with hrid and empty list in formerIds", instance(holding("h01", emptyList())), List.of("h01")),
+      arguments("holding with single formerId", instance(holding(null, List.of("id1"))), List.of("id1")),
+      arguments("holding with multiple formerIds", instance(holding(null, FORMER_IDS)), FORMER_IDS),
+      arguments("holding with all identifiers", instance(holding("h01", List.of("fid"))), List.of("h01", "fid")),
+      arguments("2 duplicated holdings", instance(
+        holding("h01", List.of("fid")), holding("h01", List.of("fid"))), List.of("h01", "fid"))
+    );
+  }
+
+  private static Instance instance(Holding... holdings) {
+    return new Instance().holdings(holdings != null ? Arrays.asList(holdings) : null);
+  }
+
+  private static Holding holding(String hrid, List<String> formerIds) {
+    return new Holding().hrid(hrid).formerIds(formerIds);
+  }
+}

--- a/src/test/java/org/folio/search/service/setter/item/ItemIdentifiersProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemIdentifiersProcessorTest.java
@@ -1,0 +1,57 @@
+package org.folio.search.service.setter.item;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.TestUtils.randomId;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Item;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@UnitTest
+class ItemIdentifiersProcessorTest {
+
+  private static final List<String> FORMER_IDS = List.of(randomId(), randomId());
+  private final ItemIdentifiersProcessor itemIdentifiersProcessor = new ItemIdentifiersProcessor();
+
+  @MethodSource("testDataProvider")
+  @DisplayName("getFieldValue_parameterized")
+  @ParameterizedTest(name = "[{index}] instance with {0}, expected={2}")
+  void getFieldValue_parameterized(@SuppressWarnings("unused") String name, Instance eventBody, List<String> expected) {
+    var actual = itemIdentifiersProcessor.getFieldValue(eventBody);
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  private static Stream<Arguments> testDataProvider() {
+    return Stream.of(
+      arguments("all empty fields", new Instance(), emptyList()),
+      arguments("empty items", instance(), emptyList()),
+      arguments("item with nullable identifier fields", instance(item(null, null, null)), emptyList()),
+      arguments("item with hrid only", instance(item("i1", null, null)), List.of("i1")),
+      arguments("item with accessionNumber only", instance(item(null, "an", null)), List.of("an")),
+      arguments("item with empty identifiers", instance(item("", "", emptyList())), emptyList()),
+      arguments("item with hrid and empty list in formerIds", instance(item("i1", null, emptyList())), List.of("i1")),
+      arguments("item with single formerId", instance(item(null, null, List.of("id1"))), List.of("id1")),
+      arguments("item with multiple formerIds", instance(item(null, null, FORMER_IDS)), FORMER_IDS),
+      arguments("item with all identifiers", instance(item("i01", "an", List.of("fid"))), List.of("i01", "an", "fid")),
+      arguments("2 duplicated items", instance(
+        item("i01", "an", List.of("fid")), item("i01", "an", List.of("fid"))), List.of("i01", "an", "fid"))
+    );
+  }
+
+  private static Instance instance(Item... items) {
+    return new Instance().items(items != null ? Arrays.asList(items) : null);
+  }
+
+  private static Item item(String hrid, String accessionNumber, List<String> formerIds) {
+    return new Item().hrid(hrid).accessionNumber(accessionNumber).formerIds(formerIds);
+  }
+}


### PR DESCRIPTION
### Purpose

The reindex request has changed and requires now its body to contain the property `recreateIndex`.  When a request is sent without `content-type` header - 500 status code is returned

### Approach
- Add the error handling method for `HttpMediaTypeNotSupportedException` in `ApiExceptionHandler.class`
- Increase code coverage for uncovered lines