### PR TITLE
MSEARCH-173 Decrease the retry timeout

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,8 +44,8 @@ application:
     lastname: System
     permissionsFilePath: permissions/mod-search.csv
   kafka:
-    retry-interval-ms: 20000
-    retry-delivery-attempts: 10
+    retry-interval-ms: ${KAFKA_RETRY_INTERVAL_MS:2000}
+    retry-delivery-attempts: ${KAFKA_RETRY_DELIVERY_ATTEMPTS:6}
     listener:
       events:
         concurrency: 2

--- a/src/test/java/org/folio/search/service/IndexServiceTest.java
+++ b/src/test/java/org/folio/search/service/IndexServiceTest.java
@@ -231,13 +231,15 @@ class IndexServiceTest {
   @Test
   void cannotIndexResourcesById_indexNotExist() {
     var eventIds = List.of(ResourceIdEvent.of(randomId(), RESOURCE_NAME, TENANT_ID, INDEX));
+
     when(indexRepository.indexExists(INDEX_NAME)).thenReturn(false);
+    when(fetchService.fetchInstancesByIds(null)).thenReturn(emptyList());
+    when(searchDocumentConverter.convertDeleteEventsAsMap(null)).thenReturn(emptyMap());
+    when(searchDocumentConverter.convertIndexEventsAsMap(emptyList())).thenReturn(emptyMap());
+    when(indexRepository.indexResources(emptyList())).thenReturn(getSuccessIndexOperationResponse());
 
-    assertThatThrownBy(() -> indexService.indexResourcesById(eventIds))
-      .isInstanceOf(SearchServiceException.class)
-      .hasMessage(INDEX_NOT_EXISTS_MESSAGE);
+    var actual = indexService.indexResourcesById(eventIds);
 
-    verifyNoInteractions(searchDocumentConverter);
-    verify(indexRepository, times(0)).indexResources(any());
+    assertThat(actual).isEqualTo(getSuccessIndexOperationResponse());
   }
 }


### PR DESCRIPTION
### Purpose/Overview:

Current retry settings for failed messages are

```
application:
  kafka:
    retry-interval-ms: 20000
    retry-delivery-attempts: 10
```
This leads that initial bulk processed with a time equal to:

```10 * 20 sec = 200 sec ```
and then, if it's failing every message is processed with the same amount of time. So the gracefully handled bulk processed with time:

```200s + 50 (amount of messages in bulk) * 10 * 20 sec = 10200 sec = 170 min```

This value must be decreased to 10 minutes to not stop the processing of messages for a long time. The current implementation will log every unprocessed message.

### Requirements/Scope:

Kafka settings: retry-interval-ms and retry-delivery-attempts must be decreased
- `retry-interval-ms` must be set to 2000
- `retry-delivery-attempts` must be set to 6
- Make these options configurable by setting environment variables: KAFKA_RETRY_INTERVAL_MS and KAFKA_RETRY_DELIVERY_ATTEMPTS

### Approach
- Ignore events when related Elasticsearch index does not exist (they won't be processed anyway), but they will be still logged to maintain observability
- Update configuration properties