### PR TITLE
MSEARCH-174 Investigate indexing issues in reference environment

### DIFF
--- a/src/main/java/org/folio/search/controller/FolioTenantController.java
+++ b/src/main/java/org/folio/search/controller/FolioTenantController.java
@@ -1,8 +1,14 @@
 package org.folio.search.controller;
 
+import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
+
+import java.util.Collection;
+import java.util.stream.Stream;
 import lombok.extern.log4j.Log4j2;
+import org.folio.search.service.IndexService;
 import org.folio.search.service.KafkaAdminService;
 import org.folio.search.service.SearchTenantService;
+import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.controller.TenantController;
 import org.folio.spring.service.TenantService;
 import org.folio.tenant.domain.dto.TenantAttributes;
@@ -16,15 +22,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController("folioTenantController")
 public class FolioTenantController extends TenantController {
 
+  private static final String REINDEX_PARAM_NAME = "runReindex";
+
   private final KafkaAdminService kafkaAdminService;
   private final SearchTenantService tenantService;
+  private final IndexService indexService;
+  private final FolioExecutionContext context;
+
 
   public FolioTenantController(TenantService baseTenantService,
-    KafkaAdminService kafkaAdminService, SearchTenantService tenantService) {
+                               KafkaAdminService kafkaAdminService, SearchTenantService tenantService,
+                               IndexService indexService, FolioExecutionContext context) {
 
     super(baseTenantService);
     this.kafkaAdminService = kafkaAdminService;
     this.tenantService = tenantService;
+    this.indexService = indexService;
+    this.context = context;
   }
 
   @Override
@@ -36,6 +50,14 @@ public class FolioTenantController extends TenantController {
 
     if (tenantInit.getStatusCode() == HttpStatus.OK) {
       tenantService.initializeTenant();
+
+      Stream.ofNullable(tenantAttributes.getParameters()).flatMap(Collection::stream)
+        .filter(parameter -> parameter.getKey().equals(REINDEX_PARAM_NAME)
+          && Boolean.parseBoolean(parameter.getValue()))
+        .findFirst().ifPresent(parameter -> {
+          indexService.dropIndex(INSTANCE_RESOURCE, context.getTenantId());
+          indexService.createIndex(INSTANCE_RESOURCE, context.getTenantId());
+        });
     }
 
     log.info("Tenant init has been completed [response={}]", tenantInit);

--- a/src/main/java/org/folio/search/controller/FolioTenantController.java
+++ b/src/main/java/org/folio/search/controller/FolioTenantController.java
@@ -34,8 +34,7 @@ public class FolioTenantController extends TenantController {
     var tenantInit = super.postTenant(tenantAttributes);
 
     if (tenantInit.getStatusCode() == HttpStatus.OK) {
-      tenantService.initializeTenant();
-      tenantService.reIndexInstances(tenantAttributes);
+      tenantService.initializeTenant(tenantAttributes);
     }
 
     log.info("Tenant init has been completed [response={}]", tenantInit);

--- a/src/main/java/org/folio/search/service/SearchTenantService.java
+++ b/src/main/java/org/folio/search/service/SearchTenantService.java
@@ -1,5 +1,7 @@
 package org.folio.search.service;
 
+import java.util.Collection;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.search.configuration.properties.SearchConfigurationProperties;
@@ -7,12 +9,14 @@ import org.folio.search.domain.dto.LanguageConfig;
 import org.folio.search.model.SearchResource;
 import org.folio.search.service.systemuser.SystemUserService;
 import org.folio.spring.FolioExecutionContext;
+import org.folio.tenant.domain.dto.TenantAttributes;
 import org.springframework.stereotype.Service;
 
 @Log4j2
 @Service
 @RequiredArgsConstructor
 public class SearchTenantService {
+  private static final String REINDEX_PARAM_NAME = "runReindex";
 
   private final IndexService indexService;
   private final FolioExecutionContext context;
@@ -45,5 +49,12 @@ public class SearchTenantService {
 
       indexService.dropIndex(resource.getName(), context.getTenantId());
     }
+  }
+
+  public void reIndexInstances(TenantAttributes tenantAttributes) {
+    Stream.ofNullable(tenantAttributes.getParameters()).flatMap(Collection::stream)
+      .filter(parameter -> parameter.getKey().equals(REINDEX_PARAM_NAME)
+        && Boolean.parseBoolean(parameter.getValue()))
+      .findFirst().ifPresent(parameter -> indexService.reindexInventory(context.getTenantId(), null));
   }
 }

--- a/src/test/java/org/folio/search/controller/FolioTenantControllerTest.java
+++ b/src/test/java/org/folio/search/controller/FolioTenantControllerTest.java
@@ -31,8 +31,7 @@ class FolioTenantControllerTest {
   void postTenant_shouldCallTenantInitialize() {
     tenantController.postTenant(TENANT_ATTRIBUTES);
 
-    verify(tenantService).initializeTenant();
-    verify(tenantService).reIndexInstances(TENANT_ATTRIBUTES);
+    verify(tenantService).initializeTenant(TENANT_ATTRIBUTES);
     verify(kafkaAdminService).createKafkaTopics();
     verify(kafkaAdminService).restartEventListeners();
   }

--- a/src/test/java/org/folio/search/controller/FolioTenantControllerTest.java
+++ b/src/test/java/org/folio/search/controller/FolioTenantControllerTest.java
@@ -1,18 +1,14 @@
 package org.folio.search.controller;
 
-import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import liquibase.exception.LiquibaseException;
-import org.folio.search.service.IndexService;
 import org.folio.search.service.KafkaAdminService;
 import org.folio.search.service.SearchTenantService;
 import org.folio.search.utils.types.UnitTest;
-import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.service.TenantService;
-import org.folio.tenant.domain.dto.Parameter;
 import org.folio.tenant.domain.dto.TenantAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,8 +25,6 @@ class FolioTenantControllerTest {
   @Mock private SearchTenantService tenantService;
   @Mock private TenantService baseTenantService;
   @Mock private KafkaAdminService kafkaAdminService;
-  @Mock private IndexService indexService;
-  @Mock private FolioExecutionContext context;
   @InjectMocks private FolioTenantController tenantController;
 
   @Test
@@ -38,6 +32,7 @@ class FolioTenantControllerTest {
     tenantController.postTenant(TENANT_ATTRIBUTES);
 
     verify(tenantService).initializeTenant();
+    verify(tenantService).reIndexInstances(TENANT_ATTRIBUTES);
     verify(kafkaAdminService).createKafkaTopics();
     verify(kafkaAdminService).restartEventListeners();
   }
@@ -56,18 +51,5 @@ class FolioTenantControllerTest {
     tenantController.deleteTenant();
 
     verify(tenantService).removeElasticsearchIndexes();
-  }
-
-  @Test
-  void shouldRunReindexOnTenantParamPresent() {
-    tenantController.postTenant(TENANT_ATTRIBUTES.addParametersItem(new Parameter().key("runReindex").value("true")));
-    verify(indexService).dropIndex(INSTANCE_RESOURCE, null);
-    verify(indexService).createIndex(INSTANCE_RESOURCE, null);
-  }
-
-  @Test
-  void shouldNotRunReindexOnTenantParamNotPresent() {
-    tenantController.postTenant(TENANT_ATTRIBUTES);
-    verifyNoInteractions(indexService);
   }
 }

--- a/src/test/java/org/folio/search/controller/FolioTenantControllerTest.java
+++ b/src/test/java/org/folio/search/controller/FolioTenantControllerTest.java
@@ -1,14 +1,18 @@
 package org.folio.search.controller;
 
+import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import liquibase.exception.LiquibaseException;
+import org.folio.search.service.IndexService;
 import org.folio.search.service.KafkaAdminService;
 import org.folio.search.service.SearchTenantService;
 import org.folio.search.utils.types.UnitTest;
+import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.service.TenantService;
+import org.folio.tenant.domain.dto.Parameter;
 import org.folio.tenant.domain.dto.TenantAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +29,8 @@ class FolioTenantControllerTest {
   @Mock private SearchTenantService tenantService;
   @Mock private TenantService baseTenantService;
   @Mock private KafkaAdminService kafkaAdminService;
+  @Mock private IndexService indexService;
+  @Mock private FolioExecutionContext context;
   @InjectMocks private FolioTenantController tenantController;
 
   @Test
@@ -50,5 +56,18 @@ class FolioTenantControllerTest {
     tenantController.deleteTenant();
 
     verify(tenantService).removeElasticsearchIndexes();
+  }
+
+  @Test
+  void shouldRunReindexOnTenantParamPresent() {
+    tenantController.postTenant(TENANT_ATTRIBUTES.addParametersItem(new Parameter().key("runReindex").value("true")));
+    verify(indexService).dropIndex(INSTANCE_RESOURCE, null);
+    verify(indexService).createIndex(INSTANCE_RESOURCE, null);
+  }
+
+  @Test
+  void shouldNotRunReindexOnTenantParamNotPresent() {
+    tenantController.postTenant(TENANT_ATTRIBUTES);
+    verifyNoInteractions(indexService);
   }
 }


### PR DESCRIPTION
### Purpose/Overview:

Currently, if mod-search is initialized for the tenant where DB already has instances, the user can’t find these instances. 

### Requirements/Scope:

- new tenant attribute processing should be added
- on _**runReindex**_ modules should start reindex

### Approach
New tenant attributes can be set up on environments with stub data which is created before mod-search starts. _**runReindex**_ attribute should trigger the full reindex on module start up