### PR TITLE
MSEARCH-169 Support normalized search for call numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Here is a table with supported search options.
 | `holdings.hrid`                                    | term      | `holdings.hrid=="hr10*3"`                                  | Matches instances that have a holding with given HRID |
 | `holdingTags`                                      | term      | `holdingTags=="important"`                                 | Matches instances that have holdings with given tags |
 | `holdingsFullCallNumbers`                          | term      | `holdingsFullCallNumbers="cn*434"`                         | Matches instances that have holdings with given call number string (prefix + call number + suffix) |
+| `holdingsNormalizedCallNumbers`                    | term      | `holdingsNormalizedCallNumbers="cn434"`                    | Matches instances that have holdings with given call number and might not be formatted correctly  |
 | `holdings.electronicAccess`                        | full text | `holdings.electronicAccess any "resource"`                 | An alias for all `electronicAccess` fields - `uri`, `linkText`, `materialsSpecification`, `publicNote`|
 | `holdings.electronicAccess.uri`                    | term      | `holdings.electronicAccess.uri="http://folio.org*"`        | Search by electronic access URI|
 | `holdings.electronicAccess.linkText`               | full text | `holdings.electronicAccess.linkText="Folio website"`       | Search by electronic access link text |
@@ -309,6 +310,7 @@ Here is a table with supported search options.
 | `items.materialTypeId`                          | term      | `items.materialTypeId="23434"`                               | Matches instances that have items with given material type |
 | `items.discoverySuppress`                       | term      | `items.discoverySuppress=true`                               | Matches instances that have items suppressed/not suppressed from discovery |
 | `itemsFullCallNumbers`                          | term      | `itemsFullCallNumbers="cn*434"`                              | Matches instances that have items with given call number string (prefix + call number + suffix) |
+| `itemsNormalizedCallNumbers`                    | term      | `itemsNormalizedCallNumbers="cn434"`                         | Matches instances that have items with given call number and might not be formatted correctly  |
 | `itemTags`                                      | term      | `itemTags="important"`                                       | Matches instances that have items with given tag |
 | `items.electronicAccess`                        | full text | `items.electronicAccess any "resource"`                      | An alias for all `electronicAccess` fields - `uri`, `linkText`, `materialsSpecification`, `publicNote`|
 | `items.electronicAccess.uri`                    | term      | `items.electronicAccess.uri="http://folio.org*"`             | Search by electronic access URI|

--- a/src/main/java/org/folio/search/cql/CallNumberSearchTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/CallNumberSearchTermProcessor.java
@@ -1,0 +1,17 @@
+package org.folio.search.cql;
+
+import static org.folio.search.cql.CqlSearchQueryConverter.ASTERISKS_SIGN;
+import static org.folio.search.utils.SearchUtils.getNormalizedCallNumber;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CallNumberSearchTermProcessor implements SearchTermProcessor {
+
+  @Override
+  public String getSearchTerm(String inputTerm) {
+    return getNormalizedCallNumber(inputTerm) + ASTERISKS_SIGN;
+  }
+}

--- a/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
@@ -57,7 +57,7 @@ import org.z3950.zing.cql.CQLTermNode;
 @RequiredArgsConstructor
 public class CqlSearchQueryConverter {
 
-  private static final String ASTERISKS_SIGN = "*";
+  static final String ASTERISKS_SIGN = "*";
 
   private final CqlSortProvider cqlSortProvider;
   private final SearchFieldProvider searchFieldProvider;

--- a/src/main/java/org/folio/search/service/setter/holding/HoldingsNormalizedCallNumbersProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/holding/HoldingsNormalizedCallNumbersProcessor.java
@@ -1,12 +1,11 @@
 package org.folio.search.service.setter.holding;
 
-import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 import static org.folio.search.utils.SearchUtils.getNormalizedCallNumber;
 
+import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Stream;
-import org.apache.commons.lang3.StringUtils;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.service.setter.FieldProcessor;
 import org.springframework.stereotype.Component;
@@ -16,13 +15,14 @@ public class HoldingsNormalizedCallNumbersProcessor implements FieldProcessor<In
 
   @Override
   public Set<String> getFieldValue(Instance instance) {
-    return toStreamSafe(instance.getHoldings())
-      .filter(holding ->
-        StringUtils.isNotEmpty(holding.getCallNumber()) || StringUtils.isNotEmpty(holding.getCallNumberPrefix()))
-      .flatMap(holding -> Stream.concat(
-        Stream.ofNullable(getNormalizedCallNumber(holding.getCallNumberPrefix(), holding.getCallNumber(),
-          holding.getCallNumberSuffix())),
-        Stream.ofNullable(getNormalizedCallNumber(holding.getCallNumber(), holding.getCallNumberSuffix()))))
-      .collect(toSet());
+    var result = new HashSet<String>();
+    toStreamSafe(instance.getHoldings())
+      .filter(holding -> isNotEmpty(holding.getCallNumber()) || isNotEmpty(holding.getCallNumberPrefix()))
+      .forEach(holding -> {
+        result.add(getNormalizedCallNumber(holding.getCallNumberPrefix(), holding.getCallNumber(),
+          holding.getCallNumberSuffix()));
+        result.add(getNormalizedCallNumber(holding.getCallNumber(), holding.getCallNumberSuffix()));
+      });
+    return result;
   }
 }

--- a/src/main/java/org/folio/search/service/setter/holding/HoldingsNormalizedCallNumbersProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/holding/HoldingsNormalizedCallNumbersProcessor.java
@@ -1,0 +1,28 @@
+package org.folio.search.service.setter.holding;
+
+import static java.util.stream.Collectors.toSet;
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
+import static org.folio.search.utils.SearchUtils.getNormalizedCallNumber;
+
+import java.util.Set;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.service.setter.FieldProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HoldingsNormalizedCallNumbersProcessor implements FieldProcessor<Instance, Set<String>> {
+
+  @Override
+  public Set<String> getFieldValue(Instance instance) {
+    return toStreamSafe(instance.getHoldings())
+      .filter(holding ->
+        StringUtils.isNotEmpty(holding.getCallNumber()) || StringUtils.isNotEmpty(holding.getCallNumberPrefix()))
+      .flatMap(holding -> Stream.concat(
+        Stream.ofNullable(getNormalizedCallNumber(holding.getCallNumberPrefix(), holding.getCallNumber(),
+          holding.getCallNumberSuffix())),
+        Stream.ofNullable(getNormalizedCallNumber(holding.getCallNumber(), holding.getCallNumberSuffix()))))
+      .collect(toSet());
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/item/ItemsNormalizedCallNumbersProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemsNormalizedCallNumbersProcessor.java
@@ -1,0 +1,31 @@
+package org.folio.search.service.setter.item;
+
+import static java.util.stream.Collectors.toSet;
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
+import static org.folio.search.utils.SearchUtils.getNormalizedCallNumber;
+
+import java.util.Set;
+import java.util.stream.Stream;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.service.setter.FieldProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ItemsNormalizedCallNumbersProcessor implements FieldProcessor<Instance, Set<String>> {
+
+  @Override
+  public Set<String> getFieldValue(Instance instance) {
+    return toStreamSafe(instance.getItems())
+      .filter(items -> items.getEffectiveCallNumberComponents() != null)
+      .flatMap(item -> {
+        var itemCallNumber = item.getEffectiveCallNumberComponents();
+        return Stream.concat(
+          Stream.ofNullable(getNormalizedCallNumber(itemCallNumber.getPrefix(),
+            itemCallNumber.getCallNumber(),
+            itemCallNumber.getSuffix())),
+          Stream.ofNullable(getNormalizedCallNumber(itemCallNumber.getCallNumber(),
+            itemCallNumber.getSuffix())));
+      })
+      .collect(toSet());
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/item/ItemsNormalizedCallNumbersProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemsNormalizedCallNumbersProcessor.java
@@ -1,11 +1,10 @@
 package org.folio.search.service.setter.item;
 
-import static java.util.stream.Collectors.toSet;
 import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 import static org.folio.search.utils.SearchUtils.getNormalizedCallNumber;
 
+import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Stream;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.service.setter.FieldProcessor;
 import org.springframework.stereotype.Component;
@@ -15,17 +14,15 @@ public class ItemsNormalizedCallNumbersProcessor implements FieldProcessor<Insta
 
   @Override
   public Set<String> getFieldValue(Instance instance) {
-    return toStreamSafe(instance.getItems())
+    var result = new HashSet<String>();
+    toStreamSafe(instance.getItems())
       .filter(items -> items.getEffectiveCallNumberComponents() != null)
-      .flatMap(item -> {
+      .forEach(item -> {
         var itemCallNumber = item.getEffectiveCallNumberComponents();
-        return Stream.concat(
-          Stream.ofNullable(getNormalizedCallNumber(itemCallNumber.getPrefix(),
-            itemCallNumber.getCallNumber(),
-            itemCallNumber.getSuffix())),
-          Stream.ofNullable(getNormalizedCallNumber(itemCallNumber.getCallNumber(),
-            itemCallNumber.getSuffix())));
-      })
-      .collect(toSet());
+        result.add(getNormalizedCallNumber(itemCallNumber.getPrefix(), itemCallNumber.getCallNumber(),
+          itemCallNumber.getSuffix()));
+        result.add(getNormalizedCallNumber(itemCallNumber.getCallNumber(), itemCallNumber.getSuffix()));
+      });
+    return result;
   }
 }

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -140,6 +141,19 @@ public class SearchUtils {
       .filter(StringUtils::isNotBlank)
       .map(String::trim)
       .collect(joining(" "));
+  }
+
+  /**
+   * Creates normalized call number for passed call number parts (prefix, call number and suffix).
+   *
+   * @param callNumberValues array with full call number parts (prefix, call number and suffix)
+   * @return created normalized call number as {@link String} value
+   */
+  public static String getNormalizedCallNumber(String ... callNumberValues) {
+    return Stream.of(callNumberValues)
+      .filter(StringUtils::isNotBlank)
+      .map(s -> s.toLowerCase().replaceAll("[^a-z0-9]", ""))
+      .collect(Collectors.joining(""));
   }
 
   /**

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -429,6 +429,18 @@
       "inventorySearchTypes": "holdings.fullCallNumber",
       "processor": "holdingsCallNumberComponentsProcessor"
     },
+    "itemsNormalizedCallNumbers": {
+      "type": "search",
+      "index": "keyword",
+      "processor": "itemsNormalizedCallNumbersProcessor",
+      "searchTermProcessor": "callNumberSearchTermProcessor"
+    },
+    "holdingsNormalizedCallNumbers": {
+      "type": "search",
+      "index": "keyword",
+      "processor": "holdingsNormalizedCallNumbersProcessor",
+      "searchTermProcessor": "callNumberSearchTermProcessor"
+    },
     "holdingIdentifiers": {
       "type": "search",
       "index": "keyword",

--- a/src/test/java/org/folio/search/controller/SearchHoldingsIT.java
+++ b/src/test/java/org/folio/search/controller/SearchHoldingsIT.java
@@ -49,4 +49,18 @@ class SearchHoldingsIT extends BaseIntegrationTest {
       .andExpect(jsonPath("totalRecords", is(1)))
       .andExpect(jsonPath("instances[0].id", is(getSemanticWeb().getId())));
   }
+
+  @ParameterizedTest(name = "[{index}] {0}: {1}")
+  @CsvSource({
+    "holdingsNormalizedCallNumbers==\"{value}\", fix",
+    "holdingsNormalizedCallNumbers==\"{value}\", number",
+    "holdingsNormalizedCallNumbers==\"{value}\", c number",
+    "holdingsNormalizedCallNumbers==\"{value}\", call suffix",
+    "holdingsNormalizedCallNumbers==\"{value}\", CAL/number suffix",
+    "holdingsNormalizedCallNumbers==\"{value}\", prefix number"
+  })
+  void canSearchByHoldings_negative(String query, String value) throws Exception {
+    doGet(searchInstancesByQuery(query), value)
+      .andExpect(jsonPath("totalRecords", is(0)));
+  }
 }

--- a/src/test/java/org/folio/search/controller/SearchHoldingsIT.java
+++ b/src/test/java/org/folio/search/controller/SearchHoldingsIT.java
@@ -16,7 +16,14 @@ class SearchHoldingsIT extends BaseIntegrationTest {
   @ParameterizedTest(name = "[{index}] {0}: {1}")
   @CsvSource({
     "holdings.hrid=={value}, hold000000000009",
-    "holdingsFullCallNumbers==\"{value}\", TK5105.88815 . A58 2004 FT MEADE"
+    "holdingsFullCallNumbers==\"{value}\", TK5105.88815 . A58 2004 FT MEADE",
+    "holdingsNormalizedCallNumbers==\"{value}\", TK5105.88815 . A58 2004 FT MEADE",
+    "holdingsNormalizedCallNumbers==\"{value}\", TK510588815",
+    "holdingsNormalizedCallNumbers==\"{value}\", TK5105.8881:5 . a58",
+    "holdingsNormalizedCallNumbers==\"{value}\", TK5105.88815",
+    "holdingsNormalizedCallNumbers==\"{value}\", tk510588815 .    A58",
+    "holdingsNormalizedCallNumbers==\"{value}\", TK5105",
+    "holdingsNormalizedCallNumbers==\"{value}\", tk510588815a582004ftmeade"
   })
   void canSearchByHoldings_exactMatch(String query, String value) throws Exception {
     doGet(searchInstancesByQuery(query), value)
@@ -27,7 +34,15 @@ class SearchHoldingsIT extends BaseIntegrationTest {
   @ParameterizedTest(name = "[{index}] {0}: {1}")
   @CsvSource({
     "holdings.hrid=={value}, ho*7",
-    "holdings.fullCallNumber=={value}, prefix*suffix"
+    "holdings.fullCallNumber=={value}, prefix*suffix",
+    "holdingsNormalizedCallNumbers==\"{value}\", prefix",
+    "holdingsNormalizedCallNumbers==\"{value}\", prefix:",
+    "holdingsNormalizedCallNumbers==\"{value}\", callnumber",
+    "holdingsNormalizedCallNumbers==\"{value}\", call:number",
+    "holdingsNormalizedCallNumbers==\"{value}\", callnumbers",
+    "holdingsNormalizedCallNumbers==\"{value}\", callnumber suffix",
+    "holdingsNormalizedCallNumbers==\"{value}\", CALL.number suffix",
+    "holdingsNormalizedCallNumbers==\"{value}\", prefixcallnumber"
   })
   void canSearchByHoldings_exactMatchWithWildcard(String query, String value) throws Exception {
     doGet(searchInstancesByQuery(query), value)

--- a/src/test/java/org/folio/search/controller/SearchItemIT.java
+++ b/src/test/java/org/folio/search/controller/SearchItemIT.java
@@ -15,12 +15,36 @@ class SearchItemIT extends BaseIntegrationTest {
 
   @CsvSource({
     "items.fullCallNumber=={value}, prefix-90000 TK51*",
-    "items.effectiveCallNumberComponents=={value}, *suffix-10101"
+    "items.effectiveCallNumberComponents=={value}, *suffix-10101",
+    "itemsNormalizedCallNumbers=={value}, prefix-90000",
+    "itemsNormalizedCallNumbers=={value}, prefix90000",
+    "itemsNormalizedCallNumbers=={value}, prefix.9",
+    "itemsNormalizedCallNumbers=={value}, TK5105.88815.A58 2004 FT MEADE",
+    "itemsNormalizedCallNumbers=={value}, TK5105.88815",
+    "itemsNormalizedCallNumbers=={value}, prefix90000 TK510588815",
+    "itemsNormalizedCallNumbers=={value}, tk510588815",
+    "itemsNormalizedCallNumbers=={value}, TK5105.88815.A58 2004 FT MEADE suffix-90000",
+    "itemsNormalizedCallNumbers=={value}, TK510588815A582004FT MEADE suffix90000",
   })
   @ParameterizedTest(name = "[{index}] {0}: {1}")
   void canSearchByItems_wildcardMatch(String query, String value) throws Throwable {
     doGet(searchInstancesByQuery(query), value)
       .andExpect(jsonPath("totalRecords", is(1)))
       .andExpect(jsonPath("instances[0].id", is(getSemanticWeb().getId())));
+  }
+
+  @CsvSource({
+    "itemsNormalizedCallNumbers=={value}, fix-90000",
+    "itemsNormalizedCallNumbers=={value}, 90000",
+    "itemsNormalizedCallNumbers=={value}, 88815.A58 2004 FT MEADE",
+    "itemsNormalizedCallNumbers=={value}, 88815 suffix90000",
+    "itemsNormalizedCallNumbers=={value}, prefix TK510588815",
+    "itemsNormalizedCallNumbers=={value}, 510588815",
+    "itemsNormalizedCallNumbers=={value}, TK5105.88815.A58 2004 FT MEADE 90000",
+  })
+  @ParameterizedTest(name = "[{index}] {0}: {1}")
+  void canSearchByItems_negative(String query, String value) throws Throwable {
+    doGet(searchInstancesByQuery(query), value)
+      .andExpect(jsonPath("totalRecords", is(0)));
   }
 }

--- a/src/test/java/org/folio/search/cql/CallNumberSearchTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/CallNumberSearchTermProcessorTest.java
@@ -1,0 +1,28 @@
+package org.folio.search.cql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+public class CallNumberSearchTermProcessorTest {
+
+  private final CallNumberSearchTermProcessor callNumberSearchTermProcessor = new CallNumberSearchTermProcessor();
+
+  @CsvSource({
+    "prefix-callnumber-suffix, prefixcallnumbersuffix*",
+    "TK5105.88815 . A58 2004 FT MEADE, tk510588815a582004ftmeade*",
+    "TK5105.88815   /  A 58 2004 ft-MEADE+, tk510588815a582004ftmeade*",
+    "++ TK5105.88815++, tk510588815*",
+  })
+  @ParameterizedTest(name = "[{index}] {0}: {1}")
+  void callNumberSearchTermProcessorCanNormalizeQuery(String query, String result) {
+    var expectedQuery = callNumberSearchTermProcessor.getSearchTerm(query);
+    assertThat(result).isEqualTo(expectedQuery);
+  }
+}

--- a/src/test/java/org/folio/search/service/setter/holding/HoldingsNormalizedCallNumbersProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/holding/HoldingsNormalizedCallNumbersProcessorTest.java
@@ -1,0 +1,50 @@
+package org.folio.search.service.setter.holding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.folio.search.domain.dto.Holding;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class HoldingsNormalizedCallNumbersProcessorTest {
+  private final HoldingsNormalizedCallNumbersProcessor processor = new HoldingsNormalizedCallNumbersProcessor();
+
+  @Test
+  void canGetFieldValue_multipleHoldings() {
+    var holdings = List.of(holdingWithCallNumber("Rare Books", "S537.N56 C82", "++"),
+      holdingWithCallNumber("Oversize", "ABC123.1 .R15 2018", "Curriculum Materials Collection"));
+
+    assertThat(processor.getFieldValue(new Instance().holdings(holdings)))
+      .containsExactlyInAnyOrder("rarebookss537n56c82", "s537n56c82",
+        "oversizeabc1231r152018curriculummaterialscollection", "abc1231r152018curriculummaterialscollection");
+  }
+
+  @Test
+  void canGetFieldValue_someComponentsAreNulls() {
+    var holdings = List.of(
+      holdingWithCallNumber(null, "cn1", "suffix1"),
+      holdingWithCallNumber("prefix2", "cn2", null),
+      holdingWithCallNumber(null, "cn3", null));
+
+    assertThat(processor.getFieldValue(new Instance().holdings(holdings)))
+      .containsExactlyInAnyOrder("cn1suffix1", "prefix2cn2", "cn2", "cn3");
+  }
+
+  @Test
+  void shouldReturnEmptySetWhenNoHoldings() {
+    assertThat(processor.getFieldValue(new Instance())).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptySetWhenHoldingsHasNoCallNumber() {
+    var holdings = List.of(new Holding(), new Holding());
+    assertThat(processor.getFieldValue(new Instance().holdings(holdings))).isEmpty();
+  }
+
+  private Holding holdingWithCallNumber(String prefix, String cn, String suffix) {
+    return new Holding().callNumberPrefix(prefix).callNumber(cn).callNumberSuffix(suffix);
+  }
+}

--- a/src/test/java/org/folio/search/service/setter/item/ItemsNormalizedCallNumbersProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemsNormalizedCallNumbersProcessorTest.java
@@ -1,0 +1,52 @@
+package org.folio.search.service.setter.item;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Item;
+import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class ItemsNormalizedCallNumbersProcessorTest {
+  private final ItemsNormalizedCallNumbersProcessor processor = new ItemsNormalizedCallNumbersProcessor();
+
+  @Test
+  void canGetFieldValue_multipleItems() {
+    var items = List.of(itemWithCallNumber("Rare Books", "S537.N56 C82", "++"),
+      itemWithCallNumber("Oversize", "ABC123.1 .R15 2018", "Curriculum Materials Collection"));
+
+    assertThat(processor.getFieldValue(new Instance().items(items)))
+      .containsExactlyInAnyOrder("rarebookss537n56c82", "s537n56c82",
+        "oversizeabc1231r152018curriculummaterialscollection", "abc1231r152018curriculummaterialscollection");
+  }
+
+  @Test
+  void canGetFieldValue_someComponentsAreNulls() {
+    var items = List.of(
+      itemWithCallNumber(null, "cn1", "suffix1"),
+      itemWithCallNumber("prefix2", "cn2", null),
+      itemWithCallNumber(null, "cn3", null));
+
+    assertThat(processor.getFieldValue(new Instance().items(items)))
+      .containsExactlyInAnyOrder("cn1suffix1", "prefix2cn2", "cn2", "cn3");
+  }
+
+  @Test
+  void shouldReturnEmptySetWhenNoItems() {
+    assertThat(processor.getFieldValue(new Instance())).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptySetWhenItemsHasNoCallNumber() {
+    var items = List.of(new Item(), new Item());
+    assertThat(processor.getFieldValue(new Instance().items(items))).isEmpty();
+  }
+
+  private Item itemWithCallNumber(String prefix, String cn, String suffix) {
+    return new Item().effectiveCallNumberComponents(
+      new ItemEffectiveCallNumberComponents().prefix(prefix).callNumber(cn).suffix(suffix));
+  }
+}

--- a/src/test/java/org/folio/search/utils/SearchUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchUtilsTest.java
@@ -173,4 +173,16 @@ class SearchUtilsTest {
     var actual = SearchUtils.getPlainFieldValue(keywordField(), "key", "v", List.of("eng"));
     assertThat(actual).isEqualTo(singletonMap("key", "v"));
   }
+
+  @Test
+  void getNormalizedCallNumber_positive() {
+    var actual = SearchUtils.getNormalizedCallNumber(null, "94 NF 14/1:3792-3835", null);
+    assertThat(actual).isEqualTo("94nf14137923835");
+  }
+
+  @Test
+  void getNormalizedCallNumber_with_suffix_prefix_positive() {
+    var actual = SearchUtils.getNormalizedCallNumber("prefix", "94 NF 14/1:3792-3835", "suffix");
+    assertThat(actual).isEqualTo("prefix94nf14137923835suffix");
+  }
 }


### PR DESCRIPTION
<p><strong>Purpose/Overview:</strong><br /> In many cases librarians need to search for the record based on a call number that is provided by a patron and might not be formatted correctly.</p>
<p><strong>Requirements/Scope:</strong></p>
<p><strong>Example:</strong></p>
<div class="table-wrap">


Prefix | Call Number | Postfix
-- | -- | --
Rare Books | S537.N56 C82 | Incunabule


</div>
<ol>
<li>s537.N56 C82 matches&nbsp; the example</li>
<li>s537 .N56 C82 matches&nbsp; the example</li>
<li>s537.N56 C82 Incunabule matches the example</li>
<li>rare books&nbsp;s537.N56 C82 matches the example</li>
</ol>
<p><strong>Approach:</strong></p>

- Added new search term processor that should normalize and add a wildcard to the query
- Normalize tokens and save pairs prefix+callnumber+suffix and callnumber+suffix

<p><strong>Acceptance criteria:</strong></p>
<ul>
<li>Existing call number search functionality does not change</li>
<li>The search matches call numbers when the punctuation is omitted</li>
<li>The search matches call numbers when the punctuation is added</li>
<li>Spaces are omitted</li>
<li>Partial matches</li>
<li>Lower and upper cases are supported and returns the same data</li>
</ul>