### PR TITLE
WIP: MSEARCH-182 Support search by all fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,30 +101,32 @@ with less powerful configuration (see [High availability](https://www.elastic.co
 
 ## Environment variables:
 
-| Name                          | Default value             | Description                                                       |
-| :-----------------------------| :------------------------:|:------------------------------------------------------------------|
-| DB_HOST                       | postgres                  | Postgres hostname                                                 |
-| DB_PORT                       | 5432                      | Postgres port                                                     |
-| DB_USERNAME                   | folio_admin               | Postgres username                                                 |
-| DB_PASSWORD                   | -                         | Postgres username password                                        |
-| DB_DATABASE                   | okapi_modules             | Postgres database name                                            |
-| ~~ELASTICSEARCH_HOST~~        | elasticsearch             | (DEPRECATED, use ELASTICSEARCH_URL) Elasticsearch hostname        |
-| ~~ELASTICSEARCH_POR~~         | 9200                      | (DEPRECATED, use ELASTICSEARCH_URL) Elasticsearch port            |
-| ELASTICSEARCH_URL             | http://elasticsearch:9200 | Elasticsearch URL                                                 |
-| ELASTICSEARCH_USERNAME        | -                         | Elasticsearch username (not required for dev envs)                |
-| ELASTICSEARCH_PASSWORD        | -                         | Elasticsearch password (not required for dev envs)                |
-| KAFKA_HOST                    | kafka                     | Kafka broker hostname                                             |
-| KAFKA_PORT                    | 9092                      | Kafka broker port                                                 |
-| KAFKA_SECURITY_PROTOCOL       | PLAINTEXT                 | Kafka security protocol used to communicate with brokers (SSL or PLAINTEXT) |
-| KAFKA_SSL_KEYSTORE_LOCATION   | -                         | The location of the Kafka key store file. This is optional for client and can be used for two-way authentication for client. |
-| KAFKA_SSL_KEYSTORE_PASSWORD   | -                         | The store password for the Kafka key store file. This is optional for client and only needed if 'ssl.keystore.location' is configured. |
-| KAFKA_SSL_TRUSTSTORE_LOCATION | -                         | The location of the Kafka trust store file. |
-| KAFKA_SSL_TRUSTSTORE_PASSWORD | -                         | The password for the Kafka trust store file. If a password is not set, trust store file configured will still be used, but integrity checking is disabled. |
-| KAFKA_EVENTS_CONSUMER_PATTERN | -                         | Custom subscription pattern for Kafka consumers. |
-| INITIAL_LANGUAGES             | eng                       | Comma separated list of languages for multilang fields see [Multi-lang search support](#multi-language-search-support) |
-| SYSTEM_USER_PASSWORD          | -                         | Password for `mod-search` system user (not required for dev envs) |
-| OKAPI_URL                     | -                         | OKAPI URL used to login system user, required                     |
-| ENV                           | -                         | The logical name of the deployment, must be unique across all environments using the same shared Kafka/Elasticsearch clusters, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed |
+| Name                             | Default value             | Description                                                       |
+| :-------------------------------:| :------------------------:|:------------------------------------------------------------------|
+| DB_HOST                          | postgres                  | Postgres hostname                                                 |
+| DB_PORT                          | 5432                      | Postgres port                                                     |
+| DB_USERNAME                      | folio_admin               | Postgres username                                                 |
+| DB_PASSWORD                      | -                         | Postgres username password                                        |
+| DB_DATABASE                      | okapi_modules             | Postgres database name                                            |
+| ~~ELASTICSEARCH_HOST~~           | elasticsearch             | (DEPRECATED, use ELASTICSEARCH_URL) Elasticsearch hostname        |
+| ~~ELASTICSEARCH_POR~~            | 9200                      | (DEPRECATED, use ELASTICSEARCH_URL) Elasticsearch port            |
+| ELASTICSEARCH_URL                | http://elasticsearch:9200 | Elasticsearch URL                                                 |
+| ELASTICSEARCH_USERNAME           | -                         | Elasticsearch username (not required for dev envs)                |
+| ELASTICSEARCH_PASSWORD           | -                         | Elasticsearch password (not required for dev envs)                |
+| KAFKA_HOST                       | kafka                     | Kafka broker hostname                                             |
+| KAFKA_PORT                       | 9092                      | Kafka broker port                                                 |
+| KAFKA_SECURITY_PROTOCOL          | PLAINTEXT                 | Kafka security protocol used to communicate with brokers (SSL or PLAINTEXT) |
+| KAFKA_SSL_KEYSTORE_LOCATION      | -                         | The location of the Kafka key store file. This is optional for client and can be used for two-way authentication for client. |
+| KAFKA_SSL_KEYSTORE_PASSWORD      | -                         | The store password for the Kafka key store file. This is optional for client and only needed if 'ssl.keystore.location' is configured. |
+| KAFKA_SSL_TRUSTSTORE_LOCATION    | -                         | The location of the Kafka trust store file. |
+| KAFKA_SSL_TRUSTSTORE_PASSWORD    | -                         | The password for the Kafka trust store file. If a password is not set, trust store file configured will still be used, but integrity checking is disabled. |
+| KAFKA_EVENTS_CONSUMER_PATTERN    | -                         | Custom subscription pattern for Kafka consumers. |
+| KAFKA_EVENTS_CONCURRENCY         | 2                         | Custom number of kafka concurrent threads for message consuming. |
+| INITIAL_LANGUAGES                | eng                       | Comma separated list of languages for multilang fields see [Multi-lang search support](#multi-language-search-support) |
+| SYSTEM_USER_PASSWORD             | -                         | Password for `mod-search` system user (not required for dev envs) |
+| OKAPI_URL                        | -                         | OKAPI URL used to login system user, required                     |
+| ENV                              | -                         | The logical name of the deployment, must be unique across all environments using the same shared Kafka/Elasticsearch clusters, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed |
+| INSTANCE_DISABLED_SEARCH_OPTIONS | cql.all                   | Comma-separated list of disabled search options (fieldName or inventorySearchType) |
 
 The module uses system user to communicate with other modules from Kafka consumers.
 For production deployments you MUST specify the password for this system user via env variable:
@@ -321,6 +323,23 @@ Here is a table with supported search options.
 | `itemPublicNotes`                               | full text | `itemPublicNotes all "public note"`                          | Search by item public notes |
 | `itemIdentifiers`                               | term      | `itemIdentifiers all "81ae0f60-f2bc-450c-84c8-5a21096daed9"` | Search by item Identifiers: `items.hrid`, `items.formerIds`, `items.accessionNumber` |
 
+### Search by all field values
+
+Search by all feature is optional and can be disabled by passing to the server configuration following ENV variable
+
+```
+INSTANCE_SEARCH_DISABLED=
+```
+
+By default, indexing processors for fields `cql.allInstance`, `cql.allItems`, `cql.allHoldings` are disabled and
+does not produce any values, so the following search options will return empty result.
+
+| Option             | Type              |Example                          | Description                    |
+| :------------------|:-----------------:| :------------------------------:|:------------------------------:|
+| `cql.all`          | full-text or term | `cql.all all "web semantic"`    | Matches instances that have instance, items and holdings field values with given text |
+| `cql.allItems`     | full-text or term | `cql.allInstance all "book"`    | Matches instances that have field values with given text |
+| `cql.allHoldings`  | full-text or term | `cql.allItems all "it001"`      | Matches instances that have items field values with given text |
+| `cql.allInstances` | full-text or term | `cql.allHoldings any "1234567"` | Matches instances that have holdings field values with given text |
 
 ### Search Facets
 

--- a/src/main/java/org/folio/search/configuration/SearchCacheNames.java
+++ b/src/main/java/org/folio/search/configuration/SearchCacheNames.java
@@ -10,4 +10,5 @@ public class SearchCacheNames {
   public static final String IDENTIFIER_IDS_CACHE = "identifier-types";
   public static final String ALTERNATIVE_TITLE_TYPES_CACHE = "alternative-title-types";
   public static final String SYSTEM_USER_CACHE = "system-user-cache";
+  public static final String RESOURCE_LANGUAGE_CACHE = "tenant-languages";
 }

--- a/src/main/java/org/folio/search/configuration/properties/SearchConfigurationProperties.java
+++ b/src/main/java/org/folio/search/configuration/properties/SearchConfigurationProperties.java
@@ -1,7 +1,9 @@
 package org.folio.search.configuration.properties;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 
+import java.util.Map;
 import java.util.Set;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
@@ -16,7 +18,15 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "application.search-config")
 public class SearchConfigurationProperties {
 
+  /**
+   * Provides list of initial languages for multi-language search.
+   */
   @NotEmpty
   @Size(max = 5)
   private Set<String> initialLanguages = emptySet();
+
+  /**
+   * Contains set of ignored search processor names for resource.
+   */
+  private Map<String, Set<String>> disabledSearchOptions = emptyMap();
 }

--- a/src/main/java/org/folio/search/model/metadata/ResourceDescription.java
+++ b/src/main/java/org/folio/search/model/metadata/ResourceDescription.java
@@ -65,6 +65,14 @@ public class ResourceDescription {
    */
   private Map<String, FieldDescription> fieldTypes = Collections.emptyMap();
 
+  /**
+   * Mappings source definition.
+   */
+  private Map<String, List<String>> mappingsSource;
+
+  /**
+   * Map with field description where key is the flattened path.
+   */
   @JsonIgnore
   @Setter(AccessLevel.PACKAGE)
   private Map<String, PlainFieldDescription> flattenFields;

--- a/src/main/java/org/folio/search/model/metadata/SearchFieldDescriptor.java
+++ b/src/main/java/org/folio/search/model/metadata/SearchFieldDescriptor.java
@@ -6,10 +6,16 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class SearchFieldDescriptor extends PlainFieldDescription {
+
   /**
    * Name of a Spring bean that is used to generate value for the field.
    *
    * @see org.folio.search.service.setter.FieldProcessor
    */
   private String processor;
+
+  /**
+   * Marks if field processor can accept raw resource as {@link java.util.Map} or not.
+   */
+  private boolean rawProcessing;
 }

--- a/src/main/java/org/folio/search/model/service/MultilangValue.java
+++ b/src/main/java/org/folio/search/model/service/MultilangValue.java
@@ -1,0 +1,48 @@
+package org.folio.search.model.service;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(staticName = "empty")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MultilangValue {
+
+  /**
+   * List of plain values.
+   */
+  private Set<String> plainValues = new LinkedHashSet<>();
+
+  /**
+   * List of multi-language values.
+   */
+  private Set<String> multilangValues = new LinkedHashSet<>();
+
+  /**
+   * Adds value to the {@link MultilangValue} object, using isMultilang flag.
+   *
+   * @param value string value as {@link String} object
+   * @param isMultilang isMultilang flag as {@code boolean} value.
+   */
+  public void addValue(String value, boolean isMultilang) {
+    if (isMultilang) {
+      multilangValues.add(value);
+      return;
+    }
+    plainValues.add(value);
+  }
+
+  /**
+   * Creates empty {@link MultilangValue} object.
+   *
+   * @return empty {@link MultilangValue} object with immutable collections inside.
+   */
+  public static MultilangValue of(Collection<String> plainValues, Collection<String> multilangValues) {
+    return new MultilangValue(new LinkedHashSet<>(plainValues), new LinkedHashSet<>(multilangValues));
+  }
+}

--- a/src/main/java/org/folio/search/service/es/SearchMappingsHelper.java
+++ b/src/main/java/org/folio/search/service/es/SearchMappingsHelper.java
@@ -53,6 +53,11 @@ public class SearchMappingsHelper {
     var mappingProperties = new LinkedHashMap<String, Object>();
     indexMappings.put(MAPPING_PROPERTIES_FIELD, mappingProperties);
 
+    var mappingsSource = description.getMappingsSource();
+    if (MapUtils.isNotEmpty(mappingsSource)) {
+      indexMappings.put("_source", mappingsSource);
+    }
+
     mappingProperties.putAll(createMappingsForFields(description.getFields()));
     mappingProperties.putAll(createMappingsForFields(description.getSearchFields()));
     var customIndexMappings = description.getIndexMappings();
@@ -131,10 +136,6 @@ public class SearchMappingsHelper {
   }
 
   private void removeUnsupportedLanguages(ObjectNode mappings) {
-    if (mappings == null) {
-      return;
-    }
-
     var languageConfigsMap = languageConfigService.getAll().getLanguageConfigs().stream()
       .collect(toMap(LanguageConfig::getCode, Function.identity()));
 

--- a/src/main/java/org/folio/search/service/metadata/LocalResourceProvider.java
+++ b/src/main/java/org/folio/search/service/metadata/LocalResourceProvider.java
@@ -1,6 +1,6 @@
 package org.folio.search.service.metadata;
 
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
@@ -24,39 +24,49 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class LocalResourceProvider implements MetadataResourceProvider {
 
+  public static final String RESOURCE_DESCRIPTIONS_LOCATION_PATTERN = "classpath*:/model/*.json";
+  public static final String INDEX_FIELD_TYPES_LOCATION = "elasticsearch/index-field-types.json";
+
   private final JsonConverter jsonConverter;
   private final LocalFileProvider localFileProvider;
   private final ResourcePatternResolver patternResolver;
+  private List<ResourceDescription> resourceDescriptions;
 
   @Override
   public List<ResourceDescription> getResourceDescriptions() {
-    var pattern = "classpath*:/model/*.json";
-    try {
-      return Stream.of(patternResolver.getResources(pattern))
-        .filter(Resource::isReadable)
-        .map(this::getResourceDescription)
-        .filter(Objects::nonNull)
-        .collect(toList());
-    } catch (IOException e) {
-      log.error("Failed to read models [pattern: {}]", pattern);
-      throw new ResourceDescriptionException(String.format(
-        "Failed to read local files [pattern: %s]", pattern), e);
+    if (this.resourceDescriptions == null) {
+      loadResourceDescriptions();
     }
+
+    return this.resourceDescriptions;
   }
 
   @Override
   public Map<String, SearchFieldType> getSearchFieldTypes() {
-    var path = "elasticsearch/index-field-types.json";
-    Map<String, SearchFieldType> fieldTypes =
-      localFileProvider.readAsObject(path, new TypeReference<>() {});
+    var typeReference = new TypeReference<Map<String, SearchFieldType>>() {};
+    var fieldTypes = localFileProvider.readAsObject(INDEX_FIELD_TYPES_LOCATION, typeReference);
     if (fieldTypes == null) {
       throw new ResourceDescriptionException(String.format(
-        "Failed to load search field types [path: %s]", path));
+        "Failed to load search field types [path: %s]", INDEX_FIELD_TYPES_LOCATION));
     }
     return fieldTypes;
   }
 
-  private ResourceDescription getResourceDescription(Resource resource) {
+  private void loadResourceDescriptions() {
+    try {
+      this.resourceDescriptions = Stream.of(patternResolver.getResources(RESOURCE_DESCRIPTIONS_LOCATION_PATTERN))
+        .filter(Resource::isReadable)
+        .map(this::loadResourceDescription)
+        .filter(Objects::nonNull)
+        .collect(toUnmodifiableList());
+    } catch (IOException e) {
+      log.error("Failed to read models [pattern: {}]", RESOURCE_DESCRIPTIONS_LOCATION_PATTERN);
+      throw new ResourceDescriptionException(String.format(
+        "Failed to read local files [pattern: %s]", RESOURCE_DESCRIPTIONS_LOCATION_PATTERN), e);
+    }
+  }
+
+  private ResourceDescription loadResourceDescription(Resource resource) {
     try (var is = resource.getInputStream()) {
       return jsonConverter.readJson(is, ResourceDescription.class);
     } catch (IOException e) {

--- a/src/main/java/org/folio/search/service/metadata/MetadataResourceProvider.java
+++ b/src/main/java/org/folio/search/service/metadata/MetadataResourceProvider.java
@@ -18,6 +18,12 @@ public interface MetadataResourceProvider {
    */
   List<ResourceDescription> getResourceDescriptions();
 
+  /**
+   * Finds resource description by given resource name.
+   *
+   * @param resourceName resource name as {@link String} value.
+   * @return {@link Optional} of {@link ResourceDescription} if it has been found, it would be empty otherwise.
+   */
   default Optional<ResourceDescription> getResourceDescription(String resourceName) {
     return getResourceDescriptions().stream()
       .filter(desc -> desc.getName().equals(resourceName))

--- a/src/main/java/org/folio/search/service/metadata/SearchFieldProvider.java
+++ b/src/main/java/org/folio/search/service/metadata/SearchFieldProvider.java
@@ -2,7 +2,6 @@ package org.folio.search.service.metadata;
 
 import java.util.List;
 import java.util.Optional;
-import org.folio.search.model.metadata.FieldDescription;
 import org.folio.search.model.metadata.PlainFieldDescription;
 import org.folio.search.model.metadata.SearchFieldType;
 
@@ -30,15 +29,6 @@ public interface SearchFieldProvider {
   List<String> getFields(String resource, String searchType);
 
   /**
-   * Provides field for given path.
-   *
-   * @param resource resource type as {@link String}
-   * @param path path to field as {@link String}
-   * @return {@link Optional} of resource field description by path, it would be empty if field by path not found.
-   */
-  Optional<FieldDescription> getFieldByPath(String resource, String path);
-
-  /**
    * Provides plain field description for given path.
    *
    * @param resource resource type as {@link String}
@@ -54,4 +44,20 @@ public interface SearchFieldProvider {
    * @return list of fields.
    */
   List<String> getSourceFields(String resource);
+
+  /**
+   * Checks if given language is supported.
+   *
+   * @return true if language is supported by system, false - otherwise.
+   */
+  boolean isSupportedLanguage(String languageCode);
+
+  /**
+   * Checks if field by path is multi-language or not.
+   *
+   * @param resourceName resource name as {@link String} object
+   * @param path path to the field as {@link String} object
+   * @return true if field by path is multi-language, false - otherwise
+   */
+  boolean isMultilangField(String resourceName, String path);
 }

--- a/src/main/java/org/folio/search/service/setter/AbstractAllValuesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/AbstractAllValuesProcessor.java
@@ -1,0 +1,88 @@
+package org.folio.search.service.setter;
+
+import static org.folio.search.utils.CollectionUtils.noneMatch;
+import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
+import static org.folio.search.utils.SearchUtils.MULTILANG_SOURCE_SUBFIELD;
+import static org.folio.search.utils.SearchUtils.updateMultilangPlainFieldKey;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Predicate;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.search.model.service.MultilangValue;
+import org.folio.search.service.metadata.SearchFieldProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public abstract class AbstractAllValuesProcessor implements FieldProcessor<Map<String, Object>, MultilangValue> {
+
+  protected SearchFieldProvider searchFieldProvider;
+  private final Set<String> excludedFieldEndings = Set.of("Id", "Ids");
+
+  /**
+   * Uses to inject {@link SearchFieldProvider} bean by dependency injection framework.
+   *
+   * @param localSearchFieldProvider {@link SearchFieldProvider} bean.
+   */
+  @Autowired
+  public void setSearchFieldProvider(SearchFieldProvider localSearchFieldProvider) {
+    this.searchFieldProvider = localSearchFieldProvider;
+  }
+
+  protected MultilangValue getAllFieldValues(Object eventBody, String initialPath, Predicate<String> keyFilter) {
+    var multilangValue = MultilangValue.empty();
+    if (ObjectUtils.isEmpty(eventBody)) {
+      return multilangValue;
+    }
+
+    collectFieldValuesFromEventBody(initialPath, multilangValue, eventBody, keyFilter);
+    return multilangValue;
+  }
+
+  private void collectFieldValuesFromEventBody(String path, MultilangValue context,
+    Map<String, Object> fields, Predicate<String> keyFilter) {
+    if (MapUtils.isEmpty(fields)) {
+      return;
+    }
+
+    var sourceLanguageValue = fields.get(MULTILANG_SOURCE_SUBFIELD);
+    if (sourceLanguageValue != null) {
+      return;
+    }
+
+    for (Entry<String, Object> entry : fields.entrySet()) {
+      String key = entry.getKey();
+      if (noneMatch(excludedFieldEndings, key::endsWith) && keyFilter.test(key)) {
+        var newKey = updateMultilangPlainFieldKey(key);
+        var newPath = path != null ? path + "." + newKey : newKey;
+        collectFieldValuesFromEventBody(newPath, context, entry.getValue(), keyFilter);
+      }
+    }
+  }
+
+  private void collectFieldValuesFromEventBody(String path, MultilangValue ctx,
+    Collection<?> collection, Predicate<String> keyFilter) {
+    if (CollectionUtils.isNotEmpty(collection)) {
+      collection.forEach(value -> collectFieldValuesFromEventBody(path, ctx, value, keyFilter));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void collectFieldValuesFromEventBody(String path, MultilangValue ctx, Object v, Predicate<String> filter) {
+    if (v instanceof String) {
+      ctx.addValue(StringUtils.strip((String) v), searchFieldProvider.isMultilangField(INSTANCE_RESOURCE, path));
+    }
+
+    if (v instanceof Collection<?>) {
+      collectFieldValuesFromEventBody(path, ctx, (Collection<?>) v, filter);
+    }
+
+    if (v instanceof Map<?, ?>) {
+      collectFieldValuesFromEventBody(path, ctx, (Map<String, Object>) v, filter);
+    }
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/holding/HoldingAllFieldValuesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/holding/HoldingAllFieldValuesProcessor.java
@@ -1,0 +1,22 @@
+package org.folio.search.service.setter.holding;
+
+import static org.apache.commons.collections.MapUtils.getObject;
+
+import java.util.Map;
+import org.folio.search.model.service.MultilangValue;
+import org.folio.search.service.setter.AbstractAllValuesProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HoldingAllFieldValuesProcessor extends AbstractAllValuesProcessor {
+
+  @Override
+  public MultilangValue getFieldValue(Map<String, Object> eventBody) {
+    var holdings = getObject(eventBody, "holdings");
+    var resultMultilangValue = getAllFieldValues(holdings, "holdings", key -> true);
+    var searchMultilangValue = getAllFieldValues(eventBody, null, key -> key.startsWith("holding"));
+    resultMultilangValue.getPlainValues().addAll(searchMultilangValue.getPlainValues());
+    resultMultilangValue.getMultilangValues().addAll(searchMultilangValue.getMultilangValues());
+    return resultMultilangValue;
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/instance/InstanceAllFieldValuesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/InstanceAllFieldValuesProcessor.java
@@ -1,0 +1,20 @@
+package org.folio.search.service.setter.instance;
+
+import static org.folio.search.utils.CollectionUtils.noneMatch;
+
+import java.util.Map;
+import java.util.Set;
+import org.folio.search.model.service.MultilangValue;
+import org.folio.search.service.setter.AbstractAllValuesProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InstanceAllFieldValuesProcessor extends AbstractAllValuesProcessor {
+
+  private final Set<String> innerResources = Set.of("item", "holding");
+
+  @Override
+  public MultilangValue getFieldValue(Map<String, Object> event) {
+    return getAllFieldValues(event, null, key -> noneMatch(innerResources, key::startsWith));
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/instance/IsbnProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/IsbnProcessor.java
@@ -5,7 +5,6 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toCollection;
 import static org.folio.isbn.IsbnUtil.convertTo13DigitNumber;
 import static org.folio.isbn.IsbnUtil.isValid10DigitNumber;
-import static org.folio.isbn.IsbnUtil.isValid13DigitNumber;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -86,7 +85,7 @@ public class IsbnProcessor extends AbstractIdentifierProcessor {
       return emptyList();
     }
     var isbn13Matcher = ISBN13_REGEX.matcher(isbnValue);
-    if (isbn13Matcher.find() && isValid13DigitNumber(isbn13Matcher.group(0))) {
+    if (isbn13Matcher.find()) {
       return getNormalizedIsbnValue(isbn13Matcher, singletonList(isbn13Matcher.group(0)));
     }
 

--- a/src/main/java/org/folio/search/service/setter/item/ItemAllFieldValuesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemAllFieldValuesProcessor.java
@@ -1,0 +1,22 @@
+package org.folio.search.service.setter.item;
+
+import static org.apache.commons.collections.MapUtils.getObject;
+
+import java.util.Map;
+import org.folio.search.model.service.MultilangValue;
+import org.folio.search.service.setter.AbstractAllValuesProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ItemAllFieldValuesProcessor extends AbstractAllValuesProcessor {
+
+  @Override
+  public MultilangValue getFieldValue(Map<String, Object> eventBody) {
+    var items = getObject(eventBody, "items");
+    var resultMultilangValue = getAllFieldValues(items, "items", key -> true);
+    var searchFieldMultilangValue = getAllFieldValues(eventBody, null, key -> key.startsWith("item"));
+    resultMultilangValue.getPlainValues().addAll(searchFieldMultilangValue.getPlainValues());
+    resultMultilangValue.getMultilangValues().addAll(searchFieldMultilangValue.getMultilangValues());
+    return resultMultilangValue;
+  }
+}

--- a/src/main/java/org/folio/search/utils/CollectionUtils.java
+++ b/src/main/java/org/folio/search/utils/CollectionUtils.java
@@ -2,35 +2,72 @@ package org.folio.search.utils;
 
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Stream.empty;
+import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.collections.MapUtils;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CollectionUtils {
 
+  /**
+   * Returns null if given map is empty or null.
+   *
+   * @param map given map to check as {@link Map} object
+   * @param <K> generic type for map key
+   * @param <V> generic type for map value
+   * @return map itself if it's not empty, null - otherwise
+   */
   public static <K, V> Map<K, V> nullIfEmpty(Map<K, V> map) {
-    return MapUtils.isEmpty(map) ? null : map;
+    return MapUtils.isNotEmpty(map) ? map : null;
   }
 
+  /**
+   * Merges given array of maps into single {@link LinkedHashMap} object.
+   *
+   * @param maps array of maps to merge into single one.
+   * @param <K> generic type for map key
+   * @param <V> generic type for map value
+   * @return merged maps into one {@link LinkedHashMap} object, null - if result is empty.
+   */
   @SafeVarargs
   public static <K, V> Map<K, V> mergeSafely(Map<K, V>... maps) {
     Map<K, V> baseMap = new LinkedHashMap<>();
 
-    for (Map<K, V> map : maps) {
-      if (map != null && !map.isEmpty()) {
+    for (var map : maps) {
+      if (MapUtils.isNotEmpty(map)) {
         baseMap.putAll(map);
       }
     }
 
     return nullIfEmpty(baseMap);
+  }
+
+  /**
+   * Merges given array of collections into single {@link LinkedHashSet} object.
+   *
+   * @param collections array of maps to merge into single one.
+   * @param <T> generic type for collection value
+   * @return merged maps into one {@link LinkedHashSet} object.
+   */
+  @SafeVarargs
+  public static <T> Collection<T> mergeSafelyToSet(Collection<T>... collections) {
+    var set = new LinkedHashSet<T>();
+    for (Collection<T> collection : collections) {
+      if (isNotEmpty(collection)) {
+        set.addAll(collection);
+      }
+    }
+    return set;
   }
 
   /**
@@ -68,5 +105,34 @@ public final class CollectionUtils {
    */
   public static <T> Stream<T> toStreamSafe(List<T> nullableList) {
     return (nullableList != null && !nullableList.isEmpty()) ? nullableList.stream() : empty();
+  }
+
+  /**
+   * Verifies that some element in iterable satisfies given condition.
+   *
+   * @param collection - collection to check
+   * @param checker - predicate for iterable elements
+   * @param <T> generic type for collection element
+   * @return true if any element matched
+   */
+  public static <T> boolean anyMatch(Iterable<T> collection, Predicate<T> checker) {
+    for (T value : collection) {
+      if (checker.test(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Verifies that all elements in iterable do not satisfy given condition.
+   *
+   * @param collection - collection to check
+   * @param checker - predicate for iterable elements
+   * @param <T> generic type for collection element
+   * @return true if all elements do not match given condition
+   */
+  public static <T> boolean noneMatch(Iterable<T> collection, Predicate<T> checker) {
+    return !anyMatch(collection, checker);
   }
 }

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -1,11 +1,12 @@
 package org.folio.search.utils;
 
+import static java.util.Collections.singletonMap;
 import static java.util.Locale.ROOT;
 import static java.util.stream.Collectors.joining;
 import static org.folio.search.configuration.properties.FolioEnvironment.getFolioEnvName;
 import static org.folio.search.model.metadata.PlainFieldDescription.STANDARD_FIELD_TYPE;
+import static org.folio.search.utils.CollectionUtils.mergeSafelyToSet;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,6 +21,7 @@ import org.folio.search.model.ResourceRequest;
 import org.folio.search.model.SearchResource;
 import org.folio.search.model.metadata.PlainFieldDescription;
 import org.folio.search.model.service.CqlSearchServiceRequest;
+import org.folio.search.model.service.MultilangValue;
 import org.folio.search.model.service.ResourceIdEvent;
 import org.folio.spring.integration.XOkapiHeaders;
 
@@ -27,6 +29,7 @@ import org.folio.spring.integration.XOkapiHeaders;
 public class SearchUtils {
 
   public static final String INSTANCE_RESOURCE = SearchResource.INSTANCE.getName();
+  public static final String CQL_META_FIELD_PREFIX = "cql.";
   public static final String X_OKAPI_TENANT_HEADER = XOkapiHeaders.TENANT;
   public static final String MULTILANG_SOURCE_SUBFIELD = "src";
   public static final String PLAIN_MULTILANG_PREFIX = "plain_";
@@ -37,12 +40,12 @@ public class SearchUtils {
   public static final float CONST_SIZE_LOAD_FACTOR = 1.0f;
 
   /**
-   * Performs elasticsearch exceptional operation and returns the result if it was positive or throws {@link
-   * RuntimeException}.
+   * Performs elasticsearch exceptional operation and returns the received result.
    *
    * @param func exceptional operation as {@link Callable} lambda.
    * @param index elasticsearch index for error message.
    * @param type operation type for error message.
+   * @throws SearchOperationException if function call throws an exception during execution.
    */
   public static <T> T performExceptionalOperation(Callable<T> func, String index, String type) {
     try {
@@ -117,6 +120,12 @@ public class SearchUtils {
     return path + ".*";
   }
 
+  /**
+   * Updates path for field at term-level queries.
+   *
+   * @param path path to field
+   * @return updated path as {@link String} object
+   */
   public static String updatePathForTermQueries(String path) {
     return path.endsWith(".*") ? getPathToPlainMultilangValue(path.substring(0, path.length() - 2)) : path;
   }
@@ -149,7 +158,7 @@ public class SearchUtils {
    * @param callNumberValues array with full call number parts (prefix, call number and suffix)
    * @return created normalized call number as {@link String} value
    */
-  public static String getNormalizedCallNumber(String ... callNumberValues) {
+  public static String getNormalizedCallNumber(String... callNumberValues) {
     return Stream.of(callNumberValues)
       .filter(StringUtils::isNotBlank)
       .map(s -> s.toLowerCase().replaceAll("[^a-z0-9]", ""))
@@ -173,7 +182,7 @@ public class SearchUtils {
     if (STANDARD_FIELD_TYPE.equals(description.getIndex())) {
       return getStandardFulltextValue(fieldName, fieldValue, description.isIndexPlainValue());
     }
-    return Collections.singletonMap(fieldName, fieldValue);
+    return singletonMap(fieldName, fieldValue);
   }
 
   /**
@@ -186,12 +195,14 @@ public class SearchUtils {
    */
   public static Map<String, Object> getMultilangValue(String key, Object value, List<String> languages) {
     var multilangValueMap = new LinkedHashMap<String, Object>(languages.size(), CONST_SIZE_LOAD_FACTOR);
-    languages.forEach(language -> multilangValueMap.put(language, value));
-    multilangValueMap.put(MULTILANG_SOURCE_SUBFIELD, value);
+    var multilangValue = getMultilangValueObject(value);
+
+    languages.forEach(language -> multilangValueMap.put(language, multilangValue));
+    multilangValueMap.put(MULTILANG_SOURCE_SUBFIELD, multilangValue);
 
     var resultMap = new LinkedHashMap<String, Object>(2, CONST_SIZE_LOAD_FACTOR);
     resultMap.put(key, multilangValueMap);
-    resultMap.put(PLAIN_MULTILANG_PREFIX + key, value);
+    resultMap.put(PLAIN_MULTILANG_PREFIX + key, getPlainValueObject(value));
 
     return resultMap;
   }
@@ -206,12 +217,34 @@ public class SearchUtils {
    */
   public static Map<String, Object> getStandardFulltextValue(String key, Object value, boolean indexPlainField) {
     if (!indexPlainField) {
-      return Collections.singletonMap(key, value);
+      return singletonMap(key, value);
     }
     var fulltextValue = new LinkedHashMap<String, Object>(2, CONST_SIZE_LOAD_FACTOR);
     fulltextValue.put(key, value);
     fulltextValue.put(PLAIN_MULTILANG_PREFIX + key, value);
 
     return fulltextValue;
+  }
+
+  /**
+   * Removes 'plain_' prefix from key if it's starting from it, returns given key otherwise.
+   *
+   * @param key field name to analyze
+   * @return key without '_plain' prefix if it's starting from it.
+   */
+  public static String updateMultilangPlainFieldKey(String key) {
+    return key.startsWith(PLAIN_MULTILANG_PREFIX) ? key.substring(PLAIN_MULTILANG_PREFIX.length()) : key;
+  }
+
+  private static Object getMultilangValueObject(Object value) {
+    return value instanceof MultilangValue ? ((MultilangValue) value).getMultilangValues() : value;
+  }
+
+  private static Object getPlainValueObject(Object value) {
+    if (value instanceof MultilangValue) {
+      var multilangValue = (MultilangValue) value;
+      return mergeSafelyToSet(multilangValue.getMultilangValues(), multilangValue.getPlainValues());
+    }
+    return value;
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,14 +30,16 @@ spring:
   liquibase:
     change-log: classpath:changelog/changelog-master.xml
   cache:
-    cache-names: es-indices,identifier-types,alternative-title-types,system-user-cache
+    cache-names: es-indices,identifier-types,alternative-title-types,system-user-cache,tenant-languages
     caffeine:
       spec: maximumSize=500,expireAfterAccess=3600s
 
 application:
   environment: ${ENV:folio}
   search-config:
-    initial-languages: ${INITIAL_LANGUAGES:eng}
+    initial-languages: ${INITIAL_LANGUAGES:eng,fre,ita,spa,ger}
+    disabled-search-options:
+      instance: ${INSTANCE_DISABLED_SEARCH_OPTIONS:cql.all}
   system-user:
     username: mod-search
     password: ${SYSTEM_USER_PASSWORD:Mod-search-1-0-0}
@@ -48,7 +50,7 @@ application:
     retry-delivery-attempts: ${KAFKA_RETRY_DELIVERY_ATTEMPTS:6}
     listener:
       events:
-        concurrency: 2
+        concurrency: ${KAFKA_EVENTS_CONCURRENCY:2}
         topic-pattern: ${KAFKA_EVENTS_CONSUMER_PATTERN:(${application.environment}\.)(.*\.)inventory\.(instance|holdings-record|item)}
         group-id: ${application.environment}-mod-search-events-group
 

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -420,7 +420,7 @@
     "itemsFullCallNumbers": {
       "type": "search",
       "index": "keyword",
-      "inventorySearchTypes": ["items.effectiveCallNumberComponents", "items.fullCallNumber"],
+      "inventorySearchTypes": [ "items.effectiveCallNumberComponents", "items.fullCallNumber" ],
       "processor": "effectiveCallNumberComponentsProcessor"
     },
     "holdingsFullCallNumbers": {
@@ -455,7 +455,36 @@
       "type": "search",
       "index": "multilang",
       "processor": "uniformTitleProcessor"
+    },
+    "allInstance": {
+      "type": "search",
+      "index": "multilang",
+      "processor": "instanceAllFieldValuesProcessor",
+      "rawProcessing": true,
+      "inventorySearchTypes": [ "cql.all", "cql.allInstance" ]
+    },
+    "allItems": {
+      "type": "search",
+      "index": "multilang",
+      "processor": "itemAllFieldValuesProcessor",
+      "rawProcessing": true,
+      "inventorySearchTypes": [ "cql.all", "cql.allItems" ]
+    },
+    "allHoldings": {
+      "type": "search",
+      "index": "multilang",
+      "processor": "holdingAllFieldValuesProcessor",
+      "rawProcessing": true,
+      "inventorySearchTypes": [ "cql.all", "cql.allHoldings" ]
     }
   },
-  "indexMappings": {}
+  "mappingsSource": {
+    "excludes": [
+      "allInstance.*", "plain_allInstance",
+      "allItems.*", "plain_allItems",
+      "allHoldings.*", "plain_allHoldings",
+      "sort_title", "sort_contributors"
+    ]
+  },
+  "indexMappings": { }
 }

--- a/src/test/java/org/folio/search/controller/SearchByAllFieldsIT.java
+++ b/src/test/java/org/folio/search/controller/SearchByAllFieldsIT.java
@@ -1,0 +1,116 @@
+package org.folio.search.controller;
+
+import static org.folio.search.sample.SampleInstances.getSemanticWeb;
+import static org.folio.search.support.base.ApiEndpoints.searchInstancesByQuery;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import org.folio.search.support.base.BaseIntegrationTest;
+import org.folio.search.utils.types.IntegrationTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@IntegrationTest
+@TestPropertySource(properties = {
+  "application.search-config.disabled-search-options.instance="
+})
+public class SearchByAllFieldsIT extends BaseIntegrationTest {
+
+  private static final String TENANT_ID = "search_all";
+
+  @BeforeAll
+  static void beforeAll(@Autowired MockMvc mockMvc) {
+    setUpTenant(TENANT_ID, mockMvc, getSemanticWeb());
+  }
+
+  @AfterAll
+  static void afterAll(@Autowired MockMvc mockMvc) {
+    removeTenant(mockMvc, TENANT_ID);
+  }
+
+  @ValueSource(strings = {
+    // instance field values
+    "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",
+    "A semantic web primer",
+    "An alternative title",
+    "Cooperative information systems",
+    "0262012103",
+    "2003065165",
+    "Antoniou, Grigoris",
+    "TK5105.88815 .A58 2004",
+
+    // holding field values
+    "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19",
+    "ho00000000006",
+    "ho00000000007",
+    "TK5105.88815 . A58 2004 FT MEADE",
+    "Includes bibliographical references and index of holdings.",
+
+    // item field values
+    "7212ba6a-8dcf-45a1-be9a-ffaa847c4423",
+    "TK5105.88815 . A58 2004 FT MEADE",
+    "item000000000014",
+    "item_accession_number",
+    "Available",
+  })
+  @ParameterizedTest(name = "[{index}] cql.all='{query}', query=''{0}''")
+  void canSearchByAllFieldValues_positive(String value) throws Throwable {
+    var query = "cql.all=\"{query}\"";
+    doGet(searchInstancesByQuery(query), value)
+      .andExpect(jsonPath("totalRecords", is(1)))
+      .andExpect(jsonPath("instances[0].id", is(getSemanticWeb().getId())));
+  }
+
+  @ValueSource(strings = {
+    "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",
+    "A semantic web primer",
+    "An alternative title",
+    "Cooperative information systems",
+    "0262012103",
+    "2003065165",
+    "Antoniou, Grigoris",
+    "TK5105.88815 .A58 2004",
+  })
+  @ParameterizedTest(name = "[{index}] cql.allInstance='{query}', query=''{0}''")
+  void canSearchByInstanceFieldValues_positive(String value) throws Throwable {
+    var query = "cql.allInstance=\"{query}\"";
+    doGet(searchInstancesByQuery(query), value)
+      .andExpect(jsonPath("totalRecords", is(1)))
+      .andExpect(jsonPath("instances[0].id", is(getSemanticWeb().getId())));
+  }
+
+  @ValueSource(strings = {
+    "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19",
+    "ho00000000006",
+    "ho00000000007",
+    "TK5105.88815 . A58 2004 FT MEADE",
+    "Includes bibliographical references and index of holdings.",
+  })
+  @ParameterizedTest(name = "[{index}] cql.allHoldings='{query}', query=''{0}''")
+  void canSearchByHoldingFieldValues_positive(String value) throws Throwable {
+    var query = "cql.allHoldings=\"{query}\"";
+    doGet(searchInstancesByQuery(query), value)
+      .andExpect(jsonPath("totalRecords", is(1)))
+      .andExpect(jsonPath("instances[0].id", is(getSemanticWeb().getId())));
+  }
+
+  @ValueSource(strings = {
+    "7212ba6a-8dcf-45a1-be9a-ffaa847c4423",
+    "TK5105.88815 . A58 2004 FT MEADE",
+    "item000000000014",
+    "item_accession_number",
+    "Available",
+  })
+  @ParameterizedTest(name = "[{index}] cql.allItems='{query}', query=''{0}''")
+  void canSearchByItemFieldValues_positive(String value) throws Throwable {
+    var query = "cql.allItems=\"{query}\"";
+    doGet(searchInstancesByQuery(query), value)
+      .andExpect(jsonPath("totalRecords", is(1)))
+      .andExpect(jsonPath("instances[0].id", is(getSemanticWeb().getId())));
+  }
+}

--- a/src/test/java/org/folio/search/integration/ResourceFetchServiceTest.java
+++ b/src/test/java/org/folio/search/integration/ResourceFetchServiceTest.java
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import org.folio.search.domain.dto.Instance;
@@ -63,6 +64,12 @@ class ResourceFetchServiceTest {
 
     verify(jsonConverter).convert(instance1.toInstance(), MAP_TYPE_REFERENCE);
     verify(jsonConverter).convert(instance2.toInstance(), MAP_TYPE_REFERENCE);
+  }
+
+  @Test
+  void fetchInstancesByIds_positive_emptyListOfIds() {
+    var actual = resourceFetchService.fetchInstancesByIds(Collections.emptyList());
+    assertThat(actual).isEmpty();
   }
 
   private static List<ResourceIdEvent> resourceIdEvents() {

--- a/src/test/java/org/folio/search/model/metadata/PostProcessResourceDescriptionConverterTest.java
+++ b/src/test/java/org/folio/search/model/metadata/PostProcessResourceDescriptionConverterTest.java
@@ -15,9 +15,8 @@ import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.Test;
 
 @UnitTest
-class PostProcessResourceDescriptionConverterTest {
-  private final PostProcessResourceDescriptionConverter converter =
-    new PostProcessResourceDescriptionConverter();
+public class PostProcessResourceDescriptionConverterTest {
+  private final PostProcessResourceDescriptionConverter converter = new PostProcessResourceDescriptionConverter();
 
   @Test
   void canFlattenNestedObjectFields() {

--- a/src/test/java/org/folio/search/sample/SampleInstances.java
+++ b/src/test/java/org/folio/search/sample/SampleInstances.java
@@ -4,6 +4,8 @@ import static java.util.Arrays.asList;
 import static org.folio.search.utils.TestUtils.OBJECT_MAPPER;
 import static org.folio.search.utils.TestUtils.readJsonFromFile;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.folio.search.domain.dto.Holding;
@@ -16,6 +18,10 @@ public class SampleInstances {
 
   public static Instance getSemanticWeb() {
     return OBJECT_MAPPER.convertValue(SEMANTIC_WEB, Instance.class);
+  }
+
+  public static Map<String, Object> getSemanticWebAsMap() {
+    return OBJECT_MAPPER.convertValue(SEMANTIC_WEB, new TypeReference<>() {});
   }
 
   private static Instance readSampleInstance(String sampleName) {

--- a/src/test/java/org/folio/search/service/LanguageConfigServiceTest.java
+++ b/src/test/java/org/folio/search/service/LanguageConfigServiceTest.java
@@ -20,7 +20,7 @@ import org.folio.search.domain.dto.LanguageConfig;
 import org.folio.search.exception.ValidationException;
 import org.folio.search.model.config.LanguageConfigEntity;
 import org.folio.search.repository.LanguageConfigRepository;
-import org.folio.search.service.metadata.ResourceDescriptionService;
+import org.folio.search.service.metadata.LocalSearchFieldProvider;
 import org.folio.search.utils.SearchUtils;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.Test;
@@ -38,13 +38,13 @@ class LanguageConfigServiceTest {
 
   @InjectMocks private LanguageConfigService configService;
   @Mock private LanguageConfigRepository configRepository;
-  @Mock private ResourceDescriptionService descriptionService;
+  @Mock private LocalSearchFieldProvider searchFieldProvider;
   @Mock private TenantScopedExecutionService tenantScopedExecutionService;
 
   @Test
   void canAddLanguageConfig() {
     when(configRepository.count()).thenReturn(0L);
-    when(descriptionService.isSupportedLanguage(SUPPORTED_LANGUAGE_CODE)).thenReturn(true);
+    when(searchFieldProvider.isSupportedLanguage(SUPPORTED_LANGUAGE_CODE)).thenReturn(true);
     when(configRepository.save(any(LanguageConfigEntity.class)))
       .thenReturn(new LanguageConfigEntity(SUPPORTED_LANGUAGE_CODE, null));
 
@@ -72,7 +72,7 @@ class LanguageConfigServiceTest {
     final var languageConfig = new LanguageConfig().code(SUPPORTED_LANGUAGE_CODE);
 
     when(configRepository.count()).thenReturn(5L);
-    when(descriptionService.isSupportedLanguage(SUPPORTED_LANGUAGE_CODE)).thenReturn(true);
+    when(searchFieldProvider.isSupportedLanguage(SUPPORTED_LANGUAGE_CODE)).thenReturn(true);
 
     assertThrows(ValidationException.class, () -> configService.create(languageConfig));
   }

--- a/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
+++ b/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
@@ -5,6 +5,7 @@ import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Set;
@@ -84,5 +85,14 @@ class SearchTenantServiceTest {
     TenantAttributes attributes = TENANT_ATTRIBUTES.addParametersItem(new Parameter().key("runReindexx").value("true"));
     searchTenantService.initializeTenant(attributes);
     verify(indexService, times(0)).reindexInventory(TENANT_ID, null);
+  }
+
+  @Test
+  void removeElasticsearchIndices_positive() {
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    searchTenantService.removeElasticsearchIndexes();
+
+    verify(indexService).dropIndex(INSTANCE.getName(), TENANT_ID);
+    verifyNoMoreInteractions(indexService);
   }
 }

--- a/src/test/java/org/folio/search/service/context/FolioExecutionProcessingContextBuilderTest.java
+++ b/src/test/java/org/folio/search/service/context/FolioExecutionProcessingContextBuilderTest.java
@@ -9,7 +9,7 @@ import org.folio.spring.FolioModuleMetadata;
 import org.junit.jupiter.api.Test;
 
 @UnitTest
-class FolioExecutionContextBuilderTest {
+class FolioExecutionProcessingContextBuilderTest {
   private final FolioExecutionContextBuilder builder =
     new FolioExecutionContextBuilder(mock(FolioModuleMetadata.class));
 

--- a/src/test/java/org/folio/search/service/converter/SearchDocumentConverterTest.java
+++ b/src/test/java/org/folio/search/service/converter/SearchDocumentConverterTest.java
@@ -49,9 +49,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class SearchDocumentConverterTest {
 
   @InjectMocks private SearchDocumentConverter documentMapper;
-  @Mock private ResourceDescriptionService descriptionService;
   @Mock private LanguageConfigService languageConfigService;
   @Mock private SearchFieldsProcessor searchFieldsProcessor;
+  @Mock private ResourceDescriptionService descriptionService;
   @Spy private final JsonConverter jsonConverter = new JsonConverter(OBJECT_MAPPER);
 
   @Test

--- a/src/test/java/org/folio/search/service/es/SearchMappingsHelperTest.java
+++ b/src/test/java/org/folio/search/service/es/SearchMappingsHelperTest.java
@@ -83,8 +83,9 @@ class SearchMappingsHelperTest {
         "subtitle", jsonObject("type", "text"),
         "isbn", jsonObject("type", KEYWORD_TYPE, "normalizer", "lowercase_normalizer"),
         "metadata", jsonObject("properties", jsonObject("createdDate", dateType.getMapping())),
-        "identifiers", keywordType.getMapping()
-      ))));
+        "identifiers", keywordType.getMapping()),
+      "_source", jsonObject("excludes", jsonArray("plain_all"))
+    )));
     verify(jsonConverter).toJson(anyMap());
   }
 
@@ -210,6 +211,7 @@ class SearchMappingsHelperTest {
         "createdDate", plainField("date")
       ))));
     resourceDescription.setSearchFields(mapOf("identifiers", searchField("isbn_identifier")));
+    resourceDescription.setMappingsSource(mapOf("excludes", List.of("plain_all")));
     return resourceDescription;
   }
 

--- a/src/test/java/org/folio/search/service/metadata/LocalSearchFieldProviderTest.java
+++ b/src/test/java/org/folio/search/service/metadata/LocalSearchFieldProviderTest.java
@@ -2,12 +2,15 @@ package org.folio.search.service.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.utils.JsonUtils.jsonObject;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestUtils.mapOf;
+import static org.folio.search.utils.TestUtils.multilangField;
 import static org.folio.search.utils.TestUtils.objectField;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,10 +25,12 @@ import org.folio.search.model.metadata.SearchFieldType;
 import org.folio.search.utils.TestUtils;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -39,13 +44,13 @@ class LocalSearchFieldProviderTest {
 
   @InjectMocks private LocalSearchFieldProvider searchFieldProvider;
   @Mock private LocalResourceProvider localResourceProvider;
-  private final PostProcessResourceDescriptionConverter converter =
-    new PostProcessResourceDescriptionConverter();
+  private final PostProcessResourceDescriptionConverter converter = new PostProcessResourceDescriptionConverter();
 
   @BeforeEach
   void setUp() {
-    when(localResourceProvider.getSearchFieldTypes()).thenReturn(mapOf("keyword", new SearchFieldType()));
-    when(localResourceProvider.getResourceDescriptions()).thenReturn(resourceDescriptions());
+    when(localResourceProvider.getResourceDescriptions()).thenReturn(List.of(resourceDescription()));
+    when(localResourceProvider.getSearchFieldTypes()).thenReturn(mapOf(
+      "keyword", new SearchFieldType(), "multilang", SearchFieldType.of(multilangMappings())));
     searchFieldProvider.init();
   }
 
@@ -65,8 +70,8 @@ class LocalSearchFieldProviderTest {
   @Test
   void getFieldByInventorySearchType_positive() {
     var fields = searchFieldProvider.getFields(RESOURCE_NAME, TITLE_SEARCH_TYPE);
-    assertThat(fields).containsExactlyInAnyOrder("title1.*", "title2.sub1", "title2.sub2.*",
-      "title2.sub3.sub4", "search1");
+    assertThat(fields).containsExactlyInAnyOrder(
+      "title1.*", "title2.sub1", "title2.sub2.*", "title2.sub3.sub4", "search1");
   }
 
   @Test
@@ -90,89 +95,117 @@ class LocalSearchFieldProviderTest {
 
   @Test
   void shouldAddStarNotationForMultilangField() {
-    when(localResourceProvider.getResourceDescription(RESOURCE_NAME))
-      .thenReturn(Optional.of(resourceDescriptions().get(0)));
-
-    assertThat(searchFieldProvider.getFields(RESOURCE_NAME, "title2.sub3.sub5"))
-      .containsExactly("title2.sub3.sub5.*");
+    when(localResourceProvider.getResourceDescription(RESOURCE_NAME)).thenReturn(Optional.of(resourceDescription()));
+    assertThat(searchFieldProvider.getFields(RESOURCE_NAME, "title2.sub3.sub5")).containsExactly("title2.sub3.sub5.*");
   }
 
-  @MethodSource("getFieldsByPathDataProvider")
+  @MethodSource("getPlainFieldsByPathDataProvider")
   @ParameterizedTest(name = "[{index}] path={0}")
-  void getFieldByPath_positive_parameterized(String path, FieldDescription expected) {
-    when(localResourceProvider.getResourceDescription(RESOURCE_NAME))
-      .thenReturn(Optional.of(resourceDescriptions().get(0)));
-    var actual = searchFieldProvider.getFieldByPath(RESOURCE_NAME, path);
+  void getPlainFieldByPath_positive_parameterized(String path, FieldDescription expected) {
+    when(localResourceProvider.getResourceDescription(RESOURCE_NAME)).thenReturn(Optional.of(resourceDescription()));
+    var actual = searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, path);
     assertThat(actual).isEqualTo(Optional.ofNullable(expected));
   }
 
   @Test
   void getPlainFieldByPath_positive() {
-    when(localResourceProvider.getResourceDescription(RESOURCE_NAME))
-      .thenReturn(Optional.of(resourceDescriptions().get(0)));
+    when(localResourceProvider.getResourceDescription(RESOURCE_NAME)).thenReturn(Optional.of(resourceDescription()));
     var actual = searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, "id");
     assertThat(actual).isPresent().get().isEqualTo(plainField("keyword", true));
   }
 
-  @Test
-  void getPlainFieldByPath_negative() {
-    when(localResourceProvider.getResourceDescription(RESOURCE_NAME))
-      .thenReturn(Optional.of(resourceDescriptions().get(0)));
-    var actual = searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, "title2.sub3");
-    assertThat(actual).isEmpty();
-  }
-
-  @Test
-  void getFieldByPath_negative_nonExistingResourceDescription() {
-    when(localResourceProvider.getResourceDescription(RESOURCE_NAME))
-      .thenReturn(Optional.of(resourceDescriptions().get(0)));
-    var actual = searchFieldProvider.getFieldByPath(RESOURCE_NAME, "path");
-    assertThat(actual).isEmpty();
-  }
-
-  @Test
-  void getFieldByPath_negative_emptyPath() {
-    when(localResourceProvider.getResourceDescription(RESOURCE_NAME))
-      .thenReturn(Optional.of(resourceDescriptions().get(0)));
-    var actual = searchFieldProvider.getFieldByPath(RESOURCE_NAME, "  ");
+  @DisplayName("getPlainFieldByPath_parameterized")
+  @ParameterizedTest(name = "[{index}] value=''{0}''")
+  @CsvSource({",", "'',", "'   '", "path", "title.sub3"})
+  void getPlainFieldByPath_negative_parameterized(String path) {
+    when(localResourceProvider.getResourceDescription(RESOURCE_NAME)).thenReturn(Optional.of(resourceDescription()));
+    var actual = searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, path);
     assertThat(actual).isEmpty();
   }
 
   @Test
   void getFieldByPath_negative_resourceDescriptionNotFound() {
     when(localResourceProvider.getResourceDescription(RESOURCE_NAME)).thenReturn(Optional.empty());
-    var actual = searchFieldProvider.getFieldByPath(RESOURCE_NAME, "id");
+    var actual = searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, "id");
     assertThat(actual).isEmpty();
   }
 
-  private List<ResourceDescription> resourceDescriptions() {
-    return List.of(converter.convert(
+  @ParameterizedTest
+  @DisplayName("isSupportedLanguage_parameterized")
+  @CsvSource({"eng,true", "ara,false", "spa,true"})
+  void isSupportedLanguage_parameterized(String language, boolean expected) {
+    var actual = searchFieldProvider.isSupportedLanguage(language);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @CsvSource({
+    "cql.all,allInstance.*;plain_allInstance;allItems.*;plain_allItems;allHoldings.*;plain_allHoldings",
+    "cql.allInstance,allInstance.*;plain_allInstance",
+    "cql.allItems,allItems.*;plain_allItems",
+    "cql.allHoldings,allHoldings.*;plain_allHoldings",
+  })
+  @ParameterizedTest
+  @DisplayName("getFields_cqlAll_parameterized")
+  void getFields_cqlAll_parameterized(String inventorySearchType, String fieldsAsString) {
+    var expectedFields = List.of(fieldsAsString.split(";"));
+    var actual = searchFieldProvider.getFields(RESOURCE_NAME, inventorySearchType);
+    assertThat(actual).isEqualTo(expectedFields);
+  }
+
+  @ParameterizedTest
+  @DisplayName("isMultilangField_parameterized")
+  @CsvSource({"id,false", "allItems,true", "title1,true", "title2,false", "title2.sub1,false", "title2.sub2,true"})
+  void isMultilangField_parameterized(String fieldName, boolean expected) {
+    when(localResourceProvider.getResourceDescription(RESOURCE_NAME)).thenReturn(Optional.of(resourceDescription()));
+    var actual = searchFieldProvider.isMultilangField(RESOURCE_NAME, fieldName);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  private ResourceDescription resourceDescription() {
+    return converter.convert(
       resourceDescription(mapOf(
-        "id", plainField("keyword", true),
-        "title1", plainField("multilang", true, TITLE_SEARCH_TYPE),
-        "title2", objectField(mapOf(
-          "sub1", plainField("keyword", true, TITLE_SEARCH_TYPE),
-          "sub2", plainField("multilang", false, TITLE_SEARCH_TYPE),
-          "sub3", objectField(mapOf(
-            "sub4", plainField("keyword", false, TITLE_SEARCH_TYPE),
-            "sub5", plainField("multilang", true))))),
-        "source", plainField("keyword", true)),
+          "id", plainField("keyword", true),
+          "allInstance", multilangField("cql.all", "cql.allInstance"),
+          "allItems", multilangField("cql.all", "cql.allItems"),
+          "allHoldings", multilangField("cql.all", "cql.allHoldings"),
+          "title1", plainField("multilang", true, TITLE_SEARCH_TYPE),
+          "title2", objectField(mapOf(
+            "sub1", plainField("keyword", true, TITLE_SEARCH_TYPE),
+            "sub2", plainField("multilang", false, TITLE_SEARCH_TYPE),
+            "sub3", objectField(mapOf(
+              "sub4", plainField("keyword", false, TITLE_SEARCH_TYPE),
+              "sub5", plainField("multilang", true))))),
+          "source", plainField("keyword", true)),
         mapOf(
           "search1", searchField(TITLE_SEARCH_TYPE),
           "search2", searchField()))
+    );
+  }
+
+  private static ResourceDescription resourceDescription(
+    Map<String, FieldDescription> fields, Map<String, SearchFieldDescriptor> searchFields) {
+
+    var resourceDescription = TestUtils.resourceDescription(fields);
+    resourceDescription.setSearchFields(searchFields);
+
+    return resourceDescription;
+  }
+
+  private ObjectNode multilangMappings() {
+    return jsonObject("properties", jsonObject(
+      "eng", jsonObject("type", "text", "analyzer", "english"),
+      "ger", jsonObject("type", "text", "analyzer", "german"),
+      "spa", jsonObject("type", "text", "analyzer", "spanish"),
+      "src", jsonObject("type", "text", "analyzer", "standard")
     ));
   }
 
-  // Data provider for a test
-  @SuppressWarnings("unused")
-  private static Stream<Arguments> getFieldsByPathDataProvider() {
+  private static Stream<Arguments> getPlainFieldsByPathDataProvider() {
     return Stream.of(
       arguments("id", plainField("keyword", true)),
       arguments("title2.sub1", plainField("keyword", true, TITLE_SEARCH_TYPE)),
       arguments("title2.sub3.sub4", plainField("keyword", false, TITLE_SEARCH_TYPE)),
-      arguments("title2.sub3", objectField(mapOf(
-        "sub4", plainField("keyword", false, TITLE_SEARCH_TYPE),
-        "sub5", plainField("multilang", true)))),
+      arguments("title2.sub3", null),
       arguments("title4", null),
       arguments("title1.subfield", null),
       arguments("title2.subfield", null),
@@ -194,14 +227,5 @@ class LocalSearchFieldProviderTest {
     fieldDescription.setInventorySearchTypes(List.of(searchTypes));
     fieldDescription.setProcessor("processor");
     return fieldDescription;
-  }
-
-  private static ResourceDescription resourceDescription(
-    Map<String, FieldDescription> fields, Map<String, SearchFieldDescriptor> searchFields) {
-
-    var resourceDescription = TestUtils.resourceDescription(fields);
-    resourceDescription.setSearchFields(searchFields);
-
-    return resourceDescription;
   }
 }

--- a/src/test/java/org/folio/search/service/setter/holding/HoldingAllFieldValuesProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/holding/HoldingAllFieldValuesProcessorTest.java
@@ -1,0 +1,97 @@
+package org.folio.search.service.setter.holding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
+import static org.folio.search.utils.TestUtils.mapOf;
+import static org.folio.search.utils.TestUtils.randomId;
+import static org.folio.search.utils.TestUtils.toMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import org.folio.search.domain.dto.Holding;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Note;
+import org.folio.search.domain.dto.Tags;
+import org.folio.search.model.service.MultilangValue;
+import org.folio.search.service.metadata.SearchFieldProvider;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class HoldingAllFieldValuesProcessorTest {
+
+  private static final String HOLDING_ID_1 = randomId();
+  private static final String HOLDING_ID_2 = randomId();
+  private static final Set<String> MULTILANG_VALUE_PATHS = Set.of("holdings.notes.note", "holdings.tags.tagList");
+
+  @InjectMocks private HoldingAllFieldValuesProcessor processor;
+  @Mock private SearchFieldProvider searchFieldProvider;
+
+  @BeforeEach
+  void setUp() {
+    processor.setSearchFieldProvider(searchFieldProvider);
+  }
+
+  @Test
+  void getFieldValue_positive() {
+    when(searchFieldProvider.isMultilangField(eq(INSTANCE_RESOURCE), anyString())).thenAnswer(inv ->
+      MULTILANG_VALUE_PATHS.contains(inv.<String>getArgument(1)));
+
+    var actual = processor.getFieldValue(toMap(
+      new Instance().id(randomId()).holdings(List.of(holding1(), holding2()))));
+
+    assertThat(actual).isEqualTo(MultilangValue.of(
+      newLinkedHashSet(HOLDING_ID_1, "h001", "DA 3900 C89", HOLDING_ID_2, "h002", "CE 16 B6724 41993"),
+      newLinkedHashSet("tag1", "tag2", "privateNote", "publicNote", "tag3")));
+  }
+
+  @Test
+  void getFieldValue_holdingFieldsFromSearchGeneratedValues() {
+    when(searchFieldProvider.isMultilangField(INSTANCE_RESOURCE, "holdingPublicNotes")).thenReturn(true);
+    when(searchFieldProvider.isMultilangField(INSTANCE_RESOURCE, "holdingsFullCallNumbers")).thenReturn(false);
+
+    var actual = processor.getFieldValue(mapOf(
+      "holdingPublicNotes", List.of("note1", "note2"),
+      "holdingsFullCallNumbers", List.of("callNumber1", "callNumber2")));
+
+    assertThat(actual).isEqualTo(MultilangValue.of(
+      newLinkedHashSet("callNumber1", "callNumber2"), newLinkedHashSet("note1", "note2")));
+  }
+
+  private static Holding holding1() {
+    return new Holding()
+      .id(HOLDING_ID_1)
+      .hrid("h001")
+      .permanentLocationId(randomId())
+      .callNumber("DA 3900 C89")
+      .discoverySuppress(false)
+      .tags(new Tags().tagList(List.of("tag1", "tag2")))
+      .notes(List.of(
+        new Note().note("publicNote").staffOnly(false),
+        new Note().note("privateNote").staffOnly(true)));
+  }
+
+  private static Holding holding2() {
+    return new Holding()
+      .id(HOLDING_ID_2)
+      .hrid("h002")
+      .permanentLocationId(randomId())
+      .formerIds(List.of(randomId(), randomId()))
+      .callNumber("CE 16 B6724 41993")
+      .discoverySuppress(true)
+      .tags(new Tags().tagList(List.of("tag1", "tag3")))
+      .notes(List.of(
+        new Note().note("publicNote").staffOnly(false),
+        new Note().note("privateNote").staffOnly(true)));
+  }
+}

--- a/src/test/java/org/folio/search/service/setter/instance/InstanceAllFieldValuesProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/instance/InstanceAllFieldValuesProcessorTest.java
@@ -1,0 +1,155 @@
+package org.folio.search.service.setter.instance;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
+import static org.folio.search.utils.TestUtils.mapOf;
+import static org.folio.search.utils.TestUtils.randomId;
+import static org.folio.search.utils.TestUtils.toMap;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.folio.search.domain.dto.Holding;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.InstanceIdentifiers;
+import org.folio.search.domain.dto.Item;
+import org.folio.search.domain.dto.Note;
+import org.folio.search.model.service.MultilangValue;
+import org.folio.search.service.metadata.SearchFieldProvider;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class InstanceAllFieldValuesProcessorTest {
+
+  @InjectMocks private InstanceAllFieldValuesProcessor processor;
+  @Mock private SearchFieldProvider searchFieldProvider;
+
+  @BeforeEach
+  void setUp() {
+    processor.setSearchFieldProvider(searchFieldProvider);
+  }
+
+  @Test
+  void getFieldValue_positive_emptyValue() {
+    var actual = processor.getFieldValue(emptyMap());
+    assertThat(actual).isEqualTo(MultilangValue.empty());
+  }
+
+  @Test
+  void getFieldValue_positive_multilangTitle() {
+    var instanceId = randomId();
+    when(searchFieldProvider.isMultilangField(INSTANCE_RESOURCE, "id")).thenReturn(false);
+    when(searchFieldProvider.isMultilangField(INSTANCE_RESOURCE, "title")).thenReturn(true);
+    var actual = processor.getFieldValue(toMap(new Instance().id(instanceId).title("my resource")));
+    assertThat(actual).isEqualTo(MultilangValue.of(singleton(instanceId), newLinkedHashSet("my resource")));
+  }
+
+  @Test
+  void getFieldValue_positive_multilangSubjects() {
+    when(searchFieldProvider.isMultilangField(INSTANCE_RESOURCE, "subjects")).thenReturn(true);
+    var actual = processor.getFieldValue(toMap(new Instance().subjects(List.of("subject1", "subject2"))));
+    assertThat(actual).isEqualTo(MultilangValue.of(emptySet(), newLinkedHashSet("subject1", "subject2")));
+  }
+
+  @Test
+  void getFieldValue_positive_identifiers() {
+    var actual = processor.getFieldValue(toMap(new Instance().identifiers(List.of(
+      new InstanceIdentifiers().identifierTypeId(randomId()).value("978-1-56619-909-4"),
+      new InstanceIdentifiers().identifierTypeId(randomId()).value("1-56619-909-3")))));
+    assertThat(actual).isEqualTo(MultilangValue.of(
+      newLinkedHashSet("978-1-56619-909-4", "1-56619-909-3"), emptySet()));
+    verify(searchFieldProvider, times(2)).isMultilangField(INSTANCE_RESOURCE, "identifiers.value");
+  }
+
+  @Test
+  void getFieldValue_positive_instanceNotes() {
+    var actual = processor.getFieldValue(toMap(new Instance().notes(List.of(
+      new Note().note("public note").staffOnly(false),
+      new Note().note("private note").staffOnly(true)))));
+    assertThat(actual).isEqualTo(MultilangValue.of(newLinkedHashSet("public note", "private note"), emptySet()));
+    verify(searchFieldProvider, times(2)).isMultilangField(INSTANCE_RESOURCE, "notes.note");
+  }
+
+  @Test
+  void getFieldValue_positive_classification() {
+    var actual = processor.getFieldValue(mapOf("matchKey", "123456"));
+    assertThat(actual).isEqualTo(MultilangValue.of(newLinkedHashSet("123456"), emptySet()));
+    verify(searchFieldProvider).isMultilangField(INSTANCE_RESOURCE, "matchKey");
+  }
+
+  @Test
+  void getFieldValue_positive_searchFieldProcessedIsbn() {
+    var isbnValues = newLinkedHashSet("1-56619-909-3", "1566199093", "9781566199093");
+    var actual = processor.getFieldValue(mapOf("isbn", isbnValues));
+    assertThat(actual).isEqualTo(MultilangValue.of(isbnValues, emptySet()));
+    verify(searchFieldProvider, times(3)).isMultilangField(INSTANCE_RESOURCE, "isbn");
+  }
+
+  @Test
+  void getFieldValue_positive_multilangTitleValue() {
+    when(searchFieldProvider.isMultilangField(INSTANCE_RESOURCE, "title")).thenReturn(true);
+
+    var value = "titleValue";
+    var actual = processor.getFieldValue(mapOf("plain_title", value, "title", mapOf("src", value, "eng", value)));
+
+    assertThat(actual).isEqualTo(MultilangValue.of(emptySet(), singleton(value)));
+  }
+
+  @Test
+  void getFieldValue_positive_holdingsAndItemSearchFieldValue() {
+    var actual = processor.getFieldValue(mapOf(
+      "itemPublicNotes", List.of("note1", "note2"),
+      "holdingsFullCallNumbers", List.of("callNumber1", "callNumber2")));
+
+    assertThat(actual).isEqualTo(MultilangValue.empty());
+  }
+
+  @Test
+  void getFieldValue_positive_publication() {
+    var actual = processor.getFieldValue(mapOf(
+      "publication", List.of(mapOf(
+        "publisher", "MIT Press",
+        "place", "Cambridge, Mass. ",
+        "dateOfPublication", "c2004",
+        "role", "Publisher"
+      ))));
+
+    assertThat(actual).isEqualTo(MultilangValue.of(
+      List.of("MIT Press", "Cambridge, Mass.", "c2004", "Publisher"), emptyList()));
+  }
+
+  @Test
+  void getFieldValue_positive_fieldWithEmptyMapValue() {
+    var actual = processor.getFieldValue(mapOf("identifiers", emptyMap()));
+    assertThat(actual).isEqualTo(MultilangValue.empty());
+  }
+
+  @Test
+  void getFieldValue_positive_fieldWithEmptyListValue() {
+    var actual = processor.getFieldValue(mapOf("subjects", emptyList()));
+    assertThat(actual).isEqualTo(MultilangValue.empty());
+  }
+
+  @Test
+  void getFieldValue_positive_itemsAndHoldings() {
+    var instanceId = randomId();
+    var actual = processor.getFieldValue(toMap(new Instance().id(instanceId)
+      .items(List.of(new Item().id(randomId()).barcode("000333"), new Item().id(randomId()).hrid("i1")))
+      .holdings(List.of(new Holding().id(randomId()).hrid("h1")))));
+    assertThat(actual).isEqualTo(MultilangValue.of(singleton(instanceId), emptySet()));
+    verify(searchFieldProvider).isMultilangField(INSTANCE_RESOURCE, "id");
+  }
+}

--- a/src/test/java/org/folio/search/service/setter/item/ItemAllFieldValuesProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemAllFieldValuesProcessorTest.java
@@ -1,0 +1,96 @@
+package org.folio.search.service.setter.item;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
+import static org.folio.search.utils.TestUtils.mapOf;
+import static org.folio.search.utils.TestUtils.randomId;
+import static org.folio.search.utils.TestUtils.toMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Item;
+import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
+import org.folio.search.domain.dto.Note;
+import org.folio.search.domain.dto.Tags;
+import org.folio.search.model.service.MultilangValue;
+import org.folio.search.service.metadata.SearchFieldProvider;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class ItemAllFieldValuesProcessorTest {
+
+  private static final String ITEM_ID_1 = randomId();
+  private static final String ITEM_ID_2 = randomId();
+  private static final Set<String> MULTILANG_VALUE_PATHS = Set.of("items.notes.note", "items.tags.tagList");
+
+  @InjectMocks private ItemAllFieldValuesProcessor processor;
+  @Mock private SearchFieldProvider searchFieldProvider;
+
+  @BeforeEach
+  void setUp() {
+    processor.setSearchFieldProvider(searchFieldProvider);
+  }
+
+  @Test
+  void getFieldValue_positive() {
+    when(searchFieldProvider.isMultilangField(eq(INSTANCE_RESOURCE), anyString())).thenAnswer(inv ->
+      MULTILANG_VALUE_PATHS.contains(inv.<String>getArgument(1)));
+
+    var actual = processor.getFieldValue(toMap(
+      new Instance().id(randomId()).items(List.of(item1(), item2()))));
+
+    assertThat(actual).isEqualTo(MultilangValue.of(
+      newLinkedHashSet(ITEM_ID_1, "i001", "DA 3900 C89", ITEM_ID_2, "i002", "CE 16 B6724 41993"),
+      newLinkedHashSet("tag1", "tag2", "privateNote", "publicNote", "tag3")));
+  }
+
+  @Test
+  void getFieldValue_holdingFieldsFromSearchGeneratedValues() {
+    when(searchFieldProvider.isMultilangField(INSTANCE_RESOURCE, "itemPublicNotes")).thenReturn(true);
+    when(searchFieldProvider.isMultilangField(INSTANCE_RESOURCE, "itemsFullCallNumbers")).thenReturn(false);
+
+    var actual = processor.getFieldValue(mapOf(
+      "itemPublicNotes", List.of("note1", "note2"),
+      "itemsFullCallNumbers", List.of("callNumber1", "callNumber2")));
+
+    assertThat(actual).isEqualTo(MultilangValue.of(
+      newLinkedHashSet("callNumber1", "callNumber2"), newLinkedHashSet("note1", "note2")));
+  }
+
+  private static Item item1() {
+    return new Item()
+      .id(ITEM_ID_1)
+      .hrid("i001")
+      .effectiveCallNumberComponents(new ItemEffectiveCallNumberComponents().callNumber("DA 3900 C89"))
+      .discoverySuppress(false)
+      .effectiveLocationId(randomId())
+      .tags(new Tags().tagList(List.of("tag1", "tag2")))
+      .notes(List.of(
+        new Note().note("publicNote").staffOnly(false),
+        new Note().note("privateNote").staffOnly(true)));
+  }
+
+  private static Item item2() {
+    return new Item()
+      .id(ITEM_ID_2)
+      .hrid("i002")
+      .effectiveCallNumberComponents(new ItemEffectiveCallNumberComponents().callNumber("CE 16 B6724 41993"))
+      .discoverySuppress(true)
+      .tags(new Tags().tagList(List.of("tag1", "tag3")))
+      .notes(List.of(
+        new Note().note("publicNote").staffOnly(false),
+        new Note().note("privateNote").staffOnly(true)));
+  }
+}

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -39,6 +39,8 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.http.HttpHeaders;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -49,7 +51,9 @@ import org.springframework.test.web.servlet.ResultActions;
 @SpringBootTest
 @EnableElasticSearch
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public abstract class BaseIntegrationTest {
+
   protected static InventoryApi inventoryApi;
   private static OkapiConfiguration okapi;
   @Autowired protected MockMvc mockMvc;
@@ -132,8 +136,8 @@ public abstract class BaseIntegrationTest {
   @SneakyThrows
   public static ResultActions doGet(MockMvc mockMvc, String uri, Object... args) {
     return mockMvc.perform(get(uri, args)
-      .headers(defaultHeaders())
-      .header("Accept", "application/json;charset=UTF-8"))
+        .headers(defaultHeaders())
+        .header("Accept", "application/json;charset=UTF-8"))
       .andExpect(status().isOk());
   }
 
@@ -145,16 +149,16 @@ public abstract class BaseIntegrationTest {
   @SneakyThrows
   public static ResultActions doDelete(MockMvc mockMvc, String uri, Object... args) {
     return mockMvc.perform(delete(uri, args)
-      .headers(defaultHeaders()))
+        .headers(defaultHeaders()))
       .andExpect(status().isNoContent());
   }
 
   @SneakyThrows
   protected static void setUpTenant(String tenantName, MockMvc mockMvc, Instance... instances) {
     mockMvc.perform(post("/_/tenant")
-      .content(asJsonString(new TenantAttributes().moduleTo("mod-search-1.0.0")))
-      .headers(defaultHeaders(tenantName))
-      .contentType(APPLICATION_JSON))
+        .content(asJsonString(new TenantAttributes().moduleTo("mod-search-1.0.0")))
+        .headers(defaultHeaders(tenantName))
+        .contentType(APPLICATION_JSON))
       .andExpect(status().isOk());
 
     for (Instance instance : instances) {
@@ -169,7 +173,7 @@ public abstract class BaseIntegrationTest {
   @SneakyThrows
   protected static void removeTenant(MockMvc mockMvc, String tenant) {
     mockMvc.perform(delete("/_/tenant")
-      .headers(defaultHeaders(tenant)))
+        .headers(defaultHeaders(tenant)))
       .andExpect(status().isNoContent());
   }
 

--- a/src/test/java/org/folio/search/utils/CollectionUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/CollectionUtilsTest.java
@@ -2,10 +2,13 @@ package org.folio.search.utils;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.utils.CollectionUtils.addToList;
+import static org.folio.search.utils.CollectionUtils.anyMatch;
 import static org.folio.search.utils.CollectionUtils.mergeSafely;
+import static org.folio.search.utils.CollectionUtils.mergeSafelyToSet;
 import static org.folio.search.utils.CollectionUtils.nullIfEmpty;
 
 import java.util.ArrayList;
@@ -101,5 +104,23 @@ class CollectionUtilsTest {
   void toSafeStream_positive_emptyCollection() {
     var actual = CollectionUtils.toStreamSafe(emptyList()).collect(toList());
     assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void mergeSafelyToSet_positive() {
+    var actual = mergeSafelyToSet(List.of(1, 2, 3), List.of(3, 1, 2), List.of(5), null, emptySet());
+    assertThat(actual).containsExactly(1, 2, 3, 5);
+  }
+
+  @Test
+  void anyMatchTest_positive() {
+    var given = List.of(1, 2, 3);
+    assertThat(anyMatch(given, e -> e == 2)).isTrue();
+  }
+
+  @Test
+  void anyMatchTest_negative() {
+    var given = List.of(1, 2, 3);
+    assertThat(anyMatch(given, e -> e == 5)).isFalse();
   }
 }

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -215,6 +215,12 @@ public class TestUtils {
     return plainField(PLAIN, MULTILANG_FIELD_TYPE, emptyList());
   }
 
+  public static PlainFieldDescription multilangField(String... inventorySearchType) {
+    var field = plainField(PLAIN, MULTILANG_FIELD_TYPE, emptyList());
+    field.setInventorySearchTypes(List.of(inventorySearchType));
+    return field;
+  }
+
   public static PlainFieldDescription standardFulltextField() {
     return plainField(PLAIN, STANDARD_FIELD_TYPE, emptyList());
   }
@@ -288,6 +294,10 @@ public class TestUtils {
 
   public static Instance instanceWithIdentifiers(InstanceIdentifiers... identifiers) {
     return new Instance().identifiers(identifiers != null ? asList(identifiers) : null);
+  }
+
+  public static Map<String, Object> toMap(Instance instance) {
+    return OBJECT_MAPPER.convertValue(instance, new TypeReference<>() {});
   }
 
   public static void setEnvProperty(String value) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,7 +19,7 @@ spring:
     producer:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
   cache:
-    cache-names: es-indices,identifier-types,alternative-title-types,system-user-cache
+    cache-names: es-indices,identifier-types,alternative-title-types,system-user-cache,tenant-languages
     caffeine:
       spec: maximumSize=500,expireAfterAccess=3600s
 
@@ -29,6 +29,8 @@ application:
   environment: folio-test
   search-config:
     initial-languages: eng,fre,ita,spa,ger
+    disabled-search-options:
+      instance: cql.all
   system-user:
     username: mod-search
     password: Mod-search-1-0-0


### PR DESCRIPTION
### Purpose
Some users would like to be able to conduct a search across all properties of all record types. Proof of concept implemented in terms of https://issues.folio.org/browse/MSEARCH-168

### Scope:

- create an additional search option that will cover search by all properties from all inventory record types:
  - instance field values
  - item field values
  - holding-record field values
  - all field values

### Approach
- Search can be done using following indices `cql.all`, `cql.allInstances`, `cql.allItems`, `cql.allHoldings`
- Extract isSupportedLanguage from ResourceDescriptionService
- Add missing Javadocs
- Add global mappings source at SearchMappingsHelper
- Rename MetadataResourceProvider interface to ResourceDescriptionProvider
- Remove unoptimized call to getResourceDescription() from MetadataResourceProvider
- LocalSearchFieldProvider now uses flattenedFields from ResourceDescription
- Add caching for tenant language code to increase indexing performance
- Add disabled search options as a configuration property
- Update README.md documentation
- Add integration tests and fix them to perform correctly searching by all field values