### PR TITLE
MSEARCH-182 Fix cql.allInstance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,14 +339,14 @@ INSTANCE_DISABLED_SEARCH_OPTIONS=
 ```
 
 By default, indexing processors for fields `cql.allInstance`, `cql.allItems`, `cql.allHoldings` are disabled and
-does not produce any values, so the following search options will return empty result.
+does not produce any values, so the following search options will return an empty result.
 
-| Option             | Type              |Example                          | Description                    |
-| :------------------|:-----------------:| :------------------------------:|:------------------------------:|
-| `cql.all`          | full-text or term | `cql.all all "web semantic"`    | Matches instances that have instance, items and holdings field values with given text |
-| `cql.allItems`     | full-text or term | `cql.allInstance all "book"`    | Matches instances that have field values with given text |
-| `cql.allHoldings`  | full-text or term | `cql.allItems all "it001"`      | Matches instances that have items field values with given text |
-| `cql.allInstances` | full-text or term | `cql.allHoldings any "1234567"` | Matches instances that have holdings field values with given text |
+| Option             | Type              |Example                           | Description                    |
+| :------------------|:-----------------:| :-------------------------------:|:------------------------------:|
+| `cql.all`          | full-text or term | `cql.all all "web semantic"`     | Matches instances that have given text in instance, item and holding field values |
+| `cql.allItems`     | full-text or term | `cql.allItems all "book"`        | Matches instances that have given text in item field values |
+| `cql.allHoldings`  | full-text or term | `cql.allHoldings all "it001"`    | Matches instances that have given text in holding field values |
+| `cql.allInstances` | full-text or term | `cql.allInstances any "1234567"` | Matches instances that have given text in instance field values |
 
 ### Search Facets
 

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -456,12 +456,12 @@
       "index": "multilang",
       "processor": "uniformTitleProcessor"
     },
-    "allInstance": {
+    "allInstances": {
       "type": "search",
       "index": "multilang",
       "processor": "instanceAllFieldValuesProcessor",
       "rawProcessing": true,
-      "inventorySearchTypes": [ "cql.all", "cql.allInstance" ]
+      "inventorySearchTypes": [ "cql.all", "cql.allInstances" ]
     },
     "allItems": {
       "type": "search",

--- a/src/test/java/org/folio/search/controller/SearchByAllFieldsIT.java
+++ b/src/test/java/org/folio/search/controller/SearchByAllFieldsIT.java
@@ -1,6 +1,5 @@
 package org.folio.search.controller;
 
-import static org.folio.search.sample.SampleInstances.getSemanticWeb;
 import static org.folio.search.sample.SampleInstances.getSemanticWebAsMap;
 import static org.folio.search.sample.SampleInstances.getSemanticWebId;
 import static org.folio.search.support.base.ApiEndpoints.instanceSearchPath;
@@ -68,7 +67,7 @@ class SearchByAllFieldsIT extends BaseIntegrationTest {
   void canSearchByAllFieldValues_positive(String cqlQuery) throws Throwable {
     mockMvc.perform(searchRequest("cql.all=\"{0}\"", cqlQuery))
       .andExpect(jsonPath("totalRecords", is(1)))
-      .andExpect(jsonPath("instances[0].id", is(getSemanticWeb().getId())));
+      .andExpect(jsonPath("instances[0].id", is(getSemanticWebId())));
   }
 
   @ValueSource(strings = {
@@ -80,11 +79,13 @@ class SearchByAllFieldsIT extends BaseIntegrationTest {
     "2003065165",
     "Antoniou, Grigoris",
     "TK5105.88815 .A58 2004",
-    "Cambridge, Mass."
+    "Cambridge, Mass.",
+    "2020-12-08T15:47:13.625+00:00",
+    "2020-12-08T15:47:13.625+0000"
   })
-  @ParameterizedTest(name = "[{index}] cql.allInstance='{query}', query=''{0}''")
+  @ParameterizedTest(name = "[{index}] cql.allInstances='{query}', query=''{0}''")
   void canSearchByInstanceFieldValues_positive(String cqlQuery) throws Throwable {
-    mockMvc.perform(searchRequest("cql.allInstance=\"{0}\"", cqlQuery))
+    mockMvc.perform(searchRequest("cql.allInstances=\"{0}\"", cqlQuery))
       .andExpect(jsonPath("totalRecords", is(1)))
       .andExpect(jsonPath("instances[0].id", is(getSemanticWebId())));
   }


### PR DESCRIPTION
### Purpose
- Fix the README.md file because it contained invalid description of field options
- Rename search option from `cql.allInstance` to `cql.allInstances`
- Ad test cases for searching by date values