### PR TITLE
MSEARCH-194 Add contributorNameTypeId field for contributors

### DIFF
--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -71,7 +71,7 @@
           "index": "bool",
           "showInResponse": true
         },
-        "contributorTypeId": {
+        "contributorNameTypeId": {
           "index": "source",
           "showInResponse": true
         }

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -70,6 +70,10 @@
         "primary": {
           "index": "bool",
           "showInResponse": true
+        },
+        "contributorTypeId": {
+          "index": "source",
+          "showInResponse": true
         }
       }
     },

--- a/src/main/resources/swagger.api/schemas/instance.json
+++ b/src/main/resources/swagger.api/schemas/instance.json
@@ -74,6 +74,10 @@
             "type": "string",
             "description": "Personal name, corporate name, meeting name"
           },
+          "contributorTypeId": {
+            "type": "string",
+            "description": "UUID for the contributor type term defined in controlled vocabulary"
+          },
           "primary": {
             "type": "boolean",
             "description": "Whether this is the primary contributor"

--- a/src/main/resources/swagger.api/schemas/instance.json
+++ b/src/main/resources/swagger.api/schemas/instance.json
@@ -74,9 +74,9 @@
             "type": "string",
             "description": "Personal name, corporate name, meeting name"
           },
-          "contributorTypeId": {
+          "contributorNameTypeId": {
             "type": "string",
-            "description": "UUID for the contributor type term defined in controlled vocabulary"
+            "description": "UUID of contributor name type term defined by the MARC code list for relators"
           },
           "primary": {
             "type": "boolean",

--- a/src/test/java/org/folio/search/cql/CallNumberSearchTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/CallNumberSearchTermProcessorTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-public class CallNumberSearchTermProcessorTest {
+class CallNumberSearchTermProcessorTest {
 
   private final CallNumberSearchTermProcessor callNumberSearchTermProcessor = new CallNumberSearchTermProcessor();
 

--- a/src/test/java/org/folio/search/service/ResourceIdServiceTest.java
+++ b/src/test/java/org/folio/search/service/ResourceIdServiceTest.java
@@ -68,7 +68,8 @@ class ResourceIdServiceTest {
 
     when(objectMapper.createGenerator(outputStream)).thenThrow(new IOException("Failed to create generator"));
 
-    assertThatThrownBy(() -> resourceIdService.streamResourceIds(request(), outputStream))
+    var request = request();
+    assertThatThrownBy(() -> resourceIdService.streamResourceIds(request, outputStream))
       .isInstanceOf(SearchServiceException.class)
       .hasMessage("Failed to write data into json [reason: Failed to create generator]");
   }
@@ -83,7 +84,8 @@ class ResourceIdServiceTest {
     when(objectMapper.createGenerator(outputStream)).thenReturn(generator);
     doThrow(new IOException("Failed to write string field")).when(generator).writeStringField("id", RANDOM_ID);
 
-    assertThatThrownBy(() -> resourceIdService.streamResourceIds(request(), outputStream))
+    var request = request();
+    assertThatThrownBy(() -> resourceIdService.streamResourceIds(request, outputStream))
       .isInstanceOf(SearchServiceException.class)
       .hasMessage("Failed to write to id value into json stream [reason: Failed to write string field]");
   }


### PR DESCRIPTION
### Purpose
Add a 'contributorNameTypeId' field value to unblock further development

### Approach
- Add 'contributorNameTypeId' to the instance.json to be correctly indexed
- Existing integration and unit tests proves functionality