### PR TITLE
MSEARCH-185 Implement cql.allRecords=1 search option

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,15 @@ Here is a table with supported search options.
 
 ### Search Options
 
+#### Matching all records
+
+A search matching all records in the target index can be executed with a `cql.allRecords=1` (CQL standard, the fastest option)
+or a `id=*` (slower option, check all documents in index) query. They can be used alone or as part of a more complex query,
+for example `cql.allRecords=1 NOT contributors=Smith sortBy title/sort.ascending`
+
+- `cql.allRecords=1 NOT contributors=Smith` matches all records where contributors name does not contain `Smith`
+as a word.
+
 #### Instance search options
 
 | Option                                    | Type      |Example                                            | Description                  |

--- a/src/main/java/org/folio/search/controller/ApiExceptionHandler.java
+++ b/src/main/java/org/folio/search/controller/ApiExceptionHandler.java
@@ -31,7 +31,6 @@ import org.folio.search.exception.ValidationException;
 import org.folio.search.model.types.ErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -123,25 +122,6 @@ public class ApiExceptionHandler {
         .type(ConstraintViolationException.class.getSimpleName())));
     errorResponse.totalRecords(errorResponse.getErrors().size());
 
-    return buildResponseEntity(errorResponse, BAD_REQUEST);
-  }
-
-  /**
-   * Catches and handles all exceptions of type {@link BindException}.
-   *
-   * @param exception {@link BindException} to process
-   * @return {@link ResponseEntity} with {@link ErrorResponse} body
-   */
-  @ExceptionHandler
-  public ResponseEntity<ErrorResponse> handleSpringBindException(BindException exception) {
-    logException(DEBUG, exception);
-    var errorResponse = new ErrorResponse();
-    exception.getFieldErrors().forEach(fieldError ->
-      errorResponse.addErrorsItem(new Error()
-        .message(String.format("%s value %s", fieldError.getField(), fieldError.getDefaultMessage()))
-        .code(ErrorCode.VALIDATION_ERROR.getValue())
-        .type(BindException.class.getSimpleName())));
-    errorResponse.totalRecords(errorResponse.getErrors().size());
     return buildResponseEntity(errorResponse, BAD_REQUEST);
   }
 

--- a/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
@@ -6,6 +6,7 @@ import static org.elasticsearch.index.query.MultiMatchQueryBuilder.Type.CROSS_FI
 import static org.elasticsearch.index.query.MultiMatchQueryBuilder.Type.PHRASE;
 import static org.elasticsearch.index.query.Operator.AND;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
@@ -57,6 +58,7 @@ import org.z3950.zing.cql.CQLTermNode;
 public class CqlSearchQueryConverter {
 
   static final String ASTERISKS_SIGN = "*";
+  static final String MATCH_ALL_CQL_QUERY = "cql.allRecords = 1";
 
   private final CqlSortProvider cqlSortProvider;
   private final SearchFieldProvider searchFieldProvider;
@@ -105,6 +107,10 @@ public class CqlSearchQueryConverter {
   }
 
   private QueryBuilder convertToTermQuery(CQLTermNode node, String resource) {
+    if (MATCH_ALL_CQL_QUERY.equals(node.toCQL())) {
+      return matchAllQuery();
+    }
+
     var fieldName = node.getIndex();
     var fieldsGroup = searchFieldProvider.getFields(resource, fieldName);
     var fieldList = fieldsGroup.isEmpty() ? getFieldsForFulltextField(fieldName, resource) : fieldsGroup;

--- a/src/test/java/org/folio/search/controller/IndexControllerTest.java
+++ b/src/test/java/org/folio/search/controller/IndexControllerTest.java
@@ -160,8 +160,8 @@ class IndexControllerTest {
     when(indexService.reindexInventory(TENANT_ID, null)).thenReturn(new ReindexJob().id(jobId));
 
     mockMvc.perform(post("/search/index/inventory/reindex")
-      .header(X_OKAPI_TENANT_HEADER, TENANT_ID)
-      .contentType(APPLICATION_JSON))
+        .header(X_OKAPI_TENANT_HEADER, TENANT_ID)
+        .contentType(APPLICATION_JSON))
       .andExpect(status().isOk())
       .andExpect(jsonPath("id", is(jobId)));
   }
@@ -173,10 +173,10 @@ class IndexControllerTest {
     when(indexService.reindexInventory(TENANT_ID, request)).thenReturn(new ReindexJob().id(jobId));
 
     mockMvc.perform(post("/search/index/inventory/reindex")
-      .header(X_OKAPI_TENANT_HEADER, TENANT_ID)
-      .contentType(APPLICATION_JSON)
-      .content(asJsonString(request))
-      .param("recreateIndex", "true"))
+        .header(X_OKAPI_TENANT_HEADER, TENANT_ID)
+        .contentType(APPLICATION_JSON)
+        .content(asJsonString(request))
+        .param("recreateIndex", "true"))
       .andExpect(status().isOk())
       .andExpect(jsonPath("id", is(jobId)));
   }
@@ -212,6 +212,20 @@ class IndexControllerTest {
       .andExpect(jsonPath("$.total_records", is(1)))
       .andExpect(jsonPath("$.errors[0].message", is("recreateIndices must be boolean")))
       .andExpect(jsonPath("$.errors[0].type", is("ConstraintViolationException")))
+      .andExpect(jsonPath("$.errors[0].code", is("validation_error")));
+  }
+
+  @Test
+  void reindexInventoryRecords_negative_illegalArgumentException() throws Exception {
+    when(indexService.reindexInventory(TENANT_ID, null)).thenThrow(new IllegalArgumentException("invalid value"));
+
+    mockMvc.perform(post("/search/index/inventory/reindex")
+        .header(X_OKAPI_TENANT_HEADER, TENANT_ID)
+        .contentType(APPLICATION_JSON))
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.total_records", is(1)))
+      .andExpect(jsonPath("$.errors[0].message", is("invalid value")))
+      .andExpect(jsonPath("$.errors[0].type", is("IllegalArgumentException")))
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")));
   }
 

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -1,7 +1,7 @@
 package org.folio.search.controller;
 
-import static org.folio.search.sample.SampleInstances.getSemanticWeb;
 import static org.folio.search.sample.SampleInstances.getSemanticWebAsMap;
+import static org.folio.search.sample.SampleInstances.getSemanticWebId;
 import static org.folio.search.support.base.ApiEndpoints.instanceIds;
 import static org.folio.search.support.base.ApiEndpoints.searchInstancesByQuery;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
@@ -53,7 +53,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
       searchResult
         .andExpect(status().isOk())
         .andExpect(jsonPath("totalRecords", is(1)))
-        .andExpect(jsonPath("instances[0].id", is(getSemanticWeb().getId())));
+        .andExpect(jsonPath("instances[0].id", is(getSemanticWebId())));
     }
   }
 
@@ -62,15 +62,16 @@ class SearchInstanceIT extends BaseIntegrationTest {
     mockMvc.perform(get(instanceIds("id=*")).headers(defaultHeaders()))
       .andExpect(status().isOk())
       .andExpect(jsonPath("totalRecords", is(1)))
-      .andExpect(jsonPath("ids[0].id", is(getSemanticWeb().getId())));
+      .andExpect(jsonPath("ids[0].id", is(getSemanticWebId())));
   }
 
   // Test source
   @SuppressWarnings("unused")
   private static Stream<Arguments> positiveSearchTestDataProvider() {
     return Stream.of(
-      arguments("search by instance id", "id={value}", array(getSemanticWeb().getId()), null),
-      arguments("search by instance id for exactMatch", "id=={value}", array(getSemanticWeb().getId()), null),
+      arguments("search by all instances", "cql.allRecords = 1", array(getSemanticWebId()), null),
+      arguments("search by instance id", "id={value}", array(getSemanticWebId()), null),
+      arguments("search by instance id for exactMatch", "id=={value}", array(getSemanticWebId()), null),
       arguments("search by instance id using wildcard", "id={value}", array("5bf370e0*a0a39"), null),
       arguments("search by instance title (title)", "title all {value}", array("semantic"), null),
       arguments("search by instance title (series)", "title all {value}", array("cooperative"), null),
@@ -113,7 +114,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("search by contributors name", "contributors.name all {value}", array("frank"),
         (ThrowingConsumer<ResultActions>) searchResult -> searchResult
           .andExpect(jsonPath("totalRecords", is(1)))
-          .andExpect(jsonPath("instances[0].id", is(getSemanticWeb().getId())))
+          .andExpect(jsonPath("instances[0].id", is(getSemanticWebId())))
           .andExpect(jsonPath("instances[0].contributors[0].name", is("Antoniou, Grigoris")))
           .andExpect(jsonPath("instances[0].contributors[1].name", is("Van Harmelen, Frank")))),
       arguments("search by contributors name", "contributors.name all {value}", array("franks"), zeroResultConsumer()),

--- a/src/test/java/org/folio/search/cql/CqlSearchQueryConverterTest.java
+++ b/src/test/java/org/folio/search/cql/CqlSearchQueryConverterTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -312,26 +311,6 @@ class CqlSearchQueryConverterTest {
     assertThat(actual).isEqualTo(searchSource().query(query));
   }
 
-  @CsvSource({
-    "cql.allRecords = 1",
-    "cql.allRecords=1",
-    "cql.allRecords= 1",
-    "cql.allRecords= \"1\""
-  })
-  @ParameterizedTest
-  void convert_positive_matchAllQuery(String query) {
-    var actual = cqlSearchQueryConverter.convert(query, RESOURCE_NAME);
-    assertThat(actual).isEqualTo(searchSource().query(matchAllQuery()));
-  }
-
-  @Test
-  void convert_positive_matchAllInBooleanQuery() {
-    var actual = cqlSearchQueryConverter.convert("cql.allRecords = 1 NOT subjects == english", RESOURCE_NAME);
-    assertThat(actual).isEqualTo(searchSource().query(boolQuery()
-      .must(matchAllQuery())
-      .mustNot(termQuery("subjects", "english"))));
-  }
-
   private static Stream<Arguments> convertCqlQueryDataProvider() {
     var resourceId = randomId();
     return Stream.of(
@@ -375,7 +354,14 @@ class CqlSearchQueryConverterTest {
 
       arguments("f1==v1 and f2==v2 and f3==v3 and f4==v4", searchSource().query(boolQuery()
         .must(termQuery("f1", "v1")).must(termQuery("f2", "v2"))
-        .must(termQuery("f3", "v3")).must(termQuery("f4", "v4"))))
+        .must(termQuery("f3", "v3")).must(termQuery("f4", "v4")))),
+
+      arguments("cql.allRecords = 1", searchSource().query(matchAllQuery())),
+      arguments("cql.allRecords=1", searchSource().query(matchAllQuery())),
+      arguments("cql.allRecords= 1", searchSource().query(matchAllQuery())),
+      arguments("cql.allRecords= \"1\"", searchSource().query(matchAllQuery())),
+      arguments("cql.allRecords = 1 NOT subjects == english", searchSource().query(boolQuery()
+        .must(matchAllQuery()).mustNot(termQuery("subjects", "english"))))
     );
   }
 

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -79,7 +79,7 @@ public abstract class BaseIntegrationTest {
 
   private static void checkThatElasticsearchAcceptResourcesFromKafka(String tenant, MockMvc mockMvc, int size) {
     await().atMost(ONE_MINUTE).pollInterval(TWO_HUNDRED_MILLISECONDS).untilAsserted(() ->
-      mockMvc.perform(get("/search/instances").param("query", "id=*").param("limit", "1")
+      mockMvc.perform(get("/search/instances").param("query", "cql.allRecords = 1").param("limit", "1")
           .headers(defaultHeaders(tenant)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.totalRecords", is(size))));


### PR DESCRIPTION
### Purpose/Overview:
`cql.allRecords=1` must return all records in Elasticsearch tenant index using `match_all` query. It would be the fastest solution to get a count of resources and any resources for the tenant.

### Aproach
- Extend `convertToTermQuery` method in `CqlSearchQueryConverter` to directrly convert `cql.allRecords=1` to the Elasticsearch `match_all` query
- Add integration and unit tests