### PR TITLE
MSEARCH-175 Item - include circulation notes search in item notes search

### DIFF
--- a/src/main/java/org/folio/search/service/setter/instance/AbstractPublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/AbstractPublicNotesProcessor.java
@@ -1,10 +1,13 @@
 package org.folio.search.service.setter.instance;
 
 import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toList;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import org.folio.search.domain.dto.CirculationNote;
 import org.folio.search.domain.dto.Instance;
@@ -20,14 +23,13 @@ public abstract class AbstractPublicNotesProcessor implements FieldProcessor<Ins
     result.addAll(getNotesAsList(getCirculationNotes(instance), note -> getNote(note.getStaffOnly(), note.getNote())));
     return result;
   }
-  
+
   private static <T> List<String> getNotesAsList(Stream<T> notesStream, Function<T, String> func) {
     return notesStream.filter(Objects::nonNull).map(func).filter(Objects::nonNull).collect(toList());
   }
 
   private static String getNote(Boolean staffOnly, String value) {
     return staffOnly == null || !staffOnly ? value : null;
-  }
   }
 
   /**

--- a/src/main/java/org/folio/search/service/setter/instance/AbstractPublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/AbstractPublicNotesProcessor.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.folio.search.domain.dto.CirculationNote;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Note;
 import org.folio.search.service.setter.FieldProcessor;
@@ -14,12 +15,28 @@ public abstract class AbstractPublicNotesProcessor implements FieldProcessor<Ins
 
   @Override
   public Set<String> getFieldValue(Instance instance) {
-    return getNotes(instance)
-      .filter(Objects::nonNull)
-      .filter(note -> note.getStaffOnly() == null || !note.getStaffOnly())
-      .map(Note::getNote)
-      .filter(Objects::nonNull)
-      .collect(toCollection(LinkedHashSet::new));
+    return Stream.concat(
+      getCirculationNotes(instance)
+        .filter(Objects::nonNull)
+        .filter(note -> note.getStaffOnly() == null || !note.getStaffOnly())
+        .map(CirculationNote::getNote)
+        .filter(Objects::nonNull),
+      getNotes(instance).filter(Objects::nonNull)
+        .filter(note -> note.getStaffOnly() == null || !note.getStaffOnly())
+        .map(Note::getNote)
+        .filter(Objects::nonNull)
+    ).collect(toCollection(LinkedHashSet::new));
+
+  }
+
+  /**
+   * Returns {@link Stream} with {@link CirculationNote} objects from holding/item.
+   *
+   * @param instance instance object to analyze
+   * @return {@link Stream} with {@link CirculationNote} object
+   */
+  protected Stream<CirculationNote> getCirculationNotes(Instance instance) {
+    return Stream.empty();
   }
 
   /**

--- a/src/main/java/org/folio/search/service/setter/instance/AbstractPublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/AbstractPublicNotesProcessor.java
@@ -1,6 +1,5 @@
 package org.folio.search.service.setter.instance;
 
-import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 
 import java.util.LinkedHashSet;
@@ -24,14 +23,6 @@ public abstract class AbstractPublicNotesProcessor implements FieldProcessor<Ins
     return result;
   }
 
-  private static <T> List<String> getNotesAsList(Stream<T> notesStream, Function<T, String> func) {
-    return notesStream.filter(Objects::nonNull).map(func).filter(Objects::nonNull).collect(toList());
-  }
-
-  private static String getNote(Boolean staffOnly, String value) {
-    return staffOnly == null || !staffOnly ? value : null;
-  }
-
   /**
    * Returns {@link Stream} with {@link CirculationNote} objects from holding/item.
    *
@@ -49,4 +40,12 @@ public abstract class AbstractPublicNotesProcessor implements FieldProcessor<Ins
    * @return {@link Stream} with {@link Note} object
    */
   protected abstract Stream<Note> getNotes(Instance instance);
+
+  private static <T> List<String> getNotesAsList(Stream<T> notesStream, Function<T, String> func) {
+    return notesStream.filter(Objects::nonNull).map(func).filter(Objects::nonNull).collect(toList());
+  }
+
+  private static String getNote(Boolean staffOnly, String value) {
+    return staffOnly == null || !staffOnly ? value : null;
+  }
 }

--- a/src/main/java/org/folio/search/service/setter/item/ItemPublicNotesProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemPublicNotesProcessor.java
@@ -5,6 +5,7 @@ import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 import java.util.Collection;
 import java.util.stream.Stream;
 import org.apache.commons.collections.CollectionUtils;
+import org.folio.search.domain.dto.CirculationNote;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.domain.dto.Note;
@@ -18,6 +19,14 @@ public class ItemPublicNotesProcessor extends AbstractPublicNotesProcessor {
   protected Stream<Note> getNotes(Instance instance) {
     return toStreamSafe(instance.getItems())
       .map(Item::getNotes)
+      .filter(CollectionUtils::isNotEmpty)
+      .flatMap(Collection::stream);
+  }
+
+  @Override
+  protected Stream<CirculationNote> getCirculationNotes(Instance instance) {
+    return toStreamSafe(instance.getItems())
+      .map(Item::getCirculationNotes)
       .filter(CollectionUtils::isNotEmpty)
       .flatMap(Collection::stream);
   }

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -285,7 +285,8 @@
           "type": "object",
           "properties": {
             "note": {
-              "index": "multilang"
+              "index": "multilang",
+              "inventorySearchTypes": "items.notes.note"
             },
             "staffOnly": {
               "index": "bool"
@@ -296,7 +297,11 @@
           "type": "object",
           "properties": {
             "note": {
-              "index": "multilang"
+              "index": "multilang",
+              "inventorySearchTypes": "items.notes.note"
+            },
+            "staffOnly": {
+              "index": "bool"
             }
           }
         }

--- a/src/main/resources/swagger.api/schemas/circulationNote.json
+++ b/src/main/resources/swagger.api/schemas/circulationNote.json
@@ -6,6 +6,11 @@
     "note": {
       "type": "string",
       "description": "Text to display"
+    },
+    "staffOnly": {
+      "type": "boolean",
+      "description": "Flag to restrict display of this note",
+      "default": false
     }
   }
 }

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -159,10 +159,16 @@ class SearchInstanceIT extends BaseIntegrationTest {
 
       arguments("search by public items.notes.note", "itemPublicNotes all {value}",
         array("bibliographical references"), null),
+      arguments("search by public circulation notes items.notes.note", "itemPublicNotes all {value}",
+        array("first-record"), zeroResultConsumer()),
+      arguments("search by public circulation notes items.notes.note", "itemPublicNotes all {value}",
+        array("SecondRecord"), null),
       arguments("search by private items.notes.note using itemPublicNotes", "itemPublicNotes == {value}",
         array("librarian private note for item"), zeroResultConsumer()),
       arguments("search by private items.notes.note", "items.notes.note == {value}",
         array("Librarian private note for item"), null),
+      arguments("search by circulation notes in items.notes.note", "items.notes.note == {value}",
+        array("testNote"), null),
 
       arguments("search by isbn10", "isbn = {value}", array("047144250X"), null),
       arguments("search by isbn10(wildcard)", "isbn = {value}", array("04714*"), null),

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -169,6 +169,8 @@ class SearchInstanceIT extends BaseIntegrationTest {
         array("Librarian private note for item"), null),
       arguments("search by circulation notes in items.notes.note", "items.notes.note == {value}",
         array("testNote"), null),
+      arguments("search by circulation notes in items.notes.note", "items.notes.note == {value}",
+        array("first-record"), null),
 
       arguments("search by isbn10", "isbn = {value}", array("047144250X"), null),
       arguments("search by isbn10(wildcard)", "isbn = {value}", array("04714*"), null),

--- a/src/test/java/org/folio/search/service/setter/item/ItemPublicNotesProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemPublicNotesProcessorTest.java
@@ -47,7 +47,7 @@ class ItemPublicNotesProcessorTest {
       arguments("items with notes and circulation notes", instance(item(
         List.of(note("regular note", false)),
         List.of(circulationNote("circ note", false), circulationNote("circ note2", false)))),
-        List.of("circ note", "circ note2", "regular note")
+        List.of("regular note", "circ note", "circ note2")
       ),
       arguments("items with private notes and circulation notes", instance(item(
         List.of(note("regular note", true), note("regular note2", true)),

--- a/src/test/java/org/folio/search/service/setter/item/ItemPublicNotesProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemPublicNotesProcessorTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
+import org.folio.search.domain.dto.CirculationNote;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.domain.dto.Note;
@@ -42,8 +43,22 @@ class ItemPublicNotesProcessorTest {
       arguments("item with note(staffOnly=true)", instance(item(note("value", true))), emptyList()),
       arguments("item with note(value=null,staffOnly=false)", instance(item(note(null, false))), emptyList()),
       arguments("items with duplicated notes", instance(
-        item(note("note", false)), item(note("note", false)), item(note("note", true))), List.of("note"))
-    );
+        item(note("note", false)), item(note("note", false)), item(note("note", true))), List.of("note")),
+      arguments("items with notes and circulation notes", instance(item(
+        List.of(note("regular note", false)),
+        List.of(circulationNote("circ note", false), circulationNote("circ note2", false)))),
+        List.of("circ note", "circ note2", "regular note")
+      ),
+      arguments("items with private notes and circulation notes", instance(item(
+        List.of(note("regular note", true), note("regular note2", true)),
+        List.of(circulationNote("circ note", false)))),
+        List.of("circ note")
+      ),
+      arguments("item with notes and private circulation notes", instance(item(
+        List.of(note("regular note", false), note("regular note2", false)),
+        List.of(circulationNote("circ note", true), circulationNote("circ note2", true)))),
+        List.of("regular note", "regular note2")
+      ));
   }
 
   private static Instance instance(Item... items) {
@@ -54,7 +69,15 @@ class ItemPublicNotesProcessorTest {
     return new Item().notes(notes != null ? Arrays.asList(notes) : null);
   }
 
+  private static Item item(List<Note> notes, List<CirculationNote> circulationNotes) {
+    return new Item().notes(notes).circulationNotes(circulationNotes);
+  }
+
   private static Note note(String value, Boolean staffOnly) {
     return new Note().note(value).staffOnly(staffOnly);
+  }
+
+  private static CirculationNote circulationNote(String value, Boolean staffOnly) {
+    return new CirculationNote().note(value).staffOnly(staffOnly);
   }
 }

--- a/src/test/resources/samples/semantic-web-primer/items.json
+++ b/src/test/resources/samples/semantic-web-primer/items.json
@@ -91,7 +91,8 @@
     ],
     "circulationNotes": [
       {
-        "note": "first-record"
+        "note": "first-record",
+        "staffOnly": true
       },
       {
         "note": "SecondRecord"


### PR DESCRIPTION
### Requirements/Scope:

- If the circulation note is mark as staff only, it is included in notes (all) search but is not included in public notes search results
- if the circulation note is not marked as staff only, it is included in public notes search results
- the functionality introduced in MSEARCH-158 stays as it is and the user can also search for circulation notes separately
