### PR TITLE
MSEARCH-188 Implement tenant configurable features

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ with less powerful configuration (see [High availability](https://www.elastic.co
 | SYSTEM_USER_PASSWORD             | -                         | Password for `mod-search` system user (not required for dev envs) |
 | OKAPI_URL                        | -                         | OKAPI URL used to login system user, required                     |
 | ENV                              | -                         | The logical name of the deployment, must be unique across all environments using the same shared Kafka/Elasticsearch clusters, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed |
-| INSTANCE_DISABLED_SEARCH_OPTIONS | cql.all                   | Comma-separated list of disabled search options (fieldName or inventorySearchType) |
+| SEARCH_BY_ALL_FIELDS_ENABLED     | false                     | Specifies if globally search by all field values must be enabled or not (tenant can override this setting) |
 
 The module uses system user to communicate with other modules from Kafka consumers.
 For production deployments you MUST specify the password for this system user via env variable:
@@ -267,6 +267,7 @@ if it is defined but doesn't match.
 - `name==""` matches all records where name is defined and empty.
 - `cql.allRecords=1 NOT name==""` matches all records where name is defined and not empty or where name is not defined.
 - `name="" NOT name==""` matches all records where name is defined and not empty.
+- `languages == "[]"` for matching records where lang is defined and an empty array
 
 #### Instance search options
 
@@ -353,10 +354,20 @@ if it is defined but doesn't match.
 
 ### Search by all field values
 
-Search by all feature is optional and can be disabled by passing to the server configuration following ENV variable
+Search by all feature is optional and disabled by default. However, it can be enabled for tenant using
+following HTTP request:
+
+`POST /search/config/features`
+```json
+{
+  "feature": "search.all.fields",
+  "enabled": true
+}
+```
+Also, search by all fields can be enabled globally by passing to mod-search service following ENV variable:
 
 ```
-INSTANCE_DISABLED_SEARCH_OPTIONS=
+SEARCH_BY_ALL_FIELDS_ENABLED=true
 ```
 
 By default, indexing processors for fields `cql.allInstance`, `cql.allItems`, `cql.allHoldings` are disabled and

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -109,6 +109,34 @@
           ],
           "pathPattern": "/search/config/languages/{id}",
           "permissionsRequired": [ "search.config.languages.item.delete" ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/search/config/features",
+          "permissionsRequired": [ "search.config.features.collection.get" ]
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/search/config/features",
+          "permissionsRequired": [ "search.config.features.item.post" ]
+        },
+        {
+          "methods": [
+            "PUT"
+          ],
+          "pathPattern": "/search/config/features/{id}",
+          "permissionsRequired": [ "search.config.features.item.put" ]
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "pathPattern": "/search/config/features/{id}",
+          "permissionsRequired": [ "search.config.features.item.delete" ]
         }
       ]
     },
@@ -222,6 +250,26 @@
       "permissionName": "search.holdings.ids.collection.get",
       "displayName": "Search - returns a list of holding ids found for the CQL query by instances",
       "description": "Returns list of resource ids for a cql query"
+    },
+    {
+      "permissionName": "search.config.features.collection.get",
+      "displayName": "Search - returns list of tenant features configuration",
+      "description": "Returns list of all specified features"
+    },
+    {
+      "permissionName": "search.config.features.item.post",
+      "displayName": "Search - adds a feature configuration",
+      "description": "Adds feature configuration"
+    },
+    {
+      "permissionName": "search.config.features.item.put",
+      "displayName": "Search - updates a feature configuration",
+      "description": "Updates feature configuration"
+    },
+    {
+      "permissionName": "search.config.features.item.delete",
+      "displayName": "Search - removes feature configuration",
+      "description": "Removes feature configuration"
     }
   ],
   "launchDescriptor": {

--- a/src/main/java/org/folio/search/configuration/SearchCacheNames.java
+++ b/src/main/java/org/folio/search/configuration/SearchCacheNames.java
@@ -11,4 +11,5 @@ public class SearchCacheNames {
   public static final String ALTERNATIVE_TITLE_TYPES_CACHE = "alternative-title-types";
   public static final String SYSTEM_USER_CACHE = "system-user-cache";
   public static final String RESOURCE_LANGUAGE_CACHE = "tenant-languages";
+  public static final String TENANT_FEATURES_CACHE = "tenant-features";
 }

--- a/src/main/java/org/folio/search/configuration/properties/SearchConfigurationProperties.java
+++ b/src/main/java/org/folio/search/configuration/properties/SearchConfigurationProperties.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 import lombok.Data;
+import org.folio.search.domain.dto.TenantConfiguredFeature;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.annotation.Validated;
@@ -26,7 +27,7 @@ public class SearchConfigurationProperties {
   private Set<String> initialLanguages = emptySet();
 
   /**
-   * Contains set of ignored search processor names for resource.
+   * Provides map with global features configuration. Can be overwritten by tenant configuration.
    */
-  private Map<String, Set<String>> disabledSearchOptions = emptyMap();
+  private Map<TenantConfiguredFeature, Boolean> searchFeatures = emptyMap();
 }

--- a/src/main/java/org/folio/search/controller/ConfigController.java
+++ b/src/main/java/org/folio/search/controller/ConfigController.java
@@ -6,9 +6,13 @@ import static org.springframework.http.ResponseEntity.ok;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.folio.search.domain.dto.FeatureConfig;
+import org.folio.search.domain.dto.FeatureConfigs;
 import org.folio.search.domain.dto.LanguageConfig;
 import org.folio.search.domain.dto.LanguageConfigs;
+import org.folio.search.domain.dto.TenantConfiguredFeature;
 import org.folio.search.rest.resource.ConfigApi;
+import org.folio.search.service.FeatureConfigService;
 import org.folio.search.service.LanguageConfigService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -21,7 +25,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/search/")
 public class ConfigController implements ConfigApi {
+
   private final LanguageConfigService languageConfigService;
+  private final FeatureConfigService featureConfigService;
 
   @Override
   public ResponseEntity<LanguageConfig> createLanguageConfig(@Valid LanguageConfig languageConfig) {
@@ -44,5 +50,26 @@ public class ConfigController implements ConfigApi {
   @Override
   public ResponseEntity<LanguageConfigs> getAllLanguageConfigs() {
     return ok(languageConfigService.getAll());
+  }
+
+  @Override
+  public ResponseEntity<FeatureConfigs> getAllFeatures() {
+    return ok(featureConfigService.getAll());
+  }
+
+  @Override
+  public ResponseEntity<FeatureConfig> saveFeatureConfiguration(FeatureConfig featureConfig) {
+    return ResponseEntity.ok(featureConfigService.create(featureConfig));
+  }
+
+  @Override
+  public ResponseEntity<FeatureConfig> updateFeatureConfiguration(String feature, FeatureConfig featureConfig) {
+    return ResponseEntity.ok(featureConfigService.update(TenantConfiguredFeature.fromValue(feature), featureConfig));
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteFeatureConfigurationById(String feature) {
+    featureConfigService.delete(TenantConfiguredFeature.fromValue(feature));
+    return noContent().build();
   }
 }

--- a/src/main/java/org/folio/search/converter/FeatureConfigMapper.java
+++ b/src/main/java/org/folio/search/converter/FeatureConfigMapper.java
@@ -1,0 +1,29 @@
+package org.folio.search.converter;
+
+import org.folio.search.domain.dto.FeatureConfig;
+import org.folio.search.domain.dto.TenantConfiguredFeature;
+import org.folio.search.model.config.FeatureConfigEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", imports = TenantConfiguredFeature.class)
+public interface FeatureConfigMapper {
+
+  /**
+   * Converts {@link FeatureConfig} object to {@link FeatureConfigEntity} object.
+   *
+   * @param config - dto object to convert as {@link FeatureConfig} object
+   * @return converted {@link FeatureConfigEntity} object
+   */
+  @Mapping(source = "feature.value", target = "featureId")
+  FeatureConfigEntity convert(FeatureConfig config);
+
+  /**
+   * Converts {@link FeatureConfigEntity} object to {@link FeatureConfig} DTO object.
+   *
+   * @param entity - entity to convert as {@link FeatureConfigEntity} object.
+   * @return converted {@link FeatureConfig} dto object
+   */
+  @Mapping(target = "feature", expression = "java(TenantConfiguredFeature.fromValue(entity.getFeatureId()))")
+  FeatureConfig convert(FeatureConfigEntity entity);
+}

--- a/src/main/java/org/folio/search/integration/InstanceReferenceDataService.java
+++ b/src/main/java/org/folio/search/integration/InstanceReferenceDataService.java
@@ -1,4 +1,4 @@
-package org.folio.search.repository.cache;
+package org.folio.search.integration;
 
 import static java.util.stream.Collectors.toSet;
 import static org.folio.search.client.cql.CqlQuery.exactMatchAny;

--- a/src/main/java/org/folio/search/model/config/FeatureConfigEntity.java
+++ b/src/main/java/org/folio/search/model/config/FeatureConfigEntity.java
@@ -1,0 +1,27 @@
+package org.folio.search.model.config;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@NoArgsConstructor
+@Table(name = "feature_config")
+@AllArgsConstructor(staticName = "of")
+public class FeatureConfigEntity {
+
+  /**
+   * Feature name as {@link String} object.
+   */
+  @Id
+  private String featureId;
+
+  /**
+   * Specifies if feature is enabled or not.
+   */
+  private boolean enabled;
+}

--- a/src/main/java/org/folio/search/model/metadata/SearchFieldDescriptor.java
+++ b/src/main/java/org/folio/search/model/metadata/SearchFieldDescriptor.java
@@ -2,6 +2,7 @@ package org.folio.search.model.metadata;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.folio.search.domain.dto.TenantConfiguredFeature;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -18,4 +19,9 @@ public class SearchFieldDescriptor extends PlainFieldDescription {
    * Marks if field processor can accept raw resource as {@link java.util.Map} or not.
    */
   private boolean rawProcessing;
+
+  /**
+   * Provides feature name, that should be checked before indexing search field.
+   */
+  private TenantConfiguredFeature dependsOnFeature;
 }

--- a/src/main/java/org/folio/search/repository/FeatureConfigRepository.java
+++ b/src/main/java/org/folio/search/repository/FeatureConfigRepository.java
@@ -1,0 +1,9 @@
+package org.folio.search.repository;
+
+import org.folio.search.model.config.FeatureConfigEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeatureConfigRepository extends JpaRepository<FeatureConfigEntity, String> {
+}

--- a/src/main/java/org/folio/search/service/FeatureConfigService.java
+++ b/src/main/java/org/folio/search/service/FeatureConfigService.java
@@ -1,0 +1,126 @@
+package org.folio.search.service;
+
+import static org.folio.search.configuration.SearchCacheNames.TENANT_FEATURES_CACHE;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.persistence.EntityNotFoundException;
+import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.search.configuration.properties.SearchConfigurationProperties;
+import org.folio.search.converter.FeatureConfigMapper;
+import org.folio.search.domain.dto.FeatureConfig;
+import org.folio.search.domain.dto.FeatureConfigs;
+import org.folio.search.domain.dto.TenantConfiguredFeature;
+import org.folio.search.exception.RequestValidationException;
+import org.folio.search.model.config.FeatureConfigEntity;
+import org.folio.search.repository.FeatureConfigRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Log4j2
+@Service
+@AllArgsConstructor
+public class FeatureConfigService {
+
+  private final FeatureConfigMapper featureConfigMapper;
+  private final FeatureConfigRepository featureConfigRepository;
+  private final SearchConfigurationProperties searchConfigurationProperties;
+
+  /**
+   * Checks if feature is enabled for tenant by id or not.
+   *
+   * @param feature - feature id as {@link TenantConfiguredFeature} object
+   * @return true if feature is enabled for tenant, false - otherwise.
+   */
+  @Transactional(readOnly = true)
+  @Cacheable(cacheNames = TENANT_FEATURES_CACHE, key = "@folioExecutionContext.tenantId + ':' + #feature.value")
+  public boolean isEnabled(TenantConfiguredFeature feature) {
+    return featureConfigRepository.findById(feature.getValue())
+      .map(FeatureConfigEntity::isEnabled)
+      .orElseGet(() -> searchConfigurationProperties.getSearchFeatures().getOrDefault(feature, false));
+  }
+
+  /**
+   * Returns all existing features configs for tenant.
+   *
+   * @return all existing feature configs as {@link FeatureConfigs} object.
+   */
+  @Transactional(readOnly = true)
+  public FeatureConfigs getAll() {
+    final List<FeatureConfig> tenantFeatures = featureConfigRepository.findAll().stream()
+      .map(featureConfigMapper::convert)
+      .collect(Collectors.toList());
+
+    return new FeatureConfigs().features(tenantFeatures).totalRecords(tenantFeatures.size());
+  }
+
+  /**
+   * Creates tenant's feature configuration using given {@link FeatureConfig} dto object.
+   *
+   * @param featureConfig - feature config dto as {@link FeatureConfig} object
+   * @return created {@link FeatureConfig} dto.
+   */
+  @Transactional
+  @CacheEvict(cacheNames = TENANT_FEATURES_CACHE,
+    key = "@folioExecutionContext.tenantId + ':' + #featureConfig.feature.value")
+  public FeatureConfig create(FeatureConfig featureConfig) {
+    log.info("Attempting to create feature configuration [feature: {}]", featureConfig.getFeature().getValue());
+    var entity = featureConfigMapper.convert(featureConfig);
+    var featureId = entity.getFeatureId();
+    if (featureConfigRepository.existsById(featureId)) {
+      throw new RequestValidationException("Feature configuration already exists", "feature", featureId);
+    }
+
+    var savedEntity = featureConfigRepository.save(entity);
+    return featureConfigMapper.convert(savedEntity);
+  }
+
+  /**
+   * Updates tenant's feature configuration by given code and {@link FeatureConfig} dto.
+   *
+   * @param feature - feature id as {@link TenantConfiguredFeature} object
+   * @param featureConfig - feature config dto as {@link FeatureConfig} object
+   * @return updated {@link FeatureConfig} dto.
+   */
+  @Transactional
+  @CacheEvict(cacheNames = TENANT_FEATURES_CACHE, key = "@folioExecutionContext.tenantId + ':' + #feature.value")
+  public FeatureConfig update(TenantConfiguredFeature feature, FeatureConfig featureConfig) {
+    log.info("Attempting to update feature configuration [feature: {}]", feature.getValue());
+    var featureId = feature.getValue();
+    var entity = featureConfigMapper.convert(featureConfig);
+
+    if (!Objects.equals(entity.getFeatureId(), featureId)) {
+      throw new RequestValidationException(
+        "Request body feature must be the same as in the URL", "feature", featureId);
+    }
+
+    var existingEntity = featureConfigRepository.findById(featureId)
+      .orElseThrow(() -> new EntityNotFoundException("Feature configuration not found for id: " + featureId));
+
+    if (existingEntity.equals(entity)) {
+      return featureConfig;
+    }
+
+    var updatedEntity = featureConfigRepository.save(entity);
+    return featureConfigMapper.convert(updatedEntity);
+  }
+
+  /**
+   * Deletes tenant's feature configuration by feature id.
+   *
+   * @param feature - feature id as {@link TenantConfiguredFeature} object
+   */
+  @Transactional
+  @CacheEvict(cacheNames = TENANT_FEATURES_CACHE, key = "@folioExecutionContext.tenantId + ':' + #feature.value")
+  public void delete(TenantConfiguredFeature feature) {
+    log.info("Attempting to delete feature configuration [feature: {}]", feature.getValue());
+    if (!featureConfigRepository.existsById(feature.getValue())) {
+      throw new EntityNotFoundException("Feature configuration not found for id: " + feature.getValue());
+    }
+    featureConfigRepository.deleteById(feature.getValue());
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/instance/AbstractIdentifierProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/AbstractIdentifierProcessor.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.InstanceIdentifiers;
-import org.folio.search.repository.cache.InstanceReferenceDataService;
+import org.folio.search.integration.InstanceReferenceDataService;
 import org.folio.search.service.setter.FieldProcessor;
 
 @RequiredArgsConstructor

--- a/src/main/java/org/folio/search/service/setter/instance/IsbnProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/IsbnProcessor.java
@@ -18,7 +18,7 @@ import org.apache.commons.lang3.CharUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.InstanceIdentifiers;
-import org.folio.search.repository.cache.InstanceReferenceDataService;
+import org.folio.search.integration.InstanceReferenceDataService;
 import org.springframework.stereotype.Component;
 
 /**

--- a/src/main/java/org/folio/search/service/setter/instance/IssnProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/IssnProcessor.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.InstanceIdentifiers;
-import org.folio.search.repository.cache.InstanceReferenceDataService;
+import org.folio.search.integration.InstanceReferenceDataService;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/org/folio/search/service/setter/instance/UniformTitleProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/UniformTitleProcessor.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.InstanceAlternativeTitles;
-import org.folio.search.repository.cache.InstanceReferenceDataService;
+import org.folio.search.integration.InstanceReferenceDataService;
 import org.folio.search.service.setter.FieldProcessor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,13 @@ spring:
   liquibase:
     change-log: classpath:changelog/changelog-master.xml
   cache:
-    cache-names: es-indices,identifier-types,alternative-title-types,system-user-cache,tenant-languages
+    cache-names:
+      - es-indices
+      - identifier-types
+      - alternative-title-types
+      - system-user-cache
+      - tenant-languages
+      - tenant-features
     caffeine:
       spec: maximumSize=500,expireAfterAccess=3600s
 
@@ -38,8 +44,8 @@ application:
   environment: ${ENV:folio}
   search-config:
     initial-languages: ${INITIAL_LANGUAGES:eng}
-    disabled-search-options:
-      instance: ${INSTANCE_DISABLED_SEARCH_OPTIONS:cql.all}
+    search-features:
+      search.all.fields: ${SEARCH_BY_ALL_FIELDS_ENABLED:false}
   system-user:
     username: mod-search
     password: ${SYSTEM_USER_PASSWORD:Mod-search-1-0-0}

--- a/src/main/resources/changelog/changes/initial_schema.xml
+++ b/src/main/resources/changelog/changes/initial_schema.xml
@@ -23,4 +23,15 @@
       <column name="es_analyzer" type="varchar(255)"/>
     </addColumn>
   </changeSet>
+
+  <changeSet id="04_create_feature_config_table" author="pavel_filippov@epam.com">
+    <createTable tableName="feature_config">
+      <column name="feature_id" type="varchar(32)">
+        <constraints primaryKey="true" nullable="false"/>
+      </column>
+      <column name="enabled" type="boolean">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -470,6 +470,7 @@
       "index": "multilang",
       "processor": "instanceAllFieldValuesProcessor",
       "rawProcessing": true,
+      "dependsOnFeature": "search.all.fields",
       "inventorySearchTypes": [ "cql.all", "cql.allInstances" ]
     },
     "allItems": {
@@ -477,6 +478,7 @@
       "index": "multilang",
       "processor": "itemAllFieldValuesProcessor",
       "rawProcessing": true,
+      "dependsOnFeature": "search.all.fields",
       "inventorySearchTypes": [ "cql.all", "cql.allItems" ]
     },
     "allHoldings": {
@@ -484,6 +486,7 @@
       "index": "multilang",
       "processor": "holdingAllFieldValuesProcessor",
       "rawProcessing": true,
+      "dependsOnFeature": "search.all.fields",
       "inventorySearchTypes": [ "cql.all", "cql.allHoldings" ]
     }
   },

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -193,11 +193,7 @@ paths:
               schema:
                 $ref: schemas/languageConfig.json
         '422':
-          description: Validation error for the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorResponse'
+          $ref: '#/components/responses/unprocessableEntityResponse'
     get:
       operationId: getAllLanguageConfigs
       description: Get all supported languages
@@ -228,11 +224,7 @@ paths:
               schema:
                 $ref: schemas/languageConfig.json
         '422':
-          description: Validation error for the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorResponse'
+          $ref: '#/components/responses/unprocessableEntityResponse'
     delete:
       operationId: deleteLanguageConfig
       description: Delete all supported languages
@@ -243,6 +235,70 @@ paths:
           description: Language support has been removed
         '404':
           description: No language support is found
+
+  /config/features:
+    post:
+      operationId: saveFeatureConfiguration
+      description: Save feature configuration (enables or disables pre-defined optional search options)
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: schemas/featureConfig.json
+      responses:
+        '200':
+          description: Language support has been added.
+          content:
+            application/json:
+              schema:
+                $ref: schemas/featureConfig.json
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '422':
+          $ref: '#/components/responses/unprocessableEntityResponse'
+    get:
+      operationId: getAllFeatures
+      description: Get all feature configurations per tenant
+      responses:
+        '200':
+          description: All feature configurations
+          content:
+            application/json:
+              schema:
+                $ref: schemas/featureConfigs.json
+
+  /config/features/{featureId}:
+    put:
+      operationId: updateFeatureConfiguration
+      description: Update feature configuration settings
+      parameters:
+        - $ref: '#/components/parameters/feature-id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: schemas/featureConfig.json
+      responses:
+        '200':
+          description: Feature configuration has been added.
+          content:
+            application/json:
+              schema:
+                $ref: schemas/featureConfig.json
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '422':
+          $ref: '#/components/responses/unprocessableEntityResponse'
+    delete:
+      operationId: deleteFeatureConfigurationById
+      description: Delete feature configuration by id
+      parameters:
+        - $ref: '#/components/parameters/feature-id'
+      responses:
+        '204':
+          description: Feature configuration has been removed
+        '404':
+          description: No feature configuration is found by id
 
 components:
   schemas:
@@ -274,6 +330,12 @@ components:
       $ref: schemas/request/reindexRequest.json
 
   responses:
+    unprocessableEntityResponse:
+      description: Validation error for the request.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/errorResponse'
     badRequestResponse:
       description: Validation errors
       content:
@@ -336,6 +398,15 @@ components:
       schema:
         type: string
         pattern: '[a-zA-Z]{3}'
+    feature-id:
+      name: featureId
+      in: path
+      required: true
+      description: Feature id (name)
+      schema:
+        type: string
+        enum:
+          - search.all.fields
     x-okapi-tenant-header:
       name: x-okapi-tenant
       in: header

--- a/src/main/resources/swagger.api/schemas/featureConfig.json
+++ b/src/main/resources/swagger.api/schemas/featureConfig.json
@@ -4,6 +4,7 @@
   "description": "Feature config request value",
   "properties": {
     "feature": {
+      "description": "The feature name",
       "$ref": "tenantConfiguredFeature.json"
     },
     "enabled": {

--- a/src/main/resources/swagger.api/schemas/featureConfig.json
+++ b/src/main/resources/swagger.api/schemas/featureConfig.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Feature config request value",
+  "properties": {
+    "feature": {
+      "$ref": "tenantConfiguredFeature.json"
+    },
+    "enabled": {
+      "type": "boolean",
+      "description": "Action - enable or disable option"
+    }
+  },
+  "additionalProperties": false,
+  "required": [ "feature", "enabled" ]
+}
+

--- a/src/main/resources/swagger.api/schemas/featureConfigs.json
+++ b/src/main/resources/swagger.api/schemas/featureConfigs.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Feature configs response per tenant",
+  "properties": {
+    "features": {
+      "type": "array",
+      "description": "Configured features per tenant",
+      "items": {
+        "$ref": "featureConfig.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer",
+      "description": "Total records that matches the query.",
+      "minimum": 0
+    }
+  }
+}
+

--- a/src/main/resources/swagger.api/schemas/tenantConfiguredFeature.json
+++ b/src/main/resources/swagger.api/schemas/tenantConfiguredFeature.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "string",
+  "description": "The feature name.",
+  "enum": [
+    "search.all.fields"
+  ]
+}

--- a/src/test/java/org/folio/search/controller/SearchByAllFieldsIT.java
+++ b/src/test/java/org/folio/search/controller/SearchByAllFieldsIT.java
@@ -1,8 +1,10 @@
 package org.folio.search.controller;
 
+import static org.folio.search.domain.dto.TenantConfiguredFeature.SEARCH_ALL_FIELDS;
 import static org.folio.search.sample.SampleInstances.getSemanticWebAsMap;
 import static org.folio.search.sample.SampleInstances.getSemanticWebId;
 import static org.folio.search.support.base.ApiEndpoints.instanceSearchPath;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -15,24 +17,20 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @IntegrationTest
-@TestPropertySource(properties = "application.search-config.disabled-search-options.instance=")
 class SearchByAllFieldsIT extends BaseIntegrationTest {
-
-  private static final String TENANT = "search_all";
 
   @BeforeAll
   static void createTenant(@Autowired MockMvc mockMvc) {
-    setUpTenant(TENANT, mockMvc, getSemanticWebAsMap());
+    setUpTenant(TENANT_ID, mockMvc, () -> enableFeature(TENANT_ID, SEARCH_ALL_FIELDS, mockMvc), getSemanticWebAsMap());
   }
 
   @AfterAll
   static void removeTenant(@Autowired MockMvc mockMvc) {
-    removeTenant(mockMvc, TENANT);
+    removeTenant(mockMvc, TENANT_ID);
   }
 
   @ValueSource(strings = {
@@ -124,6 +122,6 @@ class SearchByAllFieldsIT extends BaseIntegrationTest {
     return get(instanceSearchPath())
       .param("query", MessageFormat.format(template, cqlQuery))
       .param("limit", "1")
-      .headers(defaultHeaders(TENANT));
+      .headers(defaultHeaders());
   }
 }

--- a/src/test/java/org/folio/search/controller/SearchControllerTest.java
+++ b/src/test/java/org/folio/search/controller/SearchControllerTest.java
@@ -200,7 +200,7 @@ class SearchControllerTest {
       .andExpect(status().isBadRequest())
       .andExpect(jsonPath("$.total_records", is(1)))
       .andExpect(jsonPath("$.errors[0].message", is("Invalid facet value")))
-      .andExpect(jsonPath("$.errors[0].type", is("ValidationException")))
+      .andExpect(jsonPath("$.errors[0].type", is("RequestValidationException")))
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")))
       .andExpect(jsonPath("$.errors[0].parameters[0].key", is("facet")))
       .andExpect(jsonPath("$.errors[0].parameters[0].value", is("source")));

--- a/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
@@ -122,7 +122,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .andExpect(status().isBadRequest())
       .andExpect(jsonPath("$.total_records", is(1)))
       .andExpect(jsonPath("$.errors[0].message", is("Invalid facet value")))
-      .andExpect(jsonPath("$.errors[0].type", is("ValidationException")))
+      .andExpect(jsonPath("$.errors[0].type", is("RequestValidationException")))
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")))
       .andExpect(jsonPath("$.errors[0].parameters[0].key", is("facet")))
       .andExpect(jsonPath("$.errors[0].parameters[0].value", is("unknownFacet")));

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -71,7 +71,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
       .andExpect(status().isBadRequest())
       .andExpect(jsonPath("$.total_records", is(1)))
       .andExpect(jsonPath("$.errors[0].message", is("Invalid search field provided in the CQL query")))
-      .andExpect(jsonPath("$.errors[0].type", is("ValidationException")))
+      .andExpect(jsonPath("$.errors[0].type", is("RequestValidationException")))
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")))
       .andExpect(jsonPath("$.errors[0].parameters[0].key", is("field")))
       .andExpect(jsonPath("$.errors[0].parameters[0].value", is("unknownField")));

--- a/src/test/java/org/folio/search/controller/SortInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SortInstanceIT.java
@@ -90,7 +90,7 @@ class SortInstanceIT extends BaseIntegrationTest {
       .andExpect(status().isBadRequest())
       .andExpect(jsonPath("$.total_records", is(1)))
       .andExpect(jsonPath("$.errors[0].message", is("Sort field not found or cannot be used.")))
-      .andExpect(jsonPath("$.errors[0].type", is("ValidationException")))
+      .andExpect(jsonPath("$.errors[0].type", is("RequestValidationException")))
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")))
       .andExpect(jsonPath("$.errors[0].parameters[0].key", is("sortField")))
       .andExpect(jsonPath("$.errors[0].parameters[0].value", is("unknownSort")));

--- a/src/test/java/org/folio/search/integration/InstanceReferenceDataServiceTest.java
+++ b/src/test/java/org/folio/search/integration/InstanceReferenceDataServiceTest.java
@@ -1,4 +1,4 @@
-package org.folio.search.service.setter.instance;
+package org.folio.search.integration;
 
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
@@ -23,10 +23,9 @@ import java.util.Set;
 import org.folio.search.client.AlternativeTitleTypesClient;
 import org.folio.search.client.IdentifierTypeClient;
 import org.folio.search.client.cql.CqlQuery;
+import org.folio.search.integration.InstanceReferenceDataServiceTest.TestContextConfiguration;
 import org.folio.search.model.service.ReferenceRecord;
 import org.folio.search.model.service.ResultList;
-import org.folio.search.repository.cache.InstanceReferenceDataService;
-import org.folio.search.service.setter.instance.InstanceReferenceDataServiceTest.TestContextConfiguration;
 import org.folio.search.utils.types.UnitTest;
 import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioExecutionContext;

--- a/src/test/java/org/folio/search/service/FeatureConfigServiceTest.java
+++ b/src/test/java/org/folio/search/service/FeatureConfigServiceTest.java
@@ -1,0 +1,212 @@
+package org.folio.search.service;
+
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.configuration.SearchCacheNames.TENANT_FEATURES_CACHE;
+import static org.folio.search.domain.dto.TenantConfiguredFeature.SEARCH_ALL_FIELDS;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.folio.search.utils.TestUtils.mapOf;
+import static org.folio.spring.integration.XOkapiHeaders.TENANT;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+
+import java.util.List;
+import java.util.Optional;
+import javax.persistence.EntityNotFoundException;
+import org.folio.search.configuration.properties.SearchConfigurationProperties;
+import org.folio.search.converter.FeatureConfigMapperImpl;
+import org.folio.search.domain.dto.FeatureConfig;
+import org.folio.search.domain.dto.FeatureConfigs;
+import org.folio.search.domain.dto.TenantConfiguredFeature;
+import org.folio.search.exception.RequestValidationException;
+import org.folio.search.model.config.FeatureConfigEntity;
+import org.folio.search.repository.FeatureConfigRepository;
+import org.folio.search.service.FeatureConfigServiceTest.TestContextConfiguration;
+import org.folio.search.utils.types.UnitTest;
+import org.folio.spring.DefaultFolioExecutionContext;
+import org.folio.spring.FolioExecutionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.Cache.ValueWrapper;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+@UnitTest
+@SpringBootTest(classes = {FeatureConfigService.class, TestContextConfiguration.class}, webEnvironment = NONE)
+class FeatureConfigServiceTest {
+
+  private static final TenantConfiguredFeature FEATURE = SEARCH_ALL_FIELDS;
+  private static final String FEATURE_ID = SEARCH_ALL_FIELDS.getValue();
+
+  @Autowired private CacheManager cacheManager;
+  @Autowired private FeatureConfigService featureConfigService;
+  @MockBean private FeatureConfigRepository featureConfigRepository;
+  @MockBean private SearchConfigurationProperties searchConfigurationProperties;
+
+  @BeforeEach
+  void setUp() {
+    var cacheNames = cacheManager.getCacheNames();
+    cacheNames.forEach(name -> requireNonNull(cacheManager.getCache(name)).clear());
+  }
+
+  @Test
+  void create_positive_mustEvictCache() {
+    when(searchConfigurationProperties.getSearchFeatures()).thenReturn(mapOf(FEATURE, false));
+    assertThat(featureConfigService.isEnabled(FEATURE)).isFalse();
+    assertThat(getCachedValue()).isEqualTo(Optional.of(false));
+
+    var expectedEntity = FeatureConfigEntity.of(FEATURE_ID, true);
+    when(featureConfigRepository.existsById(FEATURE_ID)).thenReturn(false);
+    when(featureConfigRepository.save(expectedEntity)).thenReturn(expectedEntity);
+
+    var feature = new FeatureConfig().feature(FEATURE).enabled(true);
+    var actual = featureConfigService.create(feature);
+    assertThat(actual).isEqualTo(feature);
+    assertThat(getCachedValue()).isEmpty();
+  }
+
+  @Test
+  void create_negative_featureAlreadyExists() {
+    var featureId = SEARCH_ALL_FIELDS.getValue();
+    when(featureConfigRepository.existsById(featureId)).thenReturn(true);
+
+    var feature = new FeatureConfig().feature(FEATURE).enabled(true);
+    assertThatThrownBy(() -> featureConfigService.create(feature))
+      .isInstanceOf(RequestValidationException.class)
+      .hasMessage("Feature configuration already exists");
+  }
+
+  @Test
+  void isEnabled_positive_featureEnabledInDatabase() {
+    checkIfFeatureIsEnabled();
+  }
+
+  @Test
+  void isEnabled_positive_featureDisabledInDatabase() {
+    when(featureConfigRepository.findById(FEATURE_ID)).thenReturn(of(FeatureConfigEntity.of(FEATURE_ID, false)));
+    var actual = featureConfigService.isEnabled(FEATURE);
+    assertThat(actual).isFalse();
+    assertThat(getCachedValue()).isEqualTo(of(false));
+  }
+
+  @Test
+  void isEnabled_positive_featureNotConfiguredYet() {
+    when(searchConfigurationProperties.getSearchFeatures()).thenReturn(mapOf(FEATURE, false));
+    when(featureConfigRepository.findById(FEATURE_ID)).thenReturn(Optional.empty());
+    var actual = featureConfigService.isEnabled(FEATURE);
+    assertThat(actual).isFalse();
+    assertThat(getCachedValue()).isEqualTo(of(false));
+  }
+
+  @Test
+  void isEnabled_positive_featureIsNotConfiguredButEnabledInConfigurationProperties() {
+    when(searchConfigurationProperties.getSearchFeatures()).thenReturn(mapOf(FEATURE, true));
+    when(featureConfigRepository.findById(FEATURE_ID)).thenReturn(Optional.empty());
+    var actual = featureConfigService.isEnabled(FEATURE);
+    assertThat(actual).isTrue();
+    assertThat(getCachedValue()).isEqualTo(of(true));
+  }
+
+  @Test
+  void update_positive() {
+    checkIfFeatureIsEnabled();
+    var expectedFeature = new FeatureConfig().feature(FEATURE).enabled(false);
+    var expectedFeatureEntity = FeatureConfigEntity.of(FEATURE_ID, false);
+    when(featureConfigRepository.findById(FEATURE_ID)).thenReturn(of(FeatureConfigEntity.of(FEATURE_ID, true)));
+    when(featureConfigRepository.save(expectedFeatureEntity)).thenReturn(expectedFeatureEntity);
+    var actual = featureConfigService.update(FEATURE, expectedFeature);
+    assertThat(actual).isEqualTo(expectedFeature);
+    assertThat(getCachedValue()).isEmpty();
+  }
+
+  @Test
+  void update_positive_sameValues() {
+    var expectedFeature = new FeatureConfig().feature(FEATURE).enabled(true);
+    when(featureConfigRepository.findById(FEATURE_ID)).thenReturn(of(FeatureConfigEntity.of(FEATURE_ID, true)));
+    var actual = featureConfigService.update(FEATURE, expectedFeature);
+    assertThat(actual).isEqualTo(expectedFeature);
+  }
+
+  @Test
+  void update_negative_differentIncorrectId() {
+    var expectedFeature = new FeatureConfig().feature(null).enabled(true);
+    when(featureConfigRepository.findById(FEATURE_ID)).thenReturn(of(FeatureConfigEntity.of(FEATURE_ID, true)));
+    assertThatThrownBy(() -> featureConfigService.update(FEATURE, expectedFeature))
+      .isInstanceOf(RequestValidationException.class)
+      .hasMessage("Request body feature must be the same as in the URL");
+  }
+
+  @Test
+  void update_negative_entityNotFound() {
+    var expectedFeature = new FeatureConfig().feature(FEATURE).enabled(true);
+    when(featureConfigRepository.findById(FEATURE_ID)).thenReturn(Optional.empty());
+    assertThatThrownBy(() -> featureConfigService.update(FEATURE, expectedFeature))
+      .isInstanceOf(EntityNotFoundException.class)
+      .hasMessage("Feature configuration not found for id: " + FEATURE_ID);
+  }
+
+  @Test
+  void getAll_positive() {
+    when(featureConfigRepository.findAll()).thenReturn(List.of(FeatureConfigEntity.of(FEATURE_ID, true)));
+    var actual = featureConfigService.getAll();
+    var expectedFeature = new FeatureConfig().feature(FEATURE).enabled(true);
+    assertThat(actual).isEqualTo(new FeatureConfigs().features(List.of(expectedFeature)).totalRecords(1));
+  }
+
+  @Test
+  void delete_positive_mustEvictCache() {
+    checkIfFeatureIsEnabled();
+    when(featureConfigRepository.existsById(FEATURE_ID)).thenReturn(true);
+    featureConfigService.delete(FEATURE);
+    assertThat(getCachedValue()).isEmpty();
+  }
+
+  @Test
+  void delete_negative_featureConfigNotFound() {
+    when(featureConfigRepository.existsById(FEATURE_ID)).thenReturn(false);
+    assertThatThrownBy(() -> featureConfigService.delete(FEATURE))
+      .isInstanceOf(EntityNotFoundException.class)
+      .hasMessage("Feature configuration not found for id: search.all.fields");
+  }
+
+  private void checkIfFeatureIsEnabled() {
+    when(featureConfigRepository.findById(FEATURE_ID)).thenReturn(of(FeatureConfigEntity.of(FEATURE_ID, true)));
+    var actual = featureConfigService.isEnabled(FEATURE);
+
+    assertThat(actual).isTrue();
+    assertThat(getCachedValue()).isEqualTo(Optional.of(true));
+  }
+
+  private Optional<Object> getCachedValue() {
+    return ofNullable(cacheManager.getCache(TENANT_FEATURES_CACHE))
+      .map(cache -> cache.get(TENANT_ID + ":" + FEATURE_ID))
+      .map(ValueWrapper::get);
+  }
+
+  @EnableCaching
+  @TestConfiguration
+  @Import(FeatureConfigMapperImpl.class)
+  static class TestContextConfiguration {
+
+    @Bean
+    CacheManager cacheManager() {
+      return new ConcurrentMapCacheManager(TENANT_FEATURES_CACHE);
+    }
+
+    @Bean
+    FolioExecutionContext folioExecutionContext() {
+      return new DefaultFolioExecutionContext(null, mapOf(TENANT, singletonList(TENANT_ID)));
+    }
+  }
+}

--- a/src/test/java/org/folio/search/service/setter/instance/IsbnProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/instance/IsbnProcessorTest.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 import org.apache.commons.collections.CollectionUtils;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.InstanceIdentifiers;
-import org.folio.search.repository.cache.InstanceReferenceDataService;
+import org.folio.search.integration.InstanceReferenceDataService;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/org/folio/search/service/setter/instance/IssnProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/instance/IssnProcessorTest.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
 import org.apache.commons.collections.CollectionUtils;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.InstanceIdentifiers;
-import org.folio.search.repository.cache.InstanceReferenceDataService;
+import org.folio.search.integration.InstanceReferenceDataService;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/org/folio/search/service/setter/instance/UniformTitleProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/instance/UniformTitleProcessorTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.InstanceAlternativeTitles;
-import org.folio.search.repository.cache.InstanceReferenceDataService;
+import org.folio.search.integration.InstanceReferenceDataService;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/org/folio/search/support/base/ApiEndpoints.java
+++ b/src/test/java/org/folio/search/support/base/ApiEndpoints.java
@@ -2,6 +2,7 @@ package org.folio.search.support.base;
 
 import lombok.experimental.UtilityClass;
 import org.folio.cql2pgjson.model.CqlSort;
+import org.folio.search.domain.dto.TenantConfiguredFeature;
 
 @UtilityClass
 public class ApiEndpoints {
@@ -26,6 +27,14 @@ public class ApiEndpoints {
 
   public static String languageConfig() {
     return "/search/config/languages";
+  }
+
+  public static String featureConfig() {
+    return "/search/config/features";
+  }
+
+  public static String featureConfig(TenantConfiguredFeature feature) {
+    return featureConfig() + "/" + feature.getValue();
   }
 
   public static String createIndicesEndpoint() {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,7 +19,13 @@ spring:
     producer:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
   cache:
-    cache-names: es-indices,identifier-types,alternative-title-types,system-user-cache,tenant-languages
+    cache-names:
+      - es-indices
+      - identifier-types
+      - alternative-title-types
+      - system-user-cache
+      - tenant-languages
+      - tenant-features
     caffeine:
       spec: maximumSize=500,expireAfterAccess=3600s
 
@@ -29,8 +35,8 @@ application:
   environment: folio-test
   search-config:
     initial-languages: eng,fre,ita,spa,ger
-    disabled-search-options:
-      instance: cql.all
+    search-features:
+      search.all.fields: false
   system-user:
     username: mod-search
     password: Mod-search-1-0-0


### PR DESCRIPTION
### Purpose/Overview
The current implementation contains an environment variable that disables/enables search by all field values for all tenants. New implementation must provide tenants the ability to configure optional search options using REST API.

### Approach
- Implement endpoint `search/config/features` to perform CRUD operations for FeatureConfig DTO and them to the `ModuleDescriptor.json` and in OpenApi documentation file
- Add integration and unit tests for implemented feature
- Extend integration test for search by all field values