### PR TITLE
MSEARCH-199 Fix facet for instanceFormatIds

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ if it is defined but doesn't match.
 | `contributors.primary`                    | term      | `contributors all "John" and contributors.primary==true` | Matches instances that have a primary `John` contributor |
 | `subjects`                                | full text | `subjects all "Chemistry"`                        | Matches instances that have a `Chemistry` subject |
 | `instanceTypeId`                          | term      | `instanceTypeId == "123"`                         | Matches instances with the `123` type |
-| `instanceFormatId`                        | term      | `instanceFormatId == "123"`                       | Matches instances with the `123` format id |
+| `instanceFormatIds`                       | term      | `instanceFormatIds == "123"`                      | Matches instances with the `123` format id |
 | `languages`                               | term      | `languages == "eng"`                              | Matches instances that have `eng` language |
 | `metadata.createdDate`                    | term      | `metadata.createdDate > "2020-12-12"`             | Matches instances that were created after  `2020-12-12`|
 | `metadata.updatedDate`                    | term      | `metadata.updatedDate > "2020-12-12"`             | Matches instances that were updated after  `2020-12-12`|
@@ -407,7 +407,7 @@ GET /instances/facets?query=title all book&facet=source:5,discoverySuppress:2
 | :------------------------|:--------|:-------------|
 | `source`                 | term    | Requests a source facet |
 | `instanceTypeId`         | term    | Requests a type id facet |
-| `instanceFormatId`       | term    | Requests a format id facet |
+| `instanceFormatIds`      | term    | Requests a format id facet |
 | `modeOfIssuanceId`       | term    | Requests a mode of issuance id facet |
 | `natureOfContentTermIds` | term    | Requests a nature of content terms id facet |
 | `languages`              | term    | Requests a language code facet |

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -84,7 +84,7 @@
       "searchTypes": [ "facet", "filter" ],
       "index": "keyword"
     },
-    "instanceFormatId": {
+    "instanceFormatIds": {
       "searchTypes": [ "facet", "filter" ],
       "index": "keyword"
     },

--- a/src/main/resources/swagger.api/schemas/instance.json
+++ b/src/main/resources/swagger.api/schemas/instance.json
@@ -96,7 +96,7 @@
       "type": "string",
       "description": "UUID of the unique term for the resource type whether it's from the RDA content term list of locally defined"
     },
-    "instanceFormatId": {
+    "instanceFormatIds": {
       "type": "array",
       "description": "UUIDs for the unique terms for the format whether it's from the RDA carrier term list of locally defined",
       "items": {

--- a/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
@@ -149,11 +149,11 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       arguments(format("(id=* and instanceTypeId==%s) sortby title", TYPES[0]), List.of(IDS[1], IDS[2])),
       arguments(format("(id=* and instanceTypeId==%s) sortby title", TYPES[1]), List.of(IDS[0], IDS[3], IDS[4])),
 
-      arguments(format("(id=* and instanceFormatId==\"%s\") sortby title", FORMATS[0]), List.of(IDS[3])),
-      arguments(format("(id=* and instanceFormatId==%s) sortby title", FORMATS[1]),
+      arguments(format("(id=* and instanceFormatIds==\"%s\") sortby title", FORMATS[0]), List.of(IDS[3])),
+      arguments(format("(id=* and instanceFormatIds==%s) sortby title", FORMATS[1]),
         List.of(IDS[0], IDS[1], IDS[3], IDS[4])),
-      arguments(format("(id=* and instanceFormatId==%s) sortby title", FORMATS[2]), List.of(IDS[0], IDS[2], IDS[3])),
-      arguments(format("(id=* and instanceFormatId==(%s or %s)) sortby title", FORMATS[1], FORMATS[2]), List.of(IDS)),
+      arguments(format("(id=* and instanceFormatIds==%s) sortby title", FORMATS[2]), List.of(IDS[0], IDS[2], IDS[3])),
+      arguments(format("(id=* and instanceFormatIds==(%s or %s)) sortby title", FORMATS[1], FORMATS[2]), List.of(IDS)),
 
       arguments("(id=* and staffSuppress==true) sortby title", List.of(IDS[0], IDS[1], IDS[2])),
       arguments("(id=* and staffSuppress==false) sortby title", List.of(IDS[3], IDS[4])),
@@ -217,7 +217,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
 
   private static Stream<Arguments> facetQueriesProvider() {
     var allFacets = array("discoverySuppress", "staffSuppress", "languages", "instanceTags", "source",
-      "instanceTypeId", "instanceFormatId", "items.effectiveLocationId", "items.status.name",
+      "instanceTypeId", "instanceFormatIds", "items.effectiveLocationId", "items.status.name",
       "holdings.permanentLocationId", "holdings.discoverySuppress", "items.materialTypeId");
     return Stream.of(
       arguments("id=*", allFacets, mapOf(
@@ -229,7 +229,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
           facetItem("casual", 1), facetItem("text", 1)),
         "source", facet(facetItem("MARC", 3), facetItem("FOLIO", 2)),
         "instanceTypeId", facet(facetItem(TYPES[1], 3), facetItem(TYPES[0], 2)),
-        "instanceFormatId", facet(facetItem(FORMATS[1], 4), facetItem(FORMATS[2], 3), facetItem(FORMATS[0], 1)),
+        "instanceFormatIds", facet(facetItem(FORMATS[1], 4), facetItem(FORMATS[2], 3), facetItem(FORMATS[0], 1)),
 
         "items.effectiveLocationId", facet(facetItem(LOCATIONS[0], 4), facetItem(LOCATIONS[1], 3)),
         "items.status.name", facet(facetItem("Available", 3), facetItem("Checked out", 2), facetItem("Missing", 2)),
@@ -273,14 +273,14 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       arguments("id=*", array("instanceTypeId"), mapOf("instanceTypeId", facet(
         facetItem(TYPES[1], 3), facetItem(TYPES[0], 2)))),
 
-      arguments("id=*", array("instanceFormatId"), mapOf("instanceFormatId", facet(
+      arguments("id=*", array("instanceFormatIds"), mapOf("instanceFormatIds", facet(
         facetItem(FORMATS[1], 4), facetItem(FORMATS[2], 3), facetItem(FORMATS[0], 1)))),
 
-      arguments("instanceFormatId==" + FORMATS[0], array("instanceFormatId"), mapOf(
-        "instanceFormatId", facet(facetItem(FORMATS[1], 4), facetItem(FORMATS[2], 3), facetItem(FORMATS[0], 1)))),
+      arguments("instanceFormatIds==" + FORMATS[0], array("instanceFormatIds"), mapOf(
+        "instanceFormatIds", facet(facetItem(FORMATS[1], 4), facetItem(FORMATS[2], 3), facetItem(FORMATS[0], 1)))),
 
-      arguments("source==MARC", array("instanceFormatId"), mapOf(
-        "instanceFormatId", facet(facetItem(FORMATS[1], 3), facetItem(FORMATS[2], 2), facetItem(FORMATS[0], 1)))),
+      arguments("source==MARC", array("instanceFormatIds"), mapOf(
+        "instanceFormatIds", facet(facetItem(FORMATS[1], 3), facetItem(FORMATS[2], 2), facetItem(FORMATS[0], 1)))),
 
       arguments("id=*", array("items.effectiveLocationId"), mapOf(
         "items.effectiveLocationId", facet(facetItem(LOCATIONS[0], 4), facetItem(LOCATIONS[1], 3)))),
@@ -322,7 +322,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .instanceTypeId(TYPES[1])
       .staffSuppress(true)
       .discoverySuppress(true)
-      .instanceFormatId(List.of(FORMATS[1], FORMATS[2]))
+      .instanceFormatIds(List.of(FORMATS[1], FORMATS[2]))
       .tags(tags("text", "science"))
       .metadata(metadata("2021-03-01T00:00:00.000+00:00", "2021-03-05T12:30:00.000+00:00"))
       .items(List.of(
@@ -340,7 +340,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .instanceTypeId(TYPES[0])
       .staffSuppress(true)
       .discoverySuppress(true)
-      .instanceFormatId(List.of(FORMATS[1]))
+      .instanceFormatIds(List.of(FORMATS[1]))
       .tags(tags("future"))
       .metadata(metadata("2021-03-10T01:00:00.000+00:00", "2021-03-12T15:40:00.000+00:00"))
       .items(List.of(
@@ -357,7 +357,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .languages(List.of("rus", "ukr"))
       .instanceTypeId(TYPES[0])
       .staffSuppress(true)
-      .instanceFormatId(List.of(FORMATS[2]))
+      .instanceFormatIds(List.of(FORMATS[2]))
       .tags(tags("future", "science"))
       .metadata(metadata("2021-03-08T15:00:00.000+00:00", "2021-03-15T22:30:00.000+00:00"))
       .items(List.of(
@@ -372,7 +372,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .staffSuppress(false)
       .discoverySuppress(false)
       .instanceTypeId(TYPES[1])
-      .instanceFormatId(List.of(FORMATS))
+      .instanceFormatIds(List.of(FORMATS))
       .tags(tags("casual", "cooking"))
       .metadata(metadata("2021-03-15T12:00:00.000+00:00", "2021-03-15T12:00:00.000+00:00"))
       .items(List.of(new Item().id(randomId())
@@ -387,7 +387,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .source("FOLIO")
       .languages(List.of("eng", "fra"))
       .instanceTypeId(TYPES[1])
-      .instanceFormatId(List.of(FORMATS[1]))
+      .instanceFormatIds(List.of(FORMATS[1]))
       .tags(tags("cooking"))
       .items(List.of(
         new Item().id(randomId()).effectiveLocationId(LOCATIONS[0]).status(itemStatus(CHECKED_OUT)).tags(tags("itag3")),

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -201,6 +201,8 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("search by items hrid (start with)", "items.hrid = {value}", array("item*"), null),
       arguments("search by items hrid (ends with)", "items.hrid = {value}", array("*00014"), null),
       arguments("search by items hrid (wildcard)", "items.hrid = {value}", array("item*00014"), null),
+      arguments("search by instanceFormatIds",
+        "instanceFormatIds all {value}", array("7f9c4ac0-fa3d-43b7-b978-3bf0be38c4da"), null),
 
       arguments("search by items electronic access", "items.electronicAccess==\"{value}\"", array("table"), null),
       arguments("search by items electronic access (uri)", "items.electronicAccess.uri==\"{value}\"",

--- a/src/test/resources/samples/semantic-web-primer/instance.json
+++ b/src/test/resources/samples/semantic-web-primer/instance.json
@@ -96,7 +96,9 @@
     }
   ],
   "instanceTypeId": "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
-  "instanceFormatIds": [],
+  "instanceFormatIds": [
+    "7f9c4ac0-fa3d-43b7-b978-3bf0be38c4da"
+  ],
   "instanceFormats": [],
   "physicalDescriptions": [
     "xx, 238 p. : ill. ; 24 cm."


### PR DESCRIPTION
### Purpose
Filtering of Format has stopped working after the swap to use ES as a search engine - work done UIIN-1567. Format should be working similarly to e.g. Resource type, except that the values are concatenated Format type, format value.

### Approach
- Fix invalid mappings name
- Fix integration tests cases to use the correct value - `instanceFormatIds`
- Update README.md documentation