### PR TITLE
MSEARCH-190 Use opendistro image for integration tests

### DIFF
--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.10.1
+FROM amazon/opendistro-for-elasticsearch:1.13.2
 
 RUN elasticsearch-plugin install --batch \
   analysis-icu \

--- a/docker/elasticsearch/elasticsearch.yml
+++ b/docker/elasticsearch/elasticsearch.yml
@@ -1,8 +1,0 @@
-discovery.type: single-node
-discovery.zen.minimum_master_nodes: 1
-
-xpack.security.enabled: false
-xpack.monitoring.enabled: false
-xpack.ml.enabled: false
-xpack.graph.enabled: false
-xpack.watcher.enabled: false

--- a/src/test/java/org/folio/search/support/extension/impl/ElasticSearchContainerExtension.java
+++ b/src/test/java/org/folio/search/support/extension/impl/ElasticSearchContainerExtension.java
@@ -8,6 +8,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 public class ElasticSearchContainerExtension implements BeforeAllCallback, AfterAllCallback {
+
   private static final String SPRING_PROPERTY_NAME = "spring.elasticsearch.rest.uris";
   private static final String ES_IMAGE_NAME = "test-container-embedded-es:7.10.1";
   private static final Path ES_DOCKERFILE_PATH = Path.of("docker/elasticsearch/Dockerfile");
@@ -35,8 +36,7 @@ public class ElasticSearchContainerExtension implements BeforeAllCallback, After
     return new GenericContainer<>(new ImageFromDockerfile(ES_IMAGE_NAME, false)
       .withDockerfile(ES_DOCKERFILE_PATH))
       .withEnv("discovery.type", "single-node")
-      .withEnv("xpack.security.enabled", "true")
-      .withEnv("ELASTIC_PASSWORD", "s3cret")
+      .withEnv("opendistro_security.disabled", "true")
       .withExposedPorts(9200);
   }
 }


### PR DESCRIPTION
### Purpose
Upgrading the Elasticsearch client version shows that integration tests can pass through, but API tests at the snapshot environment can fail.

Error message:
```
{
  "errors":[
    {
      "message":"Invalid or missing build flavor [oss]",
      "type":"ElasticsearchException",
      "code":"elasticsearch_error"
    }
  ],
  "total_records":1
}
```

### Approach
- Use in integration tests `amazon/opendistro-for-elasticsearch:1.13.2` docker image with pre-installed list of required plugins
- Check that integration tests pass throught