### PR TITLE
MSEARCH-223 Add discovery and stuff suppress to response

### DIFF
--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -7,6 +7,12 @@
       "searchTypes": [ "facet", "filter" ],
       "index": "bool",
       "default": false
+    },
+    "visibleSuppress": {
+      "searchTypes": [ "facet", "filter" ],
+      "index": "bool",
+      "default": false,
+      "showInResponse": true
     }
   },
   "fields": {
@@ -193,10 +199,10 @@
       }
     },
     "staffSuppress": {
-      "$type": "suppress"
+      "$type": "visibleSuppress"
     },
     "discoverySuppress": {
-      "$type": "suppress"
+      "$type": "visibleSuppress"
     },
     "items": {
       "type": "object",

--- a/src/test/java/org/folio/search/controller/EsInstanceToInventoryInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/EsInstanceToInventoryInstanceIT.java
@@ -41,12 +41,14 @@ class EsInstanceToInventoryInstanceIT extends BaseIntegrationTest {
     var response = doSearchByInstances(prepareQuery("id=={value}", getSemanticWebId()))
       .andExpect(jsonPath("totalRecords", is(1)))
       // make sure that no unexpected properties are present
-      .andExpect(jsonPath("instances[0].length()", is(4)));
+      .andExpect(jsonPath("instances[0].length()", is(6)));
 
     var actual = parseResponse(response, new TypeReference<ResultList<Instance>>() {}).getResult().get(0);
     assertThat(actual.getId(), is(expected.getId()));
     assertThat(actual.getTitle(), is(expected.getTitle()));
     assertThat(actual.getContributors(), is(expected.getContributors()));
+    assertThat(actual.getStaffSuppress(), is(false));
+    assertThat(actual.getDiscoverySuppress(), is(expected.getDiscoverySuppress()));
     assertThat(actual.getPublication(), is(expected.getPublication()));
   }
 

--- a/src/test/resources/samples/semantic-web-primer/instance.json
+++ b/src/test/resources/samples/semantic-web-primer/instance.json
@@ -60,7 +60,7 @@
       "name": "Van Harmelen, Frank",
       "contributorTypeId": "6e09d47d-95e2-4d8a-831b-f777b8ef6d81",
       "contributorTypeText": "",
-      "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a",
+      "contributorNameTypeId": "9fb7f83e-260e-479f-9539-dfd9a628b858",
       "primary": true
     }
   ],


### PR DESCRIPTION
### Purpose
Add a `discoverySuppress` and `staffSuppress` to the response.

### Approach
- Add required fields to the search response
- Fix integration test to apply new fields
