### PR TITLE
MSEARCH-202 Holdings - filter/facet by holdings source

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ GET /instances/facets?query=title all book&facet=source:5,discoverySuppress:2
 | :------------------------------|:--------|:-------------|
 | `holdings.permanentLocationId` | term    | Requests a holding permanent location id facet |
 | `holdings.discoverySuppress`   | term    | Requests a holding discovery suppress facet |
+| `holdings.sourceId`            | term    | Requests a holding sourceId facet |
 | `holdingTags`                  | term    | Requests a holding tag facet |
 
 #### Item facets

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -327,6 +327,10 @@
         "id": {
           "index": "keyword"
         },
+        "sourceId": {
+          "searchTypes": [ "facet", "filter" ],
+          "index": "keyword"
+        },
         "permanentLocationId": {
           "searchTypes": [ "facet", "filter" ],
           "index": "keyword"

--- a/src/main/resources/swagger.api/schemas/holding.json
+++ b/src/main/resources/swagger.api/schemas/holding.json
@@ -19,6 +19,10 @@
       "type": "string",
       "description": "the human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"
     },
+    "sourceId": {
+      "description": "(A reference to) the source of a holdings record",
+      "type": "string"
+    },
     "formerIds": {
       "type": "array",
       "description": "Previous identifiers assigned to the holding",

--- a/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
@@ -304,7 +304,10 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
 
       arguments("id=*", array("statisticalCodes"), mapOf(
         "statisticalCodes", facet(facetItem("b5968c9e-cddc-4576-99e3-8e60aed8b0dd", 1),
-          facetItem("a2b01891-c9ab-4d04-8af8-8989af1c6aad", 1), facetItem("615e9911-edb1-4ab3-a9c3-a461a3de02f8", 1))))
+          facetItem("a2b01891-c9ab-4d04-8af8-8989af1c6aad", 1), facetItem("615e9911-edb1-4ab3-a9c3-a461a3de02f8", 1)))),
+
+      arguments("id=*", array("holdings.sourceId"), mapOf(
+        "holdings.sourceId", facet(facetItem("FOLIO", 1))))
     );
   }
 
@@ -379,7 +382,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
         .materialTypeId(MATERIAL_TYPES[1])))
       .holdings(List.of(
         new Holding().id(randomId()).permanentLocationId(PERMANENT_LOCATIONS[0])
-          .statisticalCodeIds(singletonList("a2b01891-c9ab-4d04-8af8-8989af1c6aad")),
+          .sourceId("FOLIO").statisticalCodeIds(singletonList("a2b01891-c9ab-4d04-8af8-8989af1c6aad")),
         new Holding().id(randomId()).permanentLocationId(PERMANENT_LOCATIONS[1]).tags(tags("htag2")),
         new Holding().id(randomId()).permanentLocationId(PERMANENT_LOCATIONS[2]).tags(tags("htag3"))));
 


### PR DESCRIPTION
**Purpose/Overview:**
The purpose of this story is to provide a quick way to narrow down the search results to the specific holdings source

**Requirements/Scope:**
Holdings search based on the holdings.sourceId

**Acceptance criteria:**

Search returns accurate hit count
Search returns instances with holdings that matches specified permanent location
User can limit instances search by location data associated with holdings