### PR TITLE
MSEARCH-212 Implement Authorized/Reference field

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ if it is defined but doesn't match.
 | `id`                                            | term      | `id=="1234567"`                  | Matches authorities with the id |
 | `personalName`                                  | full-text | `personalName any "john"`        | Matches authorities with `john` personal name |
 | `headingType`                                   | term      | `headingType == "Personal Name"` | Matches authorities with `Personal Name` heading type |
+| `authRefType`                                   | term      | `authRefType == "Authorized"`    | Matches authorities with `Authorized` auth/ref type |
 
 ### Search by all field values
 

--- a/src/main/java/org/folio/search/model/metadata/AuthorityFieldDescription.java
+++ b/src/main/java/org/folio/search/model/metadata/AuthorityFieldDescription.java
@@ -8,13 +8,18 @@ import lombok.EqualsAndHashCode;
 public class AuthorityFieldDescription extends PlainFieldDescription {
 
   /**
+   * Distinct type to split single to entity to multiple containing only common fields excluding all other fields marked
+   * with other distinct type.
+   */
+  private String distinctType;
+
+  /**
    * Heading type that should be set to the resource if field containing some values.
    */
   private String headingType;
 
   /**
-   * Distinct type to split single to entity to multiple containing only common fields excluding all other fields marked
-   * with other distinct type.
+   * Authorized, Reference or Auth/Ref type for divided authority record.
    */
-  private String distinctType;
+  private String authRefType;
 }

--- a/src/main/java/org/folio/search/service/setter/authority/AbstractAuthorityProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/authority/AbstractAuthorityProcessor.java
@@ -1,0 +1,44 @@
+package org.folio.search.service.setter.authority;
+
+import static org.folio.search.utils.SearchUtils.AUTHORITY_RESOURCE;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.commons.lang3.ObjectUtils;
+import org.folio.search.model.metadata.AuthorityFieldDescription;
+import org.folio.search.service.metadata.SearchFieldProvider;
+import org.folio.search.service.setter.FieldProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public abstract class AbstractAuthorityProcessor implements FieldProcessor<Map<String, Object>, String> {
+
+  private SearchFieldProvider searchFieldProvider;
+
+  @Autowired
+  public void setSearchFieldProvider(SearchFieldProvider localSearchFieldProvider) {
+    this.searchFieldProvider = localSearchFieldProvider;
+  }
+
+  protected String getAuthorityType(Map<String, Object> eventBody,
+    Function<AuthorityFieldDescription, String> valueExtractor, String defaultValue) {
+    return eventBody.entrySet().stream()
+      .map(entry -> getTypeForField(entry, valueExtractor))
+      .flatMap(Optional::stream)
+      .findFirst()
+      .orElse(defaultValue);
+  }
+
+  private Optional<String> getTypeForField(Entry<String, Object> entry,
+    Function<AuthorityFieldDescription, String> valueExtractor) {
+    if (ObjectUtils.isEmpty(entry.getValue())) {
+      return Optional.empty();
+    }
+
+    return searchFieldProvider.getPlainFieldByPath(AUTHORITY_RESOURCE, entry.getKey())
+      .filter(AuthorityFieldDescription.class::isInstance)
+      .map(AuthorityFieldDescription.class::cast)
+      .map(valueExtractor);
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/authority/AuthRefTypeProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/authority/AuthRefTypeProcessor.java
@@ -7,12 +7,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class HeadingTypeProcessor extends AbstractAuthorityProcessor {
-
-  private static final String DEFAULT_VALUE = "Other";
+public class AuthRefTypeProcessor extends AbstractAuthorityProcessor {
 
   @Override
   public String getFieldValue(Map<String, Object> eventBody) {
-    return getAuthorityType(eventBody, AuthorityFieldDescription::getHeadingType, DEFAULT_VALUE);
+    return getAuthorityType(eventBody, AuthorityFieldDescription::getAuthRefType, null);
   }
 }

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -9,120 +9,141 @@
       "type": "authority",
       "index": "standard",
       "distinctType": "personalName",
-      "headingType": "Personal Name"
+      "headingType": "Personal Name",
+      "authRefType": "Authorized"
     },
     "sftPersonalName": {
       "type": "authority",
       "index": "source",
       "distinctType": "sftPersonalName",
-      "headingType": "Personal Name"
+      "headingType": "Personal Name",
+      "authRefType": "Reference"
     },
     "saftPersonalName": {
       "type": "authority",
       "index": "source",
-      "distinctType": "saftPersonalName"
+      "distinctType": "saftPersonalName",
+      "authRefType": "Auth/Ref"
     },
     "corporateName": {
       "type": "authority",
       "index": "source",
       "distinctType": "corporateName",
-      "headingType": "Corporate Name"
+      "headingType": "Corporate Name",
+      "authRefType": "Authorized"
     },
     "sftCorporateName": {
       "type": "authority",
       "index": "source",
       "distinctType": "sftCorporateName",
-      "headingType": "Corporate Name"
+      "headingType": "Corporate Name",
+      "authRefType": "Reference"
     },
     "saftCorporateName": {
       "type": "authority",
       "index": "source",
-      "distinctType": "saftCorporateName"
+      "distinctType": "saftCorporateName",
+      "authRefType": "Auth/Ref"
     },
     "meetingName": {
       "type": "authority",
       "index": "source",
       "distinctType": "meetingName",
-      "headingType": "Meeting Name"
+      "headingType": "Meeting Name",
+      "authRefType": "Authorized"
     },
     "sftMeetingName": {
       "type": "authority",
       "index": "source",
       "distinctType": "sftMeetingName",
-      "headingType": "Meeting Name"
+      "headingType": "Meeting Name",
+      "authRefType": "Reference"
     },
     "saftMeetingName": {
       "type": "authority",
       "index": "source",
-      "distinctType": "saftMeetingName"
+      "distinctType": "saftMeetingName",
+      "authRefType": "Auth/Ref"
     },
     "geographicName": {
       "type": "authority",
       "index": "source",
       "distinctType": "geographicName",
-      "headingType": "Geographic Name"
+      "headingType": "Geographic Name",
+      "authRefType": "Authorized"
     },
     "sftGeographicTerm": {
       "type": "authority",
       "index": "source",
       "distinctType": "sftGeographicTerm",
-      "headingType": "Geographic Name"
+      "headingType": "Geographic Name",
+      "authRefType": "Reference"
     },
     "saftGeographicTerm": {
       "type": "authority",
       "index": "source",
-      "distinctType": "saftGeographicTerm"
+      "distinctType": "saftGeographicTerm",
+      "authRefType": "Auth/Ref"
     },
     "uniformTitle": {
       "type": "authority",
       "index": "source",
       "distinctType": "uniformTitle",
-      "headingType": "Uniform Title"
+      "headingType": "Uniform Title",
+      "authRefType": "Authorized"
     },
     "sftUniformTitle": {
       "type": "authority",
       "index": "source",
       "distinctType": "sftUniformTitle",
-      "headingType": "Uniform Title"
+      "headingType": "Uniform Title",
+      "authRefType": "Reference"
     },
     "saftUniformTitle": {
       "type": "authority",
       "index": "source",
-      "distinctType": "saftUniformTitle"
+      "distinctType": "saftUniformTitle",
+      "authRefType": "Auth/Ref"
     },
     "topicalTerm": {
       "type": "authority",
       "index": "source",
       "distinctType": "topicalTerm",
-      "headingType": "Topical"
+      "headingType": "Topical",
+      "authRefType": "Authorized"
     },
     "sftTopicalTerm": {
       "type": "authority",
       "index": "source",
       "distinctType": "sftTopicalTerm",
-      "headingType": "Topical"
+      "headingType": "Topical",
+      "authRefType": "Reference"
     },
     "saftTopicalTerm": {
       "type": "authority",
       "index": "source",
-      "distinctType": "saftTopicalTerm"
+      "distinctType": "saftTopicalTerm",
+      "authRefType": "Auth/Ref"
     },
     "genreTerm": {
       "type": "authority",
       "index": "source",
       "distinctType": "genreTerm",
-      "headingType": "Genre"
+      "headingType": "Genre",
+      "authRefType": "Authorized"
     },
     "sftGenreTerm": {
       "type": "authority",
       "index": "source",
       "distinctType": "sftGenreTerm",
-      "headingType": "Genre"
+      "headingType": "Genre",
+      "authRefType": "Reference"
     },
     "saftGenreTerm": {
       "type": "authority",
       "index": "source",
-      "distinctType": "saftGenreTerm"
+      "distinctType": "saftGenreTerm",
+      "authRefType": "Auth/Ref"
     },
     "subjectHeadings": {
       "index": "source"
@@ -176,6 +197,13 @@
       "searchTypes": [ "facet", "filter" ],
       "index": "keyword",
       "processor": "headingTypeProcessor",
+      "rawProcessing": true
+    },
+    "authRefType": {
+      "type": "search",
+      "searchTypes": [ "filter" ],
+      "index": "keyword",
+      "processor": "authRefTypeProcessor",
       "rawProcessing": true
     }
   },

--- a/src/main/resources/swagger.api/schemas/authority.json
+++ b/src/main/resources/swagger.api/schemas/authority.json
@@ -191,7 +191,11 @@
     },
     "headingType": {
       "type": "string",
-      "description": "Generated field by mod-search, used to easily identity the type of the record that provides authority information"
+      "description": "Generated field by mod-search, used to easily identity the heading type of the record that provides authority information"
+    },
+    "authRefType": {
+      "type": "string",
+      "description": "Generated field by mod-search, used to easily identity the authorized/reference type of the record that provides authority information"
     }
   }
 }

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -29,6 +29,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 @IntegrationTest
 class SearchAuthorityIT extends BaseIntegrationTest {
 
+  private static final String AUTHORIZED_TYPE = "Authorized";
+  private static final String REFERENCE_TYPE = "Reference";
+  private static final String AUTH_REF_TYPE = "Auth/Ref";
+  private static final String OTHER_HEADING_TYPE = "Other";
+
   @BeforeAll
   static void prepare() {
     setUpTenant(Authority.class, 21, getAuthoritySampleAsMap());
@@ -61,27 +66,27 @@ class SearchAuthorityIT extends BaseIntegrationTest {
     var actual = parseResponse(response, AuthoritySearchResult.class);
     var source = getAuthoritySample();
     assertThat(actual.getAuthorities()).isEqualTo(List.of(
-      expectedAuthority(source, visibleSearchFields("Personal Name"), "personalName"),
-      expectedAuthority(source, visibleSearchFields("Personal Name"), "sftPersonalName[0]"),
-      expectedAuthority(source, visibleSearchFields("Other"), "saftPersonalName[0]"),
-      expectedAuthority(source, visibleSearchFields("Corporate Name"), "corporateName"),
-      expectedAuthority(source, visibleSearchFields("Corporate Name"), "sftCorporateName[0]"),
-      expectedAuthority(source, visibleSearchFields("Other"), "saftCorporateName[0]"),
-      expectedAuthority(source, visibleSearchFields("Meeting Name"), "meetingName"),
-      expectedAuthority(source, visibleSearchFields("Meeting Name"), "sftMeetingName[0]"),
-      expectedAuthority(source, visibleSearchFields("Other"), "saftMeetingName[0]"),
-      expectedAuthority(source, visibleSearchFields("Geographic Name"), "geographicName"),
-      expectedAuthority(source, visibleSearchFields("Geographic Name"), "sftGeographicTerm[0]"),
-      expectedAuthority(source, visibleSearchFields("Other"), "saftGeographicTerm[0]"),
-      expectedAuthority(source, visibleSearchFields("Uniform Title"), "uniformTitle"),
-      expectedAuthority(source, visibleSearchFields("Uniform Title"), "sftUniformTitle[0]"),
-      expectedAuthority(source, visibleSearchFields("Other"), "saftUniformTitle[0]"),
-      expectedAuthority(source, visibleSearchFields("Topical"), "topicalTerm"),
-      expectedAuthority(source, visibleSearchFields("Topical"), "sftTopicalTerm[0]"),
-      expectedAuthority(source, visibleSearchFields("Other"), "saftTopicalTerm[0]"),
-      expectedAuthority(source, visibleSearchFields("Genre"), "genreTerm"),
-      expectedAuthority(source, visibleSearchFields("Genre"), "sftGenreTerm[0]"),
-      expectedAuthority(source, visibleSearchFields("Other"), "saftGenreTerm[0]")
+      expectedAuthority(source, visibleSearchFields("Personal Name", AUTHORIZED_TYPE), "personalName"),
+      expectedAuthority(source, visibleSearchFields("Personal Name", REFERENCE_TYPE), "sftPersonalName[0]"),
+      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftPersonalName[0]"),
+      expectedAuthority(source, visibleSearchFields("Corporate Name", AUTHORIZED_TYPE), "corporateName"),
+      expectedAuthority(source, visibleSearchFields("Corporate Name", REFERENCE_TYPE), "sftCorporateName[0]"),
+      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftCorporateName[0]"),
+      expectedAuthority(source, visibleSearchFields("Meeting Name", AUTHORIZED_TYPE), "meetingName"),
+      expectedAuthority(source, visibleSearchFields("Meeting Name", REFERENCE_TYPE), "sftMeetingName[0]"),
+      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftMeetingName[0]"),
+      expectedAuthority(source, visibleSearchFields("Geographic Name", AUTHORIZED_TYPE), "geographicName"),
+      expectedAuthority(source, visibleSearchFields("Geographic Name", REFERENCE_TYPE), "sftGeographicTerm[0]"),
+      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftGeographicTerm[0]"),
+      expectedAuthority(source, visibleSearchFields("Uniform Title", AUTHORIZED_TYPE), "uniformTitle"),
+      expectedAuthority(source, visibleSearchFields("Uniform Title", REFERENCE_TYPE), "sftUniformTitle[0]"),
+      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftUniformTitle[0]"),
+      expectedAuthority(source, visibleSearchFields("Topical", AUTHORIZED_TYPE), "topicalTerm"),
+      expectedAuthority(source, visibleSearchFields("Topical", REFERENCE_TYPE), "sftTopicalTerm[0]"),
+      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftTopicalTerm[0]"),
+      expectedAuthority(source, visibleSearchFields("Genre", AUTHORIZED_TYPE), "genreTerm"),
+      expectedAuthority(source, visibleSearchFields("Genre", REFERENCE_TYPE), "sftGenreTerm[0]"),
+      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftGenreTerm[0]")
     ));
   }
 
@@ -90,11 +95,12 @@ class SearchAuthorityIT extends BaseIntegrationTest {
       arguments("personalName all {value}", "\"Gary A. Wills\""),
       arguments("personalName all {value}", "gary"),
       arguments("personalName == {value}", "\"gary a.*\""),
-      arguments("personalName == {value} and headingType==\"Personal Name\"", "\"gary a.*\"")
+      arguments("personalName == {value} and headingType==\"Personal Name\"", "gary"),
+      arguments("personalName == {value} and authRefType==\"Authorized\"", "gary")
     );
   }
 
-  private static Map<String, Object> visibleSearchFields(String headingType) {
-    return mapOf("headingType", headingType);
+  private static Map<String, Object> visibleSearchFields(String headingType, String authRefType) {
+    return mapOf("headingType", headingType, "authRefType", authRefType);
   }
 }

--- a/src/test/java/org/folio/search/service/setter/authority/AuthRefTypeProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/authority/AuthRefTypeProcessorTest.java
@@ -1,0 +1,41 @@
+package org.folio.search.service.setter.authority;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.AuthoritySearchUtils.authorityField;
+import static org.folio.search.utils.SearchUtils.AUTHORITY_RESOURCE;
+import static org.folio.search.utils.TestUtils.mapOf;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.folio.search.service.metadata.SearchFieldProvider;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class AuthRefTypeProcessorTest {
+
+  @InjectMocks private AuthRefTypeProcessor authRefTypeProcessor;
+  @Mock private SearchFieldProvider searchFieldProvider;
+
+  @Test
+  void getFieldValue_positive() {
+    var expectedAuthRefType = "Authorized";
+    var desc = authorityField(null, expectedAuthRefType);
+
+    when(searchFieldProvider.getPlainFieldByPath(AUTHORITY_RESOURCE, "personalName")).thenReturn(Optional.of(desc));
+    var actual = authRefTypeProcessor.getFieldValue(mapOf("personalName", "a personal name"));
+
+    assertThat(actual).isEqualTo(expectedAuthRefType);
+  }
+
+  @Test
+  void getFieldValue_positive_emptyValue() {
+    var actual = authRefTypeProcessor.getFieldValue(mapOf("personalName", null));
+    assertThat(actual).isNull();
+  }
+}

--- a/src/test/java/org/folio/search/utils/AuthoritySearchUtils.java
+++ b/src/test/java/org/folio/search/utils/AuthoritySearchUtils.java
@@ -12,6 +12,8 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import org.folio.search.domain.dto.Authority;
+import org.folio.search.model.metadata.AuthorityFieldDescription;
+import org.folio.search.model.metadata.PlainFieldDescription;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthoritySearchUtils {
@@ -61,5 +63,13 @@ public class AuthoritySearchUtils {
         t.put(field, src.get(field));
       }
     }
+  }
+
+  public static AuthorityFieldDescription authorityField(String headingType, String authRefType) {
+    var authorityFieldDescription = new AuthorityFieldDescription();
+    authorityFieldDescription.setIndex(PlainFieldDescription.STANDARD_FIELD_TYPE);
+    authorityFieldDescription.setHeadingType(headingType);
+    authorityFieldDescription.setAuthRefType(authRefType);
+    return authorityFieldDescription;
   }
 }


### PR DESCRIPTION
### Purpose
The results list will need to include the information that will specify where the match was found so that the user can easily identify the type of record that provides authority information. The heading type must be correctly identified based on the source of the match.

### Approach
- Implement new subfield for authority field description - `authRefType`
- Implement search field `authRefType` with corresponding field processor which will populate this field with related values for further filtering
- Add a single integration test to check that new field can be used as a filter