### PR TITLE
MSEARCH-213 Implement searching by personal name fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ if it is defined but doesn't match.
 | :-----------------------------------------------|:---------:| :--------------------------------|:-------------------------------:|
 | `id`                                            | term      | `id=="1234567"`                  | Matches authorities with the id |
 | `personalName`                                  | full-text | `personalName any "john"`        | Matches authorities with `john` personal name |
+| `sftPersonalName`                               | full-text | `sftPersonalName any "john"`     | Matches authorities with `john` sft personal name |
+| `saftPersonalName`                              | full-text | `saftPersonalName any "john"`    | Matches authorities with `john` saft personal name |
 | `headingType`                                   | term      | `headingType == "Personal Name"` | Matches authorities with `Personal Name` heading type |
 
 ### Search by all field values

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -13,13 +13,13 @@
     },
     "sftPersonalName": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "sftPersonalName",
       "headingType": "Personal Name"
     },
     "saftPersonalName": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "saftPersonalName"
     },
     "corporateName": {

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -62,11 +62,11 @@ class SearchAuthorityIT extends BaseIntegrationTest {
     var actual = parseResponse(response, AuthoritySearchResult.class);
     assertThat(actual.getAuthorities()).isEqualTo(List.of(
       authority("Personal Name", AUTHORIZED_TYPE, "Gary A. Wills"),
-      authority("Personal Name", REFERENCE_TYPE, "a stf personal name"),
+      authority("Personal Name", REFERENCE_TYPE, "a sft personal name"),
       authority(OTHER_HEADING_TYPE, AUTH_REF_TYPE, "a saft personal name"),
 
       authority("Corporate Name", AUTHORIZED_TYPE, "a corporate name"),
-      authority("Corporate Name", REFERENCE_TYPE, "a stf corporate name"),
+      authority("Corporate Name", REFERENCE_TYPE, "a sft corporate name"),
       authority(OTHER_HEADING_TYPE, AUTH_REF_TYPE, "a saft corporate name"),
 
       authority("Conference Name", AUTHORIZED_TYPE, "a meeting name"),

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -91,8 +91,8 @@ class SearchAuthorityIT extends BaseIntegrationTest {
       arguments("personalName all {value}", "gary"),
       arguments("personalName == {value}", "\"gary a.*\""),
       arguments("personalName == {value} and headingType==\"Personal Name\"", "\"gary a.*\""),
-      arguments("sftPersonalName = {value}", "\"stf personal name\""),
-      arguments("sftPersonalName == {value}", "\"stf personal name\""),
+      arguments("sftPersonalName = {value}", "\"personal sft name\""),
+      arguments("sftPersonalName == {value}", "\"sft personal name\""),
       arguments("sftPersonalName == {value}", "\"*persona*\""),
       arguments("saftPersonalName = {value}", "\"saft name\""),
       arguments("saftPersonalName == {value}", "\"*saft persona*\"")

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -90,7 +90,12 @@ class SearchAuthorityIT extends BaseIntegrationTest {
       arguments("personalName all {value}", "\"Gary A. Wills\""),
       arguments("personalName all {value}", "gary"),
       arguments("personalName == {value}", "\"gary a.*\""),
-      arguments("personalName == {value} and headingType==\"Personal Name\"", "\"gary a.*\"")
+      arguments("personalName == {value} and headingType==\"Personal Name\"", "\"gary a.*\""),
+      arguments("sftPersonalName = {value}", "\"stf personal name\""),
+      arguments("sftPersonalName == {value}", "\"stf personal name\""),
+      arguments("sftPersonalName == {value}", "\"*persona*\""),
+      arguments("saftPersonalName = {value}", "\"saft name\""),
+      arguments("saftPersonalName == {value}", "\"*saft persona*\"")
     );
   }
 

--- a/src/test/resources/samples/authority-sample/authority.json
+++ b/src/test/resources/samples/authority-sample/authority.json
@@ -1,10 +1,10 @@
 {
   "id": "55294032-fcf6-45cc-b6da-4420a61ef72c",
   "personalName": "Gary A. Wills",
-  "sftPersonalName": [ "a stf personal name" ],
+  "sftPersonalName": [ "a sft personal name" ],
   "saftPersonalName": [ "a saft personal name" ],
   "corporateName": "a corporate name",
-  "sftCorporateName": [ "a stf corporate name" ],
+  "sftCorporateName": [ "a sft corporate name" ],
   "saftCorporateName": [ "a saft corporate name" ],
   "meetingName": "a meeting name",
   "sftMeetingName": [ "a sft meeting name" ],


### PR DESCRIPTION
### Purpose
The purpose of this story is to support the Authority record search option by a personal name. The story assumes that the personalName, stfPersonalName, and saftPersonalName fields are populated with the data coming from subfields  a-d,q, g  from MARC 100, 400, and 500 fields.


### Requirements
- The search is based on authority record's personalName, stfPersonalName and saftPersonalName
- The search supports:
  - Phrase search
  - Exact phrase search
  - Left anchored search (or right truncation)
  - Boolean operators
- Response contains elements:
  - Authority/Reference as described in MSEARCH-212
  - Heading/Reference as described in MSEARCH-211
  - Type of heading as described in MSEARCH-210

### Approach
- Change mappings type for `personalName`, `sftPersonalName` and `saftPersonalName` in resource description file from `source` to `standard`
- Add integration test to check implemented functionality
