### PR TITLE
MSEARCH-229 Implement searching by uniform titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,14 +366,14 @@ if it is defined but doesn't match.
 | Option                                          | Type      |Example                                   | Description                     |
 | :-----------------------------------------------|:---------:| :----------------------------------------|:-------------------------------:|
 | `id`                                            | term      | `id=="1234567"`                          | Matches authorities with the id |
+| `headingType`                                   | term      | `headingType == "Personal Name"`         | Matches authorities with `Personal Name` heading type |
+| `authRefType`                                   | term      | `authRefType == "Authorized"`            | Matches authorities with `Authorized` auth/ref type |
 | `personalName`                                  | full-text | `personalName any "john"`                | Matches authorities with `john` personal name |
 | `sftPersonalName`                               | full-text | `sftPersonalName any "john"`             | Matches authorities with `john` sft personal name |
 | `saftPersonalName`                              | full-text | `saftPersonalName any "john"`            | Matches authorities with `john` saft personal name |
 | `uniformTitle`                                  | term      | `uniformTitle == "an uniform title"`     | Matches authorities with `an uniform title` uniform title |
 | `sftUniformTitle`                               | term      | `sftUniformTitle == "an uniform title"`  | Matches authorities with `an uniform title` sft uniform title |
 | `saftUniformTitle`                              | term      | `saftUniformTitle == "an uniform title"` | Matches authorities with `an uniform title` saft uniform title |
-| `headingType`                                   | term      | `headingType == "Personal Name"`         | Matches authorities with `Personal Name` heading type |
-| `authRefType`                                   | term      | `authRefType == "Authorized"`            | Matches authorities with `Authorized` auth/ref type |
 
 ### Search by all field values
 

--- a/README.md
+++ b/README.md
@@ -363,11 +363,14 @@ if it is defined but doesn't match.
 
 ### Authority search options
 
-| Option                                          | Type      |Example                           | Description                     |
-| :-----------------------------------------------|:---------:| :--------------------------------|:-------------------------------:|
-| `id`                                            | term      | `id=="1234567"`                  | Matches authorities with the id |
-| `personalName`                                  | full-text | `personalName any "john"`        | Matches authorities with `john` personal name |
-| `headingType`                                   | term      | `headingType == "Personal Name"` | Matches authorities with `Personal Name` heading type |
+| Option                                          | Type      |Example                                   | Description                     |
+| :-----------------------------------------------|:---------:| :----------------------------------------|:-------------------------------:|
+| `id`                                            | term      | `id=="1234567"`                          | Matches authorities with the id |
+| `personalName`                                  | full-text | `personalName any "john"`                | Matches authorities with `john` personal name |
+| `headingType`                                   | term      | `headingType == "Personal Name"`         | Matches authorities with `Personal Name` heading type |
+| `uniformTitle`                                  | term      | `uniformTitle == "an uniform title"`     | Matches authorities with `an uniform title` uniform title |
+| `sftUniformTitle`                               | term      | `sftUniformTitle == "an uniform title"`  | Matches authorities with `an uniform title` sft uniform title |
+| `saftUniformTitle`                              | term      | `saftUniformTitle == "an uniform title"` | Matches authorities with `an uniform title` saft uniform title |
 
 ### Search by all field values
 

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -75,19 +75,19 @@
     },
     "uniformTitle": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "uniformTitle",
       "headingType": "Uniform Title"
     },
     "sftUniformTitle": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "sftUniformTitle",
       "headingType": "Uniform Title"
     },
     "saftUniformTitle": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "saftUniformTitle"
     },
     "topicalTerm": {

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -90,7 +90,15 @@ class SearchAuthorityIT extends BaseIntegrationTest {
       arguments("personalName all {value}", "\"Gary A. Wills\""),
       arguments("personalName all {value}", "gary"),
       arguments("personalName == {value}", "\"gary a.*\""),
-      arguments("personalName == {value} and headingType==\"Personal Name\"", "\"gary a.*\"")
+      arguments("personalName == {value} and headingType==\"Personal Name\"", "\"gary a.*\""),
+
+      arguments("uniformTitle = {value}", "\"uniform\""),
+      arguments("uniformTitle == {value}", "\"an uniform title\""),
+      arguments("uniformTitle == {value}", "\"*nifor*\""),
+      arguments("sftUniformTitle = {value}", "\"uniform title\""),
+      arguments("sftUniformTitle == {value}", "\"sft uniform\""),
+      arguments("saftUniformTitle = {value} ", "\"title saft\""),
+      arguments("saftUniformTitle == {value} ", "\"saft uniform title\"")
     );
   }
 


### PR DESCRIPTION
### Purpose
The purpose of this story is to support the Authority record search option by a personal name. The story assumes that the `uniformTitle`, `stfUniformTitle`, and `saftUniformTitle` fields are populated with the data coming from  all subfields but $6 and $8 from MARC fields 130, 430 and 530 respectively.


### Requirements
- The search is based on authority record's `uniformTitle`, `stfUniformTitle`, and `saftUniformTitle`
- The search supports:
  - Phrase search
  - Exact phrase search
  - Left anchored search (or right truncation)
  - Boolean operators
- Response contains elements:
  - Authority/Reference as described in MSEARCH-212
  - Heading/Reference as described in MSEARCH-211
  - Type of heading as described in MSEARCH-210

### Approach
- Change mappings type for `uniformTitle`, `stfUniformTitle`, and `saftUniformTitle` in resource description file from `source` to `standard`
- Add integration test to check implemented functionality
