### PR TITLE
MSEARCH-232 Implement searching by genre term fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@ if it is defined but doesn't match.
 | :-----------------------------------------------|:---------:| :--------------------------------|:-------------------------------:|
 | `id`                                            | term      | `id=="1234567"`                  | Matches authorities with the id |
 | `personalName`                                  | full-text | `personalName any "john"`        | Matches authorities with `john` personal name |
+| `genreTerm`                                     | full-text | `genreTerm any "novel"`          | Matches authorities with `novel` genre term |
+| `sftGenreTerm`                                  | full-text | `sftGenreTerm any "novel"`       | Matches authorities with `novel` sft genre term |
+| `saftGenreTerm`                                 | full-text | `saftGenreTerm any "novel"`      | Matches authorities with `novel` saft genre term |
 | `headingType`                                   | term      | `headingType == "Personal Name"` | Matches authorities with `Personal Name` heading type |
 
 ### Search by all field values

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -143,7 +143,8 @@
     "saftGenreTerm": {
       "type": "authority",
       "index": "standard",
-      "distinctType": "saftGenreTerm"
+      "distinctType": "saftGenreTerm",
+      "authRefType": "Auth/Ref"
     },
     "subjectHeadings": {
       "index": "standard"

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -109,19 +109,19 @@
     },
     "genreTerm": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "genreTerm",
       "headingType": "Genre"
     },
     "sftGenreTerm": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "sftGenreTerm",
       "headingType": "Genre"
     },
     "saftGenreTerm": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "saftGenreTerm"
     },
     "subjectHeadings": {

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -90,7 +90,16 @@ class SearchAuthorityIT extends BaseIntegrationTest {
       arguments("personalName all {value}", "\"Gary A. Wills\""),
       arguments("personalName all {value}", "gary"),
       arguments("personalName == {value}", "\"gary a.*\""),
-      arguments("personalName == {value} and headingType==\"Personal Name\"", "\"gary a.*\"")
+
+      arguments("genreTerm all {value}", "\"a genre term\""),
+      arguments("genreTerm all {value}", "genre"),
+      arguments("genreTerm == {value}", "\"a gen*\""),
+      arguments("genreTerm == {value} and headingType==\"Genre\"", "\"a gen*\""),
+      arguments("sftGenreTerm = {value}", "\"sft genre term\""),
+      arguments("sftGenreTerm == {value}", "\"sft genre term\""),
+      arguments("sftGenreTerm == {value}", "\"*gen*\""),
+      arguments("saftGenreTerm = {value}", "\"saft term\""),
+      arguments("saftGenreTerm == {value}", "\"*saft gen*\"")
     );
   }
 


### PR DESCRIPTION
### Purpose/Overview:

The purpose of this story is to support Authority record search option by genre.

Assumptions:

The story assumes that genreTerm, stfGenreTerm and saftGenreTerm fields are populated with the data coming from all subfields but $6 and $8 from MARC fields 155, 455 and 555 respectively.

### Requirements/Scope:

- The search is based on authority record's genreTerm, stfGenreTerm and saftGenreTerm
- The search supports:
  - Phrase search
  - Exact phrase search
  - Left anchored search (or right truncation)
  - Boolean operators
- Response contains elements:
  - Authority/Reference as described in MSEARCH-212
  - Heading/Reference as described in MSEARCH-211
  - Type of heading as described in MSEARCH-210

### Approach
- Change mappings type for `genreTerm`, `sftGenreTerm` and `saftGenreTerm` in resource description file from `source` to `standard`
- Add integration test to check implemented functionality