### PR TITLE
MSEARCH-230 Implement searching by subject field

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,11 +363,14 @@ if it is defined but doesn't match.
 
 ### Authority search options
 
-| Option                                          | Type      |Example                           | Description                     |
-| :-----------------------------------------------|:---------:| :--------------------------------|:-------------------------------:|
-| `id`                                            | term      | `id=="1234567"`                  | Matches authorities with the id |
-| `personalName`                                  | full-text | `personalName any "john"`        | Matches authorities with `john` personal name |
-| `headingType`                                   | term      | `headingType == "Personal Name"` | Matches authorities with `Personal Name` heading type |
+| Option                                          | Type      |Example                                | Description                     |
+| :-----------------------------------------------|:---------:| :-------------------------------------|:-------------------------------:|
+| `id`                                            | term      | `id=="1234567"`                       | Matches authorities with the id |
+| `personalName`                                  | full-text | `personalName any "john"`             | Matches authorities with `john` personal name |
+| `topicalTerm`                                   | full-text | `topicalTerm any "Optical disks"`     | Matches authorities with `Optical disks` topical term |
+| `sftTopicalTerm`                                | full-text | `sftTopicalTerm any "Optical disks"`  | Matches authorities with `Optical disks` sft topical term |
+| `saftTopicalTerm`                               | full-text | `saftTopicalTerm any "Optical disks"` | Matches authorities with `Optical disks` saft topical term |
+| `headingType`                                   | term      | `headingType == "Personal Name"`      | Matches authorities with `Personal Name` heading type |
 
 ### Search by all field values
 

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -92,19 +92,19 @@
     },
     "topicalTerm": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "topicalTerm",
       "headingType": "Topical"
     },
     "sftTopicalTerm": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "sftTopicalTerm",
       "headingType": "Topical"
     },
     "saftTopicalTerm": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "saftTopicalTerm"
     },
     "genreTerm": {

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -90,7 +90,17 @@ class SearchAuthorityIT extends BaseIntegrationTest {
       arguments("personalName all {value}", "\"Gary A. Wills\""),
       arguments("personalName all {value}", "gary"),
       arguments("personalName == {value}", "\"gary a.*\""),
-      arguments("personalName == {value} and headingType==\"Personal Name\"", "\"gary a.*\"")
+      arguments("personalName == {value} and headingType==\"Personal Name\"", "\"gary a.*\""),
+
+      arguments("topicalTerm all {value}", "\"a topical term\""),
+      arguments("topicalTerm all {value}", "topical"),
+      arguments("topicalTerm == {value}", "\"a top*\""),
+      arguments("topicalTerm == {value} and headingType==\"Topical\"", "\"a top*\""),
+      arguments("sftTopicalTerm = {value}", "\"sft topical term\""),
+      arguments("sftTopicalTerm == {value}", "\"sft topical term\""),
+      arguments("sftTopicalTerm == {value}", "\"*top*\""),
+      arguments("saftTopicalTerm = {value}", "\"saft term\""),
+      arguments("saftTopicalTerm == {value}", "\"*saft top*\"")
     );
   }
 


### PR DESCRIPTION
### Purpose/Overview:

The purpose of this story is to support Authority record search option by a topical term.

Assumptions:

The story assumes that topicalTerm, stfTopicalTerm and saftTopicalTerm fields are populated with the data coming from  all subfields but $6 and $8 from MARC fields 150, 450 and 550 respectively.

### Requirements/Scope:

- The search is based on authority record's topicalTerm, stfTopicalTerm and saftTopicalTerm
- The search supports:
  - Phrase search
  - Exact phrase search
  - Left anchored search (or right truncation)
  - Boolean operators
- Response contains elements:
  - Authority/Reference as described in MSEARCH-212
  - Heading/Reference as described in MSEARCH-211
  - Type of heading as described in MSEARCH-210

### Approach
- Change mappings type for `topicalTerm`, `sftTopicalTerm` and `saftTopicalTerm` in resource description file from `source` to `standard`
- Add integration test to check implemented functionality