### PR TITLE
MSEARCH-231 Implement searching by Children's subject headings fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ if it is defined but doesn't match.
 | :-----------------------------------------------|:---------:| :--------------------------------|:-------------------------------:|
 | `id`                                            | term      | `id=="1234567"`                  | Matches authorities with the id |
 | `personalName`                                  | full-text | `personalName any "john"`        | Matches authorities with `john` personal name |
+| `subjectHeadings`                               | full-text | `subjectHeadings any "z"`        | Matches authorities with `z` subject headings |
 | `headingType`                                   | term      | `headingType == "Personal Name"` | Matches authorities with `Personal Name` heading type |
 
 ### Search by all field values

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -125,7 +125,7 @@
       "distinctType": "saftGenreTerm"
     },
     "subjectHeadings": {
-      "index": "source"
+      "index": "standard"
     },
     "identifiers": {
       "type": "object",

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -90,7 +90,11 @@ class SearchAuthorityIT extends BaseIntegrationTest {
       arguments("personalName all {value}", "\"Gary A. Wills\""),
       arguments("personalName all {value}", "gary"),
       arguments("personalName == {value}", "\"gary a.*\""),
-      arguments("personalName == {value} and headingType==\"Personal Name\"", "\"gary a.*\"")
+      arguments("personalName == {value} and headingType==\"Personal Name\"", "\"gary a.*\""),
+
+      arguments("subjectHeadings all {value} and personalName==\"Gary\"", "\"a subject heading\""),
+      arguments("subjectHeadings all {value} and personalName==\"Gary\"", "subject"),
+      arguments("subjectHeadings == {value} and personalName==\"Gary\"", "\"a sub*\"")
     );
   }
 


### PR DESCRIPTION
### Purpose/Overview:

The purpose of this story is to support Authority record search option by Children's subject headings.

Assumptions:

The story assumes that the subjectHeadings field is populated with the data coming from 1xx field of the record that has LDR 008 position 11 set to "b"

### Requirements/Scope:

- The search is based on authority record's subjectHeadings
- The search supports:
  - Phrase search
  - Exact phrase search
  - Left anchored search (or right truncation)
  - Boolean operators
- Response contains elements:
  - Authority/Reference as described in MSEARCH-212
  - Heading/Reference as described in MSEARCH-211
  - Type of heading as described in MSEARCH-210

### Approach
- Change mappings type for `subjectHeadings` in resource description file from `source` to `standard`
- Add integration test to check implemented functionality