### PR TITLE
MSEARCH-211 Implement Heading/Reference field

### DIFF
--- a/src/main/java/org/folio/search/service/setter/authority/AbstractAuthorityProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/authority/AbstractAuthorityProcessor.java
@@ -24,21 +24,19 @@ public abstract class AbstractAuthorityProcessor implements FieldProcessor<Map<S
   protected String getAuthorityType(Map<String, Object> eventBody,
     Function<AuthorityFieldDescription, String> valueExtractor, String defaultValue) {
     return eventBody.entrySet().stream()
-      .map(entry -> getTypeForField(entry, valueExtractor))
+      .map(entry -> getAuthorityFieldForEntry(entry).map(valueExtractor))
       .flatMap(Optional::stream)
       .findFirst()
       .orElse(defaultValue);
   }
 
-  private Optional<String> getTypeForField(Entry<String, Object> entry,
-    Function<AuthorityFieldDescription, String> valueExtractor) {
+  protected Optional<AuthorityFieldDescription> getAuthorityFieldForEntry(Entry<String, Object> entry) {
     if (ObjectUtils.isEmpty(entry.getValue())) {
       return Optional.empty();
     }
 
     return searchFieldProvider.getPlainFieldByPath(AUTHORITY_RESOURCE, entry.getKey())
       .filter(AuthorityFieldDescription.class::isInstance)
-      .map(AuthorityFieldDescription.class::cast)
-      .map(valueExtractor);
+      .map(AuthorityFieldDescription.class::cast);
   }
 }

--- a/src/main/java/org/folio/search/service/setter/authority/HeadingRefProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/authority/HeadingRefProcessor.java
@@ -1,0 +1,29 @@
+package org.folio.search.service.setter.authority;
+
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HeadingRefProcessor extends AbstractAuthorityProcessor {
+
+  @Override
+  public String getFieldValue(Map<String, Object> eventBody) {
+    return eventBody.entrySet().stream()
+      .map(entry -> getAuthorityFieldForEntry(entry)
+        .map(fieldDesc -> getStringValue(entry.getValue())))
+      .flatMap(Optional::stream)
+      .findFirst()
+      .orElse(null);
+  }
+
+  private static String getStringValue(Object value) {
+    if (value instanceof String) {
+      return (String) value;
+    }
+    if (value instanceof Iterable<?>) {
+      return getStringValue(((Iterable<?>) value).iterator().next());
+    }
+    return null;
+  }
+}

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -3,7 +3,8 @@
   "eventBodyJavaClass": "org.folio.search.domain.dto.Authority",
   "fields": {
     "id": {
-      "index": "keyword"
+      "index": "keyword",
+      "showInResponse": true
     },
     "personalName": {
       "type": "authority",
@@ -49,14 +50,14 @@
       "type": "authority",
       "index": "source",
       "distinctType": "meetingName",
-      "headingType": "Meeting Name",
+      "headingType": "Conference Name",
       "authRefType": "Authorized"
     },
     "sftMeetingName": {
       "type": "authority",
       "index": "source",
       "distinctType": "sftMeetingName",
-      "headingType": "Meeting Name",
+      "headingType": "Conference Name",
       "authRefType": "Reference"
     },
     "saftMeetingName": {
@@ -197,13 +198,22 @@
       "searchTypes": [ "facet", "filter" ],
       "index": "keyword",
       "processor": "headingTypeProcessor",
-      "rawProcessing": true
+      "rawProcessing": true,
+      "showInResponse": true
     },
     "authRefType": {
       "type": "search",
       "searchTypes": [ "filter" ],
       "index": "keyword",
       "processor": "authRefTypeProcessor",
+      "rawProcessing": true,
+      "showInResponse": true
+    },
+    "headingRef": {
+      "type": "search",
+      "index": "source",
+      "processor": "headingRefProcessor",
+      "showInResponse": true,
       "rawProcessing": true
     }
   },

--- a/src/main/resources/swagger.api/schemas/authority.json
+++ b/src/main/resources/swagger.api/schemas/authority.json
@@ -196,6 +196,10 @@
     "authRefType": {
       "type": "string",
       "description": "Generated field by mod-search, used to easily identity the authorized/reference type of the record that provides authority information"
+    },
+    "headingRef": {
+      "type": "string",
+      "description": "Generated field by mod-search, used to easily identity the heading/reference of the record that provides authority information"
     }
   }
 }

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -1,18 +1,14 @@
 package org.folio.search.controller;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.folio.search.sample.SampleAuthorities.getAuthoritySample;
 import static org.folio.search.sample.SampleAuthorities.getAuthoritySampleAsMap;
 import static org.folio.search.sample.SampleAuthorities.getAuthoritySampleId;
-import static org.folio.search.utils.AuthoritySearchUtils.expectedAuthority;
-import static org.folio.search.utils.TestUtils.mapOf;
 import static org.folio.search.utils.TestUtils.parseResponse;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.folio.search.domain.dto.Authority;
 import org.folio.search.domain.dto.AuthoritySearchResult;
@@ -64,29 +60,34 @@ class SearchAuthorityIT extends BaseIntegrationTest {
   void searchByAuthorities_parameterized_all(String query, String value) throws Exception {
     var response = doSearchByAuthorities(prepareQuery(query, value)).andExpect(jsonPath("$.totalRecords", is(21)));
     var actual = parseResponse(response, AuthoritySearchResult.class);
-    var source = getAuthoritySample();
     assertThat(actual.getAuthorities()).isEqualTo(List.of(
-      expectedAuthority(source, visibleSearchFields("Personal Name", AUTHORIZED_TYPE), "personalName"),
-      expectedAuthority(source, visibleSearchFields("Personal Name", REFERENCE_TYPE), "sftPersonalName[0]"),
-      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftPersonalName[0]"),
-      expectedAuthority(source, visibleSearchFields("Corporate Name", AUTHORIZED_TYPE), "corporateName"),
-      expectedAuthority(source, visibleSearchFields("Corporate Name", REFERENCE_TYPE), "sftCorporateName[0]"),
-      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftCorporateName[0]"),
-      expectedAuthority(source, visibleSearchFields("Meeting Name", AUTHORIZED_TYPE), "meetingName"),
-      expectedAuthority(source, visibleSearchFields("Meeting Name", REFERENCE_TYPE), "sftMeetingName[0]"),
-      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftMeetingName[0]"),
-      expectedAuthority(source, visibleSearchFields("Geographic Name", AUTHORIZED_TYPE), "geographicName"),
-      expectedAuthority(source, visibleSearchFields("Geographic Name", REFERENCE_TYPE), "sftGeographicTerm[0]"),
-      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftGeographicTerm[0]"),
-      expectedAuthority(source, visibleSearchFields("Uniform Title", AUTHORIZED_TYPE), "uniformTitle"),
-      expectedAuthority(source, visibleSearchFields("Uniform Title", REFERENCE_TYPE), "sftUniformTitle[0]"),
-      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftUniformTitle[0]"),
-      expectedAuthority(source, visibleSearchFields("Topical", AUTHORIZED_TYPE), "topicalTerm"),
-      expectedAuthority(source, visibleSearchFields("Topical", REFERENCE_TYPE), "sftTopicalTerm[0]"),
-      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftTopicalTerm[0]"),
-      expectedAuthority(source, visibleSearchFields("Genre", AUTHORIZED_TYPE), "genreTerm"),
-      expectedAuthority(source, visibleSearchFields("Genre", REFERENCE_TYPE), "sftGenreTerm[0]"),
-      expectedAuthority(source, visibleSearchFields(OTHER_HEADING_TYPE, AUTH_REF_TYPE), "saftGenreTerm[0]")
+      authority("Personal Name", AUTHORIZED_TYPE, "Gary A. Wills"),
+      authority("Personal Name", REFERENCE_TYPE, "a stf personal name"),
+      authority(OTHER_HEADING_TYPE, AUTH_REF_TYPE, "a saft personal name"),
+
+      authority("Corporate Name", AUTHORIZED_TYPE, "a corporate name"),
+      authority("Corporate Name", REFERENCE_TYPE, "a stf corporate name"),
+      authority(OTHER_HEADING_TYPE, AUTH_REF_TYPE, "a saft corporate name"),
+
+      authority("Conference Name", AUTHORIZED_TYPE, "a meeting name"),
+      authority("Conference Name", REFERENCE_TYPE, "a sft meeting name"),
+      authority(OTHER_HEADING_TYPE, AUTH_REF_TYPE, "a saft meeting name"),
+
+      authority("Geographic Name", AUTHORIZED_TYPE, "a geographic name"),
+      authority("Geographic Name", REFERENCE_TYPE, "a sft geographic name"),
+      authority(OTHER_HEADING_TYPE, AUTH_REF_TYPE, "a saft geographic name"),
+
+      authority("Uniform Title", AUTHORIZED_TYPE, "an uniform title"),
+      authority("Uniform Title", REFERENCE_TYPE, "a sft uniform title"),
+      authority(OTHER_HEADING_TYPE, AUTH_REF_TYPE, "a saft uniform title"),
+
+      authority("Topical", AUTHORIZED_TYPE, "a topical term"),
+      authority("Topical", REFERENCE_TYPE, "a sft topical term"),
+      authority(OTHER_HEADING_TYPE, AUTH_REF_TYPE, "a saft topical term"),
+
+      authority("Genre", AUTHORIZED_TYPE, "a genre term"),
+      authority("Genre", REFERENCE_TYPE, "a sft genre term"),
+      authority(OTHER_HEADING_TYPE, AUTH_REF_TYPE, "a saft genre term")
     ));
   }
 
@@ -100,7 +101,11 @@ class SearchAuthorityIT extends BaseIntegrationTest {
     );
   }
 
-  private static Map<String, Object> visibleSearchFields(String headingType, String authRefType) {
-    return mapOf("headingType", headingType, "authRefType", authRefType);
+  private static Authority authority(String headingType, String authRefType, String headingRef) {
+    return new Authority()
+      .id(getAuthoritySampleId())
+      .headingType(headingType)
+      .authRefType(authRefType)
+      .headingRef(headingRef);
   }
 }

--- a/src/test/java/org/folio/search/service/setter/authority/HeadingRefProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/authority/HeadingRefProcessorTest.java
@@ -1,0 +1,67 @@
+package org.folio.search.service.setter.authority;
+
+import static java.util.Collections.singletonList;
+import static java.util.Optional.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.AuthoritySearchUtils.authorityField;
+import static org.folio.search.utils.SearchUtils.AUTHORITY_RESOURCE;
+import static org.folio.search.utils.TestConstants.RESOURCE_ID;
+import static org.folio.search.utils.TestUtils.keywordField;
+import static org.folio.search.utils.TestUtils.mapOf;
+import static org.folio.search.utils.TestUtils.toMap;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.folio.search.domain.dto.Authority;
+import org.folio.search.service.metadata.SearchFieldProvider;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class HeadingRefProcessorTest {
+
+  @InjectMocks private HeadingRefProcessor headingRefProcessor;
+  @Mock private SearchFieldProvider fieldProvider;
+
+  @Test
+  void getFieldValue_positive_personalName() {
+    when(fieldProvider.getPlainFieldByPath(AUTHORITY_RESOURCE, "id")).thenReturn(of(keywordField()));
+    when(fieldProvider.getPlainFieldByPath(AUTHORITY_RESOURCE, "personalName")).thenReturn(of(authorityField()));
+    var authority = new Authority().id(RESOURCE_ID).personalName("test-name").saftPersonalName(List.of("test-name-2"));
+    var actual = headingRefProcessor.getFieldValue(toMap(authority));
+    assertThat(actual).isEqualTo("test-name");
+  }
+
+  @Test
+  void getFieldValue_positive_sftPersonalName() {
+    when(fieldProvider.getPlainFieldByPath(AUTHORITY_RESOURCE, "sftPersonalName")).thenReturn(of(authorityField()));
+    var authority = new Authority().sftPersonalName(List.of("test-name")).saftPersonalName(List.of("test-name-2"));
+    var actual = headingRefProcessor.getFieldValue(toMap(authority));
+    assertThat(actual).isEqualTo("test-name");
+  }
+
+  @Test
+  void getFieldValue_positive_personalNameNullValue() {
+    var actual = headingRefProcessor.getFieldValue(mapOf("personalName", null));
+    assertThat(actual).isNull();
+  }
+
+  @Test
+  void getFieldValue_positive_invalidValueByPath() {
+    when(fieldProvider.getPlainFieldByPath(AUTHORITY_RESOURCE, "testField")).thenReturn(of(authorityField()));
+    var actual = headingRefProcessor.getFieldValue(mapOf("testField", 123));
+    assertThat(actual).isNull();
+  }
+
+  @Test
+  void getFieldValue_positive_invalidIterableValueByPath() {
+    when(fieldProvider.getPlainFieldByPath(AUTHORITY_RESOURCE, "testField")).thenReturn(of(authorityField()));
+    var actual = headingRefProcessor.getFieldValue(mapOf("testField", singletonList(mapOf("key", "value"))));
+    assertThat(actual).isNull();
+  }
+}

--- a/src/test/java/org/folio/search/utils/AuthoritySearchUtils.java
+++ b/src/test/java/org/folio/search/utils/AuthoritySearchUtils.java
@@ -65,6 +65,12 @@ public class AuthoritySearchUtils {
     }
   }
 
+  public static AuthorityFieldDescription authorityField() {
+    var authorityFieldDescription = new AuthorityFieldDescription();
+    authorityFieldDescription.setIndex(PlainFieldDescription.STANDARD_FIELD_TYPE);
+    return authorityFieldDescription;
+  }
+
   public static AuthorityFieldDescription authorityField(String headingType, String authRefType) {
     var authorityFieldDescription = new AuthorityFieldDescription();
     authorityFieldDescription.setIndex(PlainFieldDescription.STANDARD_FIELD_TYPE);


### PR DESCRIPTION
### Purpose
The results list will need to include the information that will specify where the match was found so that the user can easily identify the Heading/Reference of record that provides authority information.

Approach
* Implement new subfield for authority field description - `headingRef`
* This field is currently stored as `source` and it can not be searchable using queries like - `headingRef all John`
* Add a single integration test to check that new field can be used as a filter