### PR TITLE
MSEARCH-215 Implement searching by geographic name

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,9 @@ if it is defined but doesn't match.
 | `meetingName`                                   | full text | `meetingName == "conferenece name"`      | Matches authorities with `conferenece name` meeting name |
 | `sftMeetingName`                                | full text | `sftMeetingName == "conferenece name"`   | Matches authorities with `conferenece name` sft meeting name |
 | `saftMeetingName`                               | full text | `saftMeetingName == "conferenece name"`  | Matches authorities with `conferenece name` saft meeting name |
+| `geographicName`                                | full text | `geographicName == "geographic name"`    | Matches authorities with `geographic name` geographic name |
+| `sftGeographicTerm`                             | full text | `sftGeographicTerm == "geographic name"` | Matches authorities with `geographic name` sft geographic term |
+| `saftGeographicTerm`                            | full text | `saftGeographicTerm == "geographic name"`| Matches authorities with `geographic name` saft geographic term |
 | `uniformTitle`                                  | term      | `uniformTitle == "an uniform title"`     | Matches authorities with `an uniform title` uniform title |
 | `sftUniformTitle`                               | term      | `sftUniformTitle == "an uniform title"`  | Matches authorities with `an uniform title` sft uniform title |
 | `saftUniformTitle`                              | term      | `saftUniformTitle == "an uniform title"` | Matches authorities with `an uniform title` saft uniform title |

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -68,21 +68,21 @@
     },
     "geographicName": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "geographicName",
       "headingType": "Geographic Name",
       "authRefType": "Authorized"
     },
     "sftGeographicTerm": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "sftGeographicTerm",
       "headingType": "Geographic Name",
       "authRefType": "Reference"
     },
     "saftGeographicTerm": {
       "type": "authority",
-      "index": "source",
+      "index": "standard",
       "distinctType": "saftGeographicTerm",
       "authRefType": "Auth/Ref"
     },

--- a/src/test/java/org/folio/search/controller/SearchAuthorityFilterIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityFilterIT.java
@@ -1,6 +1,7 @@
 package org.folio.search.controller;
 
 import static org.folio.search.utils.TestUtils.array;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -46,7 +47,7 @@ class SearchAuthorityFilterIT extends BaseIntegrationTest {
     doSearchByAuthorities(query)
       .andExpect(status().isOk())
       .andExpect(jsonPath("totalRecords", is(expectedIds.size())))
-      .andExpect(jsonPath("authorities[*].id", is(expectedIds)));
+      .andExpect(jsonPath("authorities[*].id", containsInAnyOrder(expectedIds.toArray(String[]::new))));
   }
 
   private static Stream<Arguments> filteredSearchQueriesProvider() {

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -120,6 +120,14 @@ class SearchAuthorityIT extends BaseIntegrationTest {
       arguments("saftMeetingName = {value} ", "\"conference saft\""),
       arguments("saftMeetingName == {value} ", "\"saft conference name\""),
 
+      arguments("geographicName = {value}", "\"geographic\""),
+      arguments("geographicName == {value}", "\"a geographic name\""),
+      arguments("geographicName == {value}", "\"*graph*\""),
+      arguments("sftGeographicTerm = {value}", "\"geographic name\""),
+      arguments("sftGeographicTerm == {value}", "\"sft geographic\""),
+      arguments("saftGeographicTerm = {value} ", "\"geographic saft\""),
+      arguments("saftGeographicTerm == {value} ", "\"saft geographic name\""),
+
       arguments("uniformTitle = {value}", "\"uniform\""),
       arguments("uniformTitle == {value}", "\"an uniform title\""),
       arguments("uniformTitle == {value}", "\"*nifor*\""),


### PR DESCRIPTION
### Purpose
The purpose of this story is to support the Authority record search option by a corporate or conference name.
It's assumed that: 
- `corporateName`, `stfCorporateName` and `saftCorporateName` fields are populated with the data coming from  all subfields but $6 and $8 from MARC fields 151, 451 and 551 respectively.

### Approach
- Change mappings type for `geographicName`, `sftGeographicTerm`, `saftGeographicTerm` in resource description file from `source` to `standard`
- Add integration test to check implemented functionality