### PR TITLE
FOLIO-3231 Use api-doc CI facility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ buildMvn {
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'OAS'
   apiDirectories = 'src/main/resources/swagger.api'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-search
 
-Copyright (C) 2020 The Open Library Foundation
+Copyright (C) 2020-2021 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.


### PR DESCRIPTION
Adds the `doApiDoc` configuration to Jenkinsfile, which enables the [api-doc](https://dev.folio.org/guides/api-doc/) CI facility. This generates and publishes the API documentation during a merge to mainline and on release.

The `doUploadApidocs` is already configured for mod-search, to generate docs during the Maven build phase and then upload to S3. That is already linked from the API documentation as "view-3" (see [explain views](https://dev.folio.org/reference/api/#explain-views)).

This `doApiDoc` will generate the additional "view-4" as is done for other OAS-based modules (e.g. [mod-remote-storage](https://dev.folio.org/reference/api/#mod-remote-storage)). So mod-search will have two views of API documentation generated from the sole source API description. This is similar to RAML-based modules (such as [mod-courses](https://dev.folio.org/reference/api/#mod-courses)) which also have two views.

Note that FOLIO DevOps is planning to replace Jenkins CI with GitHub Workflows. It will be a lower priority to replace the `doUploadApidocs` facility. So this `doApiDoc` facility also ensures that mod-search will still have published API documentation.

The https://dev.folio.org/reference/api/#mod-search section of API documentation will be automatically reconfigured tomorrow to include both views:
https://dev.folio.org/reference/api/#explain-gather-config
