### PR TITLE
MSEARCH-251 Add missing permission to run reindex on tenant init

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -128,7 +128,8 @@
             "login.item.post",
             "perms.users.item.post",
             "perms.users.get",
-            "inventory-storage.instance.reindex.post"
+            "inventory-storage.instance.reindex.post",
+            "authority-storage.instance.reindex.post"
           ]
         },
         {


### PR DESCRIPTION
### Purpose
New `inventory-storage.authority.reindex.post` is missing for tenant init endpoint, which fails the tenant init operation

### Approach
- Add missing permission for tenant init module