### PR TITLE
MSEARCH-251 Fix permission name

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -128,7 +128,8 @@
             "login.item.post",
             "perms.users.item.post",
             "perms.users.get",
-            "inventory-storage.instance.reindex.post"
+            "inventory-storage.instance.reindex.post",
+            "authority-storage.instance.reindex.post"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -32,7 +32,7 @@
           "permissionsRequired": [ "search.index.inventory.reindex.post" ],
           "modulePermissions": [
             "inventory-storage.instance.reindex.post",
-            "inventory-storage.authority.reindex.post"
+            "authority-storage.authority.reindex.post"
           ]
         }
       ]
@@ -129,7 +129,7 @@
             "perms.users.item.post",
             "perms.users.get",
             "inventory-storage.instance.reindex.post",
-            "inventory-storage.authority.reindex.post"
+            "authority-storage.authority.reindex.post"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -129,7 +129,7 @@
             "perms.users.item.post",
             "perms.users.get",
             "inventory-storage.instance.reindex.post",
-            "authority-storage.instance.reindex.post"
+            "inventory-storage.authority.reindex.post"
           ]
         },
         {


### PR DESCRIPTION
### Purpose
New `inventory-storage.authority.reindex.post` is missing for tenant init endpoint, which fails the tenant init operation

### Approach
- Add missing permission for tenant init module