### PR TITLE
Fix potential NPE issue in sonarcloud

### DIFF
--- a/src/main/java/org/folio/search/service/SearchService.java
+++ b/src/main/java/org/folio/search/service/SearchService.java
@@ -52,7 +52,8 @@ public class SearchService {
 
   private <T> SearchResult<T> mapToSearchResult(SearchResponse response, Class<T> responseClass) {
     var hits = response.getHits();
-    return SearchResult.of((int) hits.getTotalHits().value, getResultDocuments(hits.getHits(), responseClass));
+    var totalRecords = hits.getTotalHits() != null ? (int) hits.getTotalHits().value : 0;
+    return SearchResult.of(totalRecords, getResultDocuments(hits.getHits(), responseClass));
   }
 
   private <T> List<T> getResultDocuments(SearchHit[] searchHits, Class<T> responseClass) {

--- a/src/test/java/org/folio/search/service/SearchServiceTest.java
+++ b/src/test/java/org/folio/search/service/SearchServiceTest.java
@@ -79,6 +79,25 @@ class SearchServiceTest {
     assertThat(actual).isEqualTo(searchResult(new TestResource().id(instanceId)));
   }
 
+  @Test
+  void search_positive_totalHitsIsNull() {
+    var instanceId = randomId();
+    var query = "id==" + instanceId;
+    var searchRequest = searchServiceRequest(TestResource.class, query, true);
+    var termQuery = termQuery("id", instanceId);
+    var searchSourceBuilder = searchSource().query(termQuery);
+    var expectedSourceBuilder = searchSource().query(termQuery).size(100).from(0).trackTotalHits(true);
+
+    when(cqlSearchQueryConverter.convert(query, RESOURCE_NAME)).thenReturn(searchSourceBuilder);
+    when(searchRepository.search(searchRequest, expectedSourceBuilder)).thenReturn(searchResponse);
+    when(searchResponse.getHits()).thenReturn(searchHits);
+    when(searchHits.getTotalHits()).thenReturn(null);
+    when(searchHits.getHits()).thenReturn(new SearchHit[] {});
+
+    var actual = searchService.search(searchRequest);
+    assertThat(actual).isEqualTo(searchResult());
+  }
+
   private void mockSearchHit(String instanceId) {
     when(searchHits.getTotalHits()).thenReturn(new TotalHits(1, EQUAL_TO));
     when(searchHits.getHits()).thenReturn(array(searchHit));


### PR DESCRIPTION
This issues is raised by sonarcloud, however it's impossible to retrieve null value for total hits according to Elasticsearch response contract