### PR TITLE
MSEARCH-257 Juniper R2 2021 - Log4j vulnerability verification and correction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 1.4.4 2021-xx-xx
-* Log4j vulnerability verification and correction (MSEARCH-255)
+* Log4j vulnerability verification and correction (MSEARCH-257)
 
 ## 1.4.3 2021-08-06
 * Added  environment variable to support custom subscription pattern (MSEARCH-164)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.4.4 2021-xx-xx
+* Kiwi R3 2021 - Log4j vulnerability verification and correction (MSEARCH-255)
+
 ## 1.4.3 2021-08-06
 * Added  environment variable to support custom subscription pattern (MSEARCH-164)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 1.4.4 2021-xx-xx
-* Kiwi R3 2021 - Log4j vulnerability verification and correction (MSEARCH-255)
+* Log4j vulnerability verification and correction (MSEARCH-255)
 
 ## 1.4.3 2021-08-06
 * Added  environment variable to support custom subscription pattern (MSEARCH-164)

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <lombok.version>1.18.16</lombok.version>
     <testcontainer.version>1.15.2</testcontainer.version>
     <wiremock.version>2.27.2</wiremock.version>
+    <log4j2.version>2.16.0</log4j2.version>
     <spring-cloud-starter-openfeign.version>3.0.2</spring-cloud-starter-openfeign.version>
   </properties>
 


### PR DESCRIPTION
The 'formatMsgNoLookups' property was added in version 2.10.0, per the JIRA Issue LOG4J2-2109 that proposed it. Therefore the 'formatMsgNoLookups=true' mitigation strategy is available in version 2.10.0 and higher, but is no longer necessary with version 2.16.0, because it then becomes the default behavior .
