### PR TITLE
modulePermissions include permissions for module user

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -129,7 +129,10 @@
             "perms.users.item.post",
             "perms.users.get",
             "inventory-storage.instance.reindex.post",
-            "authority-storage.authority.reindex.post"
+            "authority-storage.authority.reindex.post",
+            "inventory-storage.inventory-view.instances.collection.get",
+            "inventory-storage.identifier-types.collection.get",
+            "inventory-storage.alternative-title-types.collection.get"
           ]
         },
         {


### PR DESCRIPTION
Include from mod-search.csv to allow that a user is created with those
permissions - even in case of non-existing operating user.

See https://issues.folio.org/browse/MODPERMS-172

### Purpose

To make _tenant init succeed in the case where operating user is not existing (for the tenant that
tenant is performed for).

### Approach

Include in `modulePermissions` all the permissions that are to be assigned for the user.

