### PR TITLE
MSEARCH-253 Update default value for range query offset

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,7 +47,7 @@ application:
       search.all.fields: ${SEARCH_BY_ALL_FIELDS_ENABLED:false}
   query:
     properties:
-      call-number-range-offset: ${QUERY_CALL_NUMBER_RANGE_OFFSET:0.5e18}
+      call-number-range-offset: ${QUERY_CALL_NUMBER_RANGE_OFFSET:1e20}
   system-user:
     username: mod-search
     password: ${SYSTEM_USER_PASSWORD:Mod-search-1-0-0}


### PR DESCRIPTION
### Purpose
Browsing results at snapshot and testing environment contains partial data of all uploaded instances with populated effective shelving order.

### Approach
- Increase range query offset from 0.5e18 to 1e20

