### PR TITLE
MSEARCH-275 Implement highlighting using flag isAnchor

### DIFF
--- a/src/main/java/org/folio/search/service/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/CallNumberBrowseService.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
@@ -204,10 +203,7 @@ public class CallNumberBrowseService {
       items.remove(items.size() - 1);
       return;
     }
-    var fullCallNumber = firstItem.getFullCallNumber();
-    if (StringUtils.isNotBlank(fullCallNumber)) {
-      firstItem.setFullCallNumber("<mark>" + fullCallNumber + "</mark>");
-    }
+    firstItem.setIsAnchor(true);
   }
 
   private long getDifferenceBetweenCallNumberAndAnchor(Long anchor, Item item, boolean isForwardBrowsing) {
@@ -216,7 +212,7 @@ public class CallNumberBrowseService {
   }
 
   private static CallNumberBrowseItem getEmptyCallNumberBrowseItem(String anchorCallNumber) {
-    return new CallNumberBrowseItem().shelfKey(anchorCallNumber).totalRecords(0);
+    return new CallNumberBrowseItem().shelfKey(anchorCallNumber).totalRecords(0).isAnchor(true);
   }
 
   private static List<CallNumberBrowseItem> collapseSearchResultByCallNumber(List<CallNumberBrowseItem> items) {

--- a/src/main/resources/swagger.api/schemas/response/callNumberBrowseItem.json
+++ b/src/main/resources/swagger.api/schemas/response/callNumberBrowseItem.json
@@ -11,6 +11,10 @@
       "type": "string",
       "description": "Shelf key value to be used for browsing"
     },
+    "isAnchor": {
+      "type": "boolean",
+      "description": "Marks if current value is anchor or not"
+    },
     "totalRecords": {
       "type": "integer",
       "description": "Amount of records for the call number value"

--- a/src/test/java/org/folio/search/controller/CallNumberBrowseIT.java
+++ b/src/test/java/org/folio/search/controller/CallNumberBrowseIT.java
@@ -71,7 +71,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
     assertThat(actual).isEqualTo(cnBrowseResult(47, List.of(
       cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
       cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
-      cnBrowseItem(instance("instance #44"), "<mark>CE 16 B6713 X 41993</mark>", "CE 16 B6713 X 41993"),
+      cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993", "CE 16 B6713 X 41993", true),
       cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993"),
       cnBrowseItem(instance("instance #04"), "CE 16 D86 X 41998"),
       cnBrowseItem(instance("instance #38"), "CE 210 K297 41858"),
@@ -115,7 +115,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
       arguments(aroundQuery, firstAnchorCallNumber, 5, cnBrowseResult(46, List.of(
         cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993"),
         cnBrowseItem(instance("instance #04"), "CE 16 D86 X 41998"),
-        cnBrowseItem(0, "CE 210 K297 41858", null),
+        cnBrowseItem(0, "CE 210 K297 41858", null, true ),
         cnBrowseItem(instance("instance #36"), "DA 3700 B91 L79"),
         cnBrowseItem(instance("instance #09"), "DA 3700 C95 NO 18")
       ))),
@@ -123,7 +123,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
       arguments(aroundQuery, secondAnchorCallNumber, 5, cnBrowseResult(47, List.of(
         cnBrowseItem(instance("instance #13"), "DA 3880 O6 M81"),
         cnBrowseItem(instance("instance #02"), "DA 3880 O6 M96"),
-        cnBrowseItem(0, "DA 3890 A1", null),
+        cnBrowseItem(0, "DA 3890 A1", null, true),
         cnBrowseItem(instance("instance #14"), "DA 3890 A1 I72 41885"),
         cnBrowseItem(instance("instance #22"), "DA 3890 A2 B76 42002")
       ))),
@@ -131,7 +131,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
       arguments(aroundIncludingQuery, firstAnchorCallNumber, 5, cnBrowseResult(47, List.of(
         cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993"),
         cnBrowseItem(instance("instance #04"), "CE 16 D86 X 41998"),
-        cnBrowseItem(instance("instance #38"), "<mark>CE 210 K297 41858</mark>", "CE 210 K297 41858"),
+        cnBrowseItem(instance("instance #38"), "CE 210 K297 41858", "CE 210 K297 41858", true),
         cnBrowseItem(instance("instance #36"), "DA 3700 B91 L79"),
         cnBrowseItem(instance("instance #09"), "DA 3700 C95 NO 18")
       ))),
@@ -139,7 +139,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
       arguments(aroundIncludingQuery, secondAnchorCallNumber, 5, cnBrowseResult(47, List.of(
         cnBrowseItem(instance("instance #13"), "DA 3880 O6 M81"),
         cnBrowseItem(instance("instance #02"), "DA 3880 O6 M96"),
-        cnBrowseItem(0, "DA 3890 A1", null),
+        cnBrowseItem(0, "DA 3890 A1", null, true),
         cnBrowseItem(instance("instance #14"), "DA 3890 A1 I72 41885"),
         cnBrowseItem(instance("instance #22"), "DA 3890 A2 B76 42002")
       ))),
@@ -158,7 +158,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
         cnBrowseItem(instance("instance #05"), "DA 3880 O6 M15"),
         cnBrowseItem(instance("instance #13"), "DA 3880 O6 M81"),
         cnBrowseItem(instance("instance #02"), "DA 3880 O6 M96"),
-        cnBrowseItem(0, "DA 3890 A1", null),
+        cnBrowseItem(0, "DA 3890 A1", null, true),
         cnBrowseItem(instance("instance #14"), "DA 3890 A1 I72 41885"),
         cnBrowseItem(instance("instance #22"), "DA 3890 A2 B76 42002"),
         cnBrowseItem(instance("instance #19"), "DA 3890 A2 F57 42011"),
@@ -177,7 +177,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
       arguments(aroundIncludingQuery, "FC", 5, cnBrowseResult(47, List.of(
         cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
         cnBrowseItem(instance("instance #42"), "FA 46252 3977 12 237"),
-        cnBrowseItem(0, "FC", null),
+        cnBrowseItem(0, "FC", null, true),
         cnBrowseItem(3, "FC 17 B89"),
         cnBrowseItem(instance("instance #17"), "GA 16 A63 41581")
       ))),

--- a/src/test/java/org/folio/search/controller/CallNumberBrowseIT.java
+++ b/src/test/java/org/folio/search/controller/CallNumberBrowseIT.java
@@ -115,7 +115,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
       arguments(aroundQuery, firstAnchorCallNumber, 5, cnBrowseResult(46, List.of(
         cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993"),
         cnBrowseItem(instance("instance #04"), "CE 16 D86 X 41998"),
-        cnBrowseItem(0, "CE 210 K297 41858", null, true ),
+        cnBrowseItem(0, "CE 210 K297 41858", null, true),
         cnBrowseItem(instance("instance #36"), "DA 3700 B91 L79"),
         cnBrowseItem(instance("instance #09"), "DA 3700 C95 NO 18")
       ))),

--- a/src/test/java/org/folio/search/service/CallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/CallNumberBrowseServiceTest.java
@@ -97,7 +97,7 @@ class CallNumberBrowseServiceTest {
     assertThat(actual).isEqualTo(SearchResult.of(5, List.of(
       cnBrowseItem(instance("A 12"), "A 12"),
       cnBrowseItem(instance("A 11"), "A 11"),
-      cnBrowseItem(0, "B", null),
+      cnBrowseItem(0, "B", null, true),
       cnBrowseItem(instance("C 11"), "C 11"),
       cnBrowseItem(instance("C 12"), "C 12")
     )));
@@ -143,7 +143,7 @@ class CallNumberBrowseServiceTest {
 
     assertThat(actual).isEqualTo(SearchResult.of(3, List.of(
       cnBrowseItem(instance("A 11"), "A 11"),
-      cnBrowseItem(instance("B"), "<mark>B</mark>", "B"),
+      cnBrowseItem(instance("B"), "B", "B", true),
       cnBrowseItem(instance("C 11"), "C 11")
     )));
   }
@@ -160,7 +160,7 @@ class CallNumberBrowseServiceTest {
     var actual = callNumberBrowseService.browseByCallNumber(request);
 
     assertThat(actual).isEqualTo(SearchResult.of(1, List.of(
-      cnBrowseItem(instance("A"), "A"), cnBrowseItem(0, "B", null))));
+      cnBrowseItem(instance("A"), "A"), cnBrowseItem(0, "B", null, true))));
   }
 
   @Test
@@ -427,7 +427,7 @@ class CallNumberBrowseServiceTest {
     when(callNumberProcessor.getCallNumberAsLong("B")).thenReturn(ANCHOR);
     var actual = callNumberBrowseService.browseByCallNumber(request);
 
-    assertThat(actual).isEqualTo(SearchResult.of(1, List.of(cnBrowseItem(instance, null, "B"))));
+    assertThat(actual).isEqualTo(SearchResult.of(1, List.of(cnBrowseItem(instance, "B", null, true))));
   }
 
   @Test
@@ -442,7 +442,7 @@ class CallNumberBrowseServiceTest {
 
     var actual = callNumberBrowseService.browseByCallNumber(request);
 
-    assertThat(actual).isEqualTo(SearchResult.of(1, List.of(cnBrowseItem(instance, null, "B 10"))));
+    assertThat(actual).isEqualTo(SearchResult.of(1, List.of(cnBrowseItem(instance, "B 10", null))));
   }
 
   private void prepareMocksForBrowsing(CallNumberBrowseRequest request, QueryBuilder query,

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -143,8 +143,13 @@ public class TestUtils {
     return cnBrowseItem(instance, callNumber, callNumber);
   }
 
-  public static CallNumberBrowseItem cnBrowseItem(Instance instance, String callNumber, String shelfKey) {
+  public static CallNumberBrowseItem cnBrowseItem(Instance instance, String shelfKey, String callNumber) {
     return new CallNumberBrowseItem().fullCallNumber(callNumber).shelfKey(shelfKey).instance(instance).totalRecords(1);
+  }
+
+  public static CallNumberBrowseItem cnBrowseItem(Instance instance, String shelfKey, String cn, boolean isAnchor) {
+    return new CallNumberBrowseItem().fullCallNumber(cn).shelfKey(shelfKey)
+      .instance(instance).totalRecords(1).isAnchor(isAnchor);
   }
 
   public static CallNumberBrowseItem cnBrowseItem(int totalRecords, String shelfKey) {
@@ -153,6 +158,11 @@ public class TestUtils {
 
   public static CallNumberBrowseItem cnBrowseItem(int totalRecords, String shelfKey, String callNumber) {
     return new CallNumberBrowseItem().totalRecords(totalRecords).shelfKey(shelfKey).fullCallNumber(callNumber);
+  }
+
+  public static CallNumberBrowseItem cnBrowseItem(int totalRecords, String shelfKey, String cn, boolean isAnchor) {
+    return new CallNumberBrowseItem().totalRecords(totalRecords)
+      .shelfKey(shelfKey).fullCallNumber(cn).isAnchor(isAnchor);
   }
 
   public static String randomId() {


### PR DESCRIPTION
### Purpose
Current implementation with highlighting result with tags can be improved by using field isAnchor with boolean value - true if the current row must be highlighted

### Approach
* Add field `isAnchor` to the call number browse item entity.
* Fix integration and unit tests

