### PR TITLE
MSEARCH-272 Include Item identifier in Identifier (all) search

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ if it is defined but doesn't match.
 | `holdings.electronicAccess.publicNote` | full-text | `holdings.electronicAccess.publicNote="a rare book"` | Search by electronic access public note                                                                |
 | `holdings.notes.note`                  | full-text | `holdings.notes.note all "librarian note"`           | Search by holdings notes                                                                               |
 | `holdingPublicNotes`                   | full-text | `holdingPublicNotes all "public note"`               | Search by holdings public notes                                                                        |
-| `holdingIdentifiers`                   |   term    | `holdingIdentifiers == "ho00000000006"`              | Search by holdings Identifiers: `holdings.hrid`, `holdings.formerIds`                                  |
+| `holdingIdentifiers`                   |   term    | `holdingIdentifiers == "ho00000000006"`              | Search by holdings Identifiers: `holdings.id`, `holdings.hrid`, `holdings.formerIds`                                  |
 | `holdings.metadata.createdDate`        |   term    | `metadata.createdDate > "2020-12-12"`                | Matches instances with holdings that were created after  `2020-12-12`                                                              |
 | `holdings.metadata.updatedDate`        |   term    | `metadata.updatedDate > "2020-12-12"`                | Matches instances with holdings that were updated after  `2020-12-12`                                                              |
 
@@ -411,7 +411,7 @@ if it is defined but doesn't match.
 | `items.notes.note`                  | full-text | `items.notes.note all "librarian note"`                      | Search by item notes and circulation notes                                                             |
 | `items.circulationNotes.note`       | full-text | `items.circulationNotes.note all "circulation note"`         | Search by item circulation notes                                                                       |
 | `itemPublicNotes`                   | full-text | `itemPublicNotes all "public note"`                          | Search by item public notes and circulation notes                                                      |
-| `itemIdentifiers`                   |   term    | `itemIdentifiers all "81ae0f60-f2bc-450c-84c8-5a21096daed9"` | Search by item Identifiers: `items.hrid`, `items.formerIds`, `items.accessionNumber`                   |
+| `itemIdentifiers`                   |   term    | `itemIdentifiers all "81ae0f60-f2bc-450c-84c8-5a21096daed9"` | Search by item Identifiers: `items.id`, `items.hrid`, `items.formerIds`, `items.accessionNumber`                   |
 | `items.metadata.createdDate`        |   term    | `metadata.createdDate > "2020-12-12"`                        | Matches instances with items that were created after  `2020-12-12`                                                              |
 | `items.metadata.updatedDate`        |   term    | `metadata.updatedDate > "2020-12-12"`                        | Matches instances with items that were updated after  `2020-12-12`                                                              |
 

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,11 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>one.util</groupId>
+      <artifactId>streamex</artifactId>
+      <version>0.8.1</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -499,6 +504,11 @@
       <id>folio-nexus</id>
       <name>FOLIO Maven repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
+    </repository>
+    <repository>
+      <id>index-data-nexus</id>
+      <name>FOLIO Maven repository</name>
+      <url>https://maven.indexdata.com</url>
     </repository>
   </repositories>
 

--- a/src/main/java/org/folio/search/service/setter/holding/HoldingIdentifiersProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/holding/HoldingIdentifiersProcessor.java
@@ -5,6 +5,7 @@ import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import one.util.streamex.StreamEx;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.service.setter.FieldProcessor;
@@ -16,7 +17,9 @@ public class HoldingIdentifiersProcessor implements FieldProcessor<Instance, Set
   @Override
   public Set<String> getFieldValue(Instance instance) {
     return toStreamSafe(instance.getHoldings())
-      .flatMap(holding -> Stream.concat(toStreamSafe(holding.getFormerIds()), Stream.of(holding.getHrid())))
+      .flatMap(holding -> StreamEx.of(toStreamSafe(holding.getFormerIds()))
+        .append(Stream.of(holding.getHrid()))
+        .append(Stream.of(holding.getId())))
       .filter(StringUtils::isNotEmpty)
       .collect(Collectors.toSet());
   }

--- a/src/main/java/org/folio/search/service/setter/item/ItemIdentifiersProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemIdentifiersProcessor.java
@@ -5,6 +5,7 @@ import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import one.util.streamex.StreamEx;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.service.setter.FieldProcessor;
@@ -16,8 +17,10 @@ public class ItemIdentifiersProcessor implements FieldProcessor<Instance, Set<St
   @Override
   public Set<String> getFieldValue(Instance instance) {
     return toStreamSafe(instance.getItems())
-      .flatMap(item -> Stream.concat(Stream.concat(toStreamSafe(item.getFormerIds()), Stream.of(item.getHrid())),
-        Stream.of(item.getAccessionNumber())))
+      .flatMap(item -> StreamEx.of(toStreamSafe(item.getFormerIds()))
+        .append(Stream.of(item.getHrid()))
+        .append(Stream.of(item.getAccessionNumber()))
+        .append(Stream.of(item.getId())))
       .filter(StringUtils::isNotEmpty)
       .collect(Collectors.toSet());
   }

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -199,6 +199,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("itemIdentifiers all {value}", "item000000000014"),
       arguments("itemIdentifiers all {value}", "81ae0f60-f2bc-450c-84c8-5a21096daed9"),
       arguments("itemIdentifiers all {value}", "item_accession_number"),
+      arguments("itemIdentifiers all {value}", "7212ba6a-8dcf-45a1-be9a-ffaa847c4423"),
 
       arguments("items.notes.note == {value}", "Librarian public note for item"),
       arguments("items.notes.note == {value}", "Librarian private note for item"),
@@ -228,7 +229,8 @@ class SearchInstanceIT extends BaseIntegrationTest {
 
       arguments("holdingIdentifiers all {value}", "hold000000000009"),
       arguments("holdingIdentifiers == {value}", "1d76ee84-d776-48d2-ab96-140c24e39ac5"),
-      arguments("holdingIdentifiers all {value}", "9b8ec096-fa2e-451b-8e7a-6d1c977ee946")
+      arguments("holdingIdentifiers all {value}", "9b8ec096-fa2e-451b-8e7a-6d1c977ee946"),
+      arguments("holdingIdentifiers all {value}", "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19")
     );
   }
 }

--- a/src/test/java/org/folio/search/service/setter/holding/HoldingIdentifiersProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/holding/HoldingIdentifiersProcessorTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class HoldingIdentifiersProcessorTest {
 
   private static final List<String> FORMER_IDS = List.of(randomId(), randomId());
+  private static final String UUID = randomId();
   private final HoldingIdentifiersProcessor itemIdentifiersProcessor = new HoldingIdentifiersProcessor();
 
   @MethodSource("testDataProvider")
@@ -36,11 +37,14 @@ class HoldingIdentifiersProcessorTest {
       arguments("empty items", instance(), emptyList()),
       arguments("holding with nullable identifier fields", instance(holding(null, null)), emptyList()),
       arguments("holding with hrid only", instance(holding("h01", null)), List.of("h01")),
+      arguments("holding with UUID only", instance(holding(UUID)), List.of(UUID)),
       arguments("holding with empty identifiers", instance(holding("", emptyList())), emptyList()),
       arguments("holding with hrid and empty list in formerIds", instance(holding("h01", emptyList())), List.of("h01")),
       arguments("holding with single formerId", instance(holding(null, List.of("id1"))), List.of("id1")),
       arguments("holding with multiple formerIds", instance(holding(null, FORMER_IDS)), FORMER_IDS),
       arguments("holding with all identifiers", instance(holding("h01", List.of("fid"))), List.of("h01", "fid")),
+      arguments("holding with all identifiers and UUID", instance(
+        holding("h01", List.of("fid")), holding(UUID)), List.of("h01", "fid", UUID)),
       arguments("2 duplicated holdings", instance(
         holding("h01", List.of("fid")), holding("h01", List.of("fid"))), List.of("h01", "fid"))
     );
@@ -52,5 +56,9 @@ class HoldingIdentifiersProcessorTest {
 
   private static Holding holding(String hrid, List<String> formerIds) {
     return new Holding().hrid(hrid).formerIds(formerIds);
+  }
+
+  private static Holding holding(String id) {
+    return new Holding().id(id);
   }
 }

--- a/src/test/java/org/folio/search/service/setter/item/ItemIdentifiersProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemIdentifiersProcessorTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ItemIdentifiersProcessorTest {
 
   private static final List<String> FORMER_IDS = List.of(randomId(), randomId());
+  private static final String UUID = randomId();
   private final ItemIdentifiersProcessor itemIdentifiersProcessor = new ItemIdentifiersProcessor();
 
   @MethodSource("testDataProvider")
@@ -36,12 +37,14 @@ class ItemIdentifiersProcessorTest {
       arguments("empty items", instance(), emptyList()),
       arguments("item with nullable identifier fields", instance(item(null, null, null)), emptyList()),
       arguments("item with hrid only", instance(item("i1", null, null)), List.of("i1")),
+      arguments("item with UUID only", instance(item(UUID)), List.of(UUID)),
       arguments("item with accessionNumber only", instance(item(null, "an", null)), List.of("an")),
       arguments("item with empty identifiers", instance(item("", "", emptyList())), emptyList()),
       arguments("item with hrid and empty list in formerIds", instance(item("i1", null, emptyList())), List.of("i1")),
       arguments("item with single formerId", instance(item(null, null, List.of("id1"))), List.of("id1")),
       arguments("item with multiple formerIds", instance(item(null, null, FORMER_IDS)), FORMER_IDS),
-      arguments("item with all identifiers", instance(item("i01", "an", List.of("fid"))), List.of("i01", "an", "fid")),
+      arguments("item with all identifiers and UUID", instance
+        (item("i01", "an", List.of("fid")), item(UUID)), List.of("i01", "an", "fid", UUID)),
       arguments("2 duplicated items", instance(
         item("i01", "an", List.of("fid")), item("i01", "an", List.of("fid"))), List.of("i01", "an", "fid"))
     );
@@ -53,5 +56,9 @@ class ItemIdentifiersProcessorTest {
 
   private static Item item(String hrid, String accessionNumber, List<String> formerIds) {
     return new Item().hrid(hrid).accessionNumber(accessionNumber).formerIds(formerIds);
+  }
+
+  private static Item item(String id) {
+    return new Item().id(id);
   }
 }

--- a/src/test/java/org/folio/search/service/setter/item/ItemIdentifiersProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemIdentifiersProcessorTest.java
@@ -43,8 +43,8 @@ class ItemIdentifiersProcessorTest {
       arguments("item with hrid and empty list in formerIds", instance(item("i1", null, emptyList())), List.of("i1")),
       arguments("item with single formerId", instance(item(null, null, List.of("id1"))), List.of("id1")),
       arguments("item with multiple formerIds", instance(item(null, null, FORMER_IDS)), FORMER_IDS),
-      arguments("item with all identifiers and UUID", instance
-        (item("i01", "an", List.of("fid")), item(UUID)), List.of("i01", "an", "fid", UUID)),
+      arguments("item with all identifiers and UUID", instance(
+        item("i01", "an", List.of("fid")), item(UUID)), List.of("i01", "an", "fid", UUID)),
       arguments("2 duplicated items", instance(
         item("i01", "an", List.of("fid")), item("i01", "an", List.of("fid"))), List.of("i01", "an", "fid"))
     );


### PR DESCRIPTION
### Purpose
The existing implementation of Item Identifiers (all) includes searches for items' HRIDs, Former Ids, and Accession numbers.   However, the libraries might use Item Identifiers as well, for example for a secondary remote storage identifier.

### Approach
item and holding UUID added to the corresponding processors.

