### PR TITLE
MSEARCH-254 Fix reindexing issue for instance_subject secondary resource

### DIFF
--- a/src/main/java/org/folio/search/model/metadata/ResourceDescription.java
+++ b/src/main/java/org/folio/search/model/metadata/ResourceDescription.java
@@ -23,6 +23,11 @@ public class ResourceDescription {
   private String name;
 
   /**
+   * Specifies if resource is primary and must be re-indexed using inventory-storage API.
+   */
+  private boolean isPrimary = true;
+
+  /**
    * Related java class for event body.
    */
   private Class<?> eventBodyJavaClass;

--- a/src/main/java/org/folio/search/service/IndexService.java
+++ b/src/main/java/org/folio/search/service/IndexService.java
@@ -209,8 +209,8 @@ public class IndexService {
   }
 
   private void validateResourceName(String resourceName) {
-    var existingResourceNames = resourceDescriptionService.getResourceNames();
-    if (!existingResourceNames.contains(resourceName)) {
+    var resourceDescription = resourceDescriptionService.get(resourceName);
+    if (resourceDescription == null || !resourceDescription.isPrimary()) {
       throw new RequestValidationException(
         "Reindex request contains invalid resource name", "resourceName", resourceName);
     }

--- a/src/main/java/org/folio/search/service/SearchTenantService.java
+++ b/src/main/java/org/folio/search/service/SearchTenantService.java
@@ -56,14 +56,16 @@ public class SearchTenantService {
       .forEach(languageConfigService::create);
 
     var resourceNames = resourceDescriptionService.getResourceNames();
-    resourceNames.forEach(resourceName ->
-      indexService.createIndexIfNotExist(resourceName, context.getTenantId()));
+    resourceNames.forEach(resourceName -> indexService.createIndexIfNotExist(resourceName, context.getTenantId()));
     Stream.ofNullable(tenantAttributes.getParameters())
       .flatMap(Collection::stream)
       .filter(parameter -> parameter.getKey().equals(REINDEX_PARAM_NAME) && parseBoolean(parameter.getValue()))
       .findFirst()
-      .ifPresent(parameter -> resourceNames.forEach(resource ->
-        indexService.reindexInventory(context.getTenantId(), new ReindexRequest().resourceName(resource))));
+      .ifPresent(parameter -> resourceNames.forEach(resource -> {
+        if (resourceDescriptionService.get(resource).isPrimary()) {
+          indexService.reindexInventory(context.getTenantId(), new ReindexRequest().resourceName(resource));
+        }
+      }));
   }
 
   /**

--- a/src/main/resources/model/instance_subject.json
+++ b/src/main/resources/model/instance_subject.json
@@ -1,5 +1,6 @@
 {
   "name": "instance_subject",
+  "isPrimary": false,
   "fields": {
     "subject": {
       "index": "plain_fulltext"

--- a/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
+++ b/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
@@ -2,6 +2,8 @@ package org.folio.search.service;
 
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.folio.search.utils.TestUtils.resourceDescription;
+import static org.folio.search.utils.TestUtils.secondaryResourceDescription;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -71,7 +73,9 @@ class SearchTenantServiceTest {
   @Test
   void shouldRunReindexOnTenantParamPresent() {
     when(context.getTenantId()).thenReturn(TENANT_ID);
-    when(resourceDescriptionService.getResourceNames()).thenReturn(List.of(RESOURCE_NAME));
+    when(resourceDescriptionService.getResourceNames()).thenReturn(List.of(RESOURCE_NAME, "secondary"));
+    when(resourceDescriptionService.get(RESOURCE_NAME)).thenReturn(resourceDescription(RESOURCE_NAME));
+    when(resourceDescriptionService.get("secondary")).thenReturn(secondaryResourceDescription("secondary"));
     var attributes = TENANT_ATTRIBUTES.addParametersItem(new Parameter().key("runReindex").value("true"));
 
     searchTenantService.initializeTenant(attributes);

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -248,6 +248,7 @@ public class TestUtils {
     var resourceDescription = new ResourceDescription();
     resourceDescription.setName(name);
     resourceDescription.setFields(fields);
+    resourceDescription.setPrimary(true);
     return resourceDescription;
   }
 
@@ -255,6 +256,12 @@ public class TestUtils {
     Map<String, FieldDescription> fields, List<String> languageSourcePaths) {
     var resourceDescription = resourceDescription(RESOURCE_NAME, fields);
     resourceDescription.setLanguageSourcePaths(languageSourcePaths);
+    return resourceDescription;
+  }
+
+  public static ResourceDescription secondaryResourceDescription(String name) {
+    var resourceDescription = resourceDescription(name, emptyMap());
+    resourceDescription.setPrimary(false);
     return resourceDescription;
   }
 


### PR DESCRIPTION
### Purpose
Current implementation scan all resource descriptors and runs for them reindex on tenant initialization. With that change, it will be fixed and only primary resources will be reindexed, when secondary resources can exist safely.

### Approach
- Add boolean flag `isPrimary` for resource descriptors
- Fix unit tests and add new to check that secondary resources won't be reindexed.

