### PR TITLE
MSEARCH-254 Fix reindexing issue for instance_subject secondary resource

### DIFF
--- a/src/main/java/org/folio/search/model/metadata/ResourceDescription.java
+++ b/src/main/java/org/folio/search/model/metadata/ResourceDescription.java
@@ -25,7 +25,7 @@ public class ResourceDescription {
   /**
    * Specifies if resource is primary and must be re-indexed using inventory-storage API.
    */
-  private boolean isPrimary = true;
+  private boolean primary = true;
 
   /**
    * Related java class for event body.

--- a/src/main/java/org/folio/search/service/IndexService.java
+++ b/src/main/java/org/folio/search/service/IndexService.java
@@ -62,11 +62,8 @@ public class IndexService {
    * @throws SearchServiceException if {@link IOException} has been occurred during index request execution
    */
   public FolioCreateIndexResponse createIndex(String resourceName, String tenantId) {
-    if (resourceDescriptionService.get(resourceName) == null) {
-      throw new RequestValidationException(
-        "Index cannot be created for the resource because resource description is not found.",
-        RESOURCE_NAME_PARAMETER, resourceName);
-    }
+    validateResourceName(resourceName,
+      "Index cannot be created for the resource because resource description is not found.");
 
     var index = getElasticsearchIndexName(resourceName, tenantId);
     var settings = settingsHelper.getSettings(resourceName);
@@ -85,11 +82,7 @@ public class IndexService {
    * @return {@link AcknowledgedResponse} object.
    */
   public FolioIndexOperationResponse updateMappings(String resourceName, String tenantId) {
-    var resourceDescription = resourceDescriptionService.get(resourceName);
-    if (resourceDescription == null || !resourceDescription.isPrimary()) {
-      throw new RequestValidationException(
-        "Reindex request contains invalid resource name", RESOURCE_NAME_PARAMETER, resourceName);
-    }
+    validateResourceName(resourceName, "Mappings cannot be updated, resource name is invalid.");
     var index = getElasticsearchIndexName(resourceName, tenantId);
     var mappings = mappingHelper.getMappings(resourceName);
 
@@ -227,5 +220,11 @@ public class IndexService {
     }
 
     return reindexRequest.getResourceName();
+  }
+
+  private void validateResourceName(String resourceName, String message) {
+    if (resourceDescriptionService.get(resourceName) == null) {
+      throw new RequestValidationException(message, RESOURCE_NAME_PARAMETER, resourceName);
+    }
   }
 }

--- a/src/main/java/org/folio/search/service/IndexService.java
+++ b/src/main/java/org/folio/search/service/IndexService.java
@@ -43,6 +43,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class IndexService {
 
+  private static final String RESOURCE_NAME_PARAMETER = "resourceName";
+
   private final IndexRepository indexRepository;
   private final SearchMappingsHelper mappingHelper;
   private final SearchSettingsHelper settingsHelper;
@@ -63,7 +65,7 @@ public class IndexService {
     if (resourceDescriptionService.get(resourceName) == null) {
       throw new RequestValidationException(
         "Index cannot be created for the resource because resource description is not found.",
-        "resourceName", resourceName);
+        RESOURCE_NAME_PARAMETER, resourceName);
     }
 
     var index = getElasticsearchIndexName(resourceName, tenantId);
@@ -86,7 +88,7 @@ public class IndexService {
     var resourceDescription = resourceDescriptionService.get(resourceName);
     if (resourceDescription == null || !resourceDescription.isPrimary()) {
       throw new RequestValidationException(
-        "Reindex request contains invalid resource name", "resourceName", resourceName);
+        "Reindex request contains invalid resource name", RESOURCE_NAME_PARAMETER, resourceName);
     }
     var index = getElasticsearchIndexName(resourceName, tenantId);
     var mappings = mappingHelper.getMappings(resourceName);
@@ -221,7 +223,7 @@ public class IndexService {
     var resourceDescription = resourceDescriptionService.get(resourceName);
     if (resourceDescription == null || !resourceDescription.isPrimary()) {
       throw new RequestValidationException(
-        "Reindex request contains invalid resource name", "resourceName", resourceName);
+        "Reindex request contains invalid resource name", RESOURCE_NAME_PARAMETER, resourceName);
     }
 
     return reindexRequest.getResourceName();

--- a/src/main/resources/model/instance_subject.json
+++ b/src/main/resources/model/instance_subject.json
@@ -1,6 +1,6 @@
 {
   "name": "instance_subject",
-  "isPrimary": false,
+  "primary": false,
   "fields": {
     "subject": {
       "index": "plain_fulltext"

--- a/src/test/java/org/folio/search/controller/IndexingIT.java
+++ b/src/test/java/org/folio/search/controller/IndexingIT.java
@@ -124,6 +124,24 @@ class IndexingIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.submittedDate", is("2021-11-08T13:00:00.000+00:00")));
   }
 
+  @Test
+  void runReindex_positive_instanceSubject() throws Exception {
+    var request = post(ApiEndpoints.reindexPath())
+      .content(asJsonString(new ReindexRequest().resourceName("instance_subject")))
+      .headers(defaultHeaders())
+      .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
+      .contentType(MediaType.APPLICATION_JSON);
+
+    mockMvc.perform(request)
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.total_records", is(1)))
+      .andExpect(jsonPath("$.errors[0].message", is("Reindex request contains invalid resource name")))
+      .andExpect(jsonPath("$.errors[0].type", is("RequestValidationException")))
+      .andExpect(jsonPath("$.errors[0].code", is("validation_error")))
+      .andExpect(jsonPath("$.errors[0].parameters[0].key", is("resourceName")))
+      .andExpect(jsonPath("$.errors[0].parameters[0].value", is("instance_subject")));
+  }
+
   private void createInstances() {
     var instances = INSTANCE_IDS.stream()
       .map(id -> new Instance().id(id))

--- a/src/test/java/org/folio/search/service/IndexServiceTest.java
+++ b/src/test/java/org/folio/search/service/IndexServiceTest.java
@@ -66,7 +66,7 @@ class IndexServiceTest {
   @Mock private MultiTenantSearchDocumentConverter searchDocumentConverter;
 
   @Test
-  void createIndex() {
+  void createIndex_positive() {
     var expectedResponse = getSuccessFolioCreateIndexResponse(List.of(INDEX_NAME));
 
     when(resourceDescriptionService.get(RESOURCE_NAME)).thenReturn(resourceDescription(RESOURCE_NAME));
@@ -76,6 +76,14 @@ class IndexServiceTest {
 
     var indexResponse = indexService.createIndex(RESOURCE_NAME, TENANT_ID);
     assertThat(indexResponse).isEqualTo(expectedResponse);
+  }
+
+  @Test
+  void createIndex_negative_resourceDescriptionNotFound() {
+    when(resourceDescriptionService.get(RESOURCE_NAME)).thenReturn(null);
+    assertThatThrownBy(() -> indexService.createIndex(RESOURCE_NAME, TENANT_ID))
+      .isInstanceOf(RequestValidationException.class)
+      .hasMessage("Index cannot be created for the resource because resource description is not found.");
   }
 
   @Test

--- a/src/test/java/org/folio/search/service/IndexServiceTest.java
+++ b/src/test/java/org/folio/search/service/IndexServiceTest.java
@@ -99,6 +99,14 @@ class IndexServiceTest {
   }
 
   @Test
+  void updateMappings_negative_resourceDescriptionNotFound() {
+    when(resourceDescriptionService.get(RESOURCE_NAME)).thenReturn(null);
+    assertThatThrownBy(() -> indexService.updateMappings(RESOURCE_NAME, TENANT_ID))
+      .isInstanceOf(RequestValidationException.class)
+      .hasMessage("Mappings cannot be updated, resource name is invalid.");
+  }
+
+  @Test
   void indexResources_positive() {
     var searchBody = searchDocumentBody();
     var resourceEvent = resourceEvent(RESOURCE_NAME, mapOf("id", randomId()));


### PR DESCRIPTION
### Purpose
Current implementation scan all resource descriptors and runs for them reindex on tenant initialization. With that change, it will be fixed and only primary resources will be reindexed, when secondary resources can exist safely.

### Approach
- Rename boolean flag from `isPrimary` to `primary` because Jackson ignores it.
