### PR TITLE
MSEARCH-283 Fix call number exists query

### DIFF
--- a/src/main/java/org/folio/search/cql/CallNumberBrowseSearchTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/CallNumberBrowseSearchTermProcessor.java
@@ -2,6 +2,7 @@ package org.folio.search.cql;
 
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.search.service.setter.instance.CallNumberProcessor;
 import org.marc4j.callnum.LCCallNumber;
 import org.springframework.stereotype.Component;
@@ -17,6 +18,10 @@ public class CallNumberBrowseSearchTermProcessor implements SearchTermProcessor 
 
   @Override
   public Long getSearchTerm(String term) {
+    if (StringUtils.isBlank(term)) {
+      return null;
+    }
+
     var termToProcess = SHELF_KEY_PATTERN.matcher(term).matches() ? term : new LCCallNumber(term).getShelfKey();
     return callNumberProcessor.getCallNumberAsLong(termToProcess);
   }

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -171,6 +171,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("publicNotes all {value}", "development"),
       arguments("notes.note == {value}", "Librarian private note"),
       arguments("notes.note == {value}", "The development of the Semantic Web,"),
+      arguments("callNumber = {value}", "\"\""),
 
       // search by isbn10
       arguments("isbn = {value}", "047144250X"),

--- a/src/test/java/org/folio/search/cql/CallNumberBrowseSearchTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/CallNumberBrowseSearchTermProcessorTest.java
@@ -37,4 +37,11 @@ class CallNumberBrowseSearchTermProcessorTest {
     var actual = searchTermProcessor.getSearchTerm(callNumber);
     assertThat(actual).isEqualTo(100L);
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "  ", "   "})
+  void getSearchTerm_parameterized_emptyValues(String searchTerm) {
+    var actual = searchTermProcessor.getSearchTerm(searchTerm);
+    assertThat(actual).isNull();
+  }
 }


### PR DESCRIPTION
### Purpose
Query ```callNumber = ""``` must return all results containing generated callNumber.

### Approach
- Fix an issue when `CallNumberBrowseSearchTermProcessor` returns 0 for empty value
- Add unit and integration test to verify the new approach