### PR TITLE
MSEARCH-285 Separate Statistical code facets for instances, holdings and items

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ GET /instances/facets?query=title all book&facet=source:5,discoverySuppress:2
 | `instanceTags`           |  term   | Requests a tags facet                                                |
 | `staffSuppress`          | boolean | Requests a staff suppress facet                                      |
 | `discoverySuppress`      | boolean | Requests a discovery suppress facet                                  |
+| `statisticalCodeIds`     |  term   | Requests a statistical code ids facet                                |
 | `statisticalCodes`       |  term   | Requests a statistical code ids from instance, holdings, items facet |
 
 ### Holding facets
@@ -555,6 +556,7 @@ GET /instances/facets?query=title all book&facet=source:5,discoverySuppress:2
 |:-------------------------------|:----:|:-----------------------------------------------|
 | `holdings.permanentLocationId` | term | Requests a holding permanent location id facet |
 | `holdings.discoverySuppress`   | term | Requests a holding discovery suppress facet    |
+| `holdings.statisticalCodeIds`  | term | Requests a holding statistical code ids        |
 | `holdings.sourceId`            | term | Requests a holding sourceId facet              |
 | `holdingTags`                  | term | Requests a holding tag facet                   |
 
@@ -566,6 +568,7 @@ GET /instances/facets?query=title all book&facet=source:5,discoverySuppress:2
 | `items.status.name`         |  term   | Requests an item status facet                |
 | `items.materialTypeId`      |  term   | Requests an item material type id facet      |
 | `items.discoverySuppress`   | boolean | Requests an item discovery suppress facet    |
+| `items.statisticalCodeIds`  | boolean | Requests an item statistical code ids facet  |
 | `itemTags`                  |  term   | Requests an item tag facet                   |
 
 ### Authority facets

--- a/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
@@ -2,6 +2,7 @@ package org.folio.search.controller;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.support.base.ApiEndpoints.recordFacets;
@@ -229,7 +230,18 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       arguments("(items.metadata.updatedDate > 2021-03-05) sortby title", List.of(IDS[1], IDS[2], IDS[3])),
       arguments("(items.metadata.updatedDate < 2021-03-15) sortby title", List.of(IDS[0], IDS[1])),
       arguments("(items.metadata.updatedDate > 2021-03-14 and metadata.updatedDate < 2021-03-16) sortby title",
-        List.of(IDS[2], IDS[3]))
+        List.of(IDS[2], IDS[3])),
+
+      arguments("statisticalCodes == b5968c9e-cddc-4576-99e3-8e60aed8b0dd", List.of(IDS[0])),
+      arguments("statisticalCodes == a2b01891-c9ab-4d04-8af8-8989af1c6aad", List.of(IDS[3])),
+      arguments("statisticalCodes == 615e9911-edb1-4ab3-a9c3-a461a3de02f8", List.of(IDS[1])),
+      arguments("statisticalCodes == unknown", emptyList()),
+      arguments("statisticalCodeIds == b5968c9e-cddc-4576-99e3-8e60aed8b0dd", List.of(IDS[0])),
+      arguments("statisticalCodeIds == a2b01891-c9ab-4d04-8af8-8989af1c6aad", emptyList()),
+      arguments("holdings.statisticalCodeIds == b5968c9e-cddc-4576-99e3-8e60aed8b0dd", emptyList()),
+      arguments("holdings.statisticalCodeIds == a2b01891-c9ab-4d04-8af8-8989af1c6aad", List.of(IDS[3])),
+      arguments("items.statisticalCodeIds == b5968c9e-cddc-4576-99e3-8e60aed8b0dd", emptyList()),
+      arguments("items.statisticalCodeIds == 615e9911-edb1-4ab3-a9c3-a461a3de02f8", List.of(IDS[1]))
     );
   }
 
@@ -331,8 +343,16 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
         "statisticalCodes", facet(facetItem("b5968c9e-cddc-4576-99e3-8e60aed8b0dd", 1),
           facetItem("a2b01891-c9ab-4d04-8af8-8989af1c6aad", 1), facetItem("615e9911-edb1-4ab3-a9c3-a461a3de02f8", 1)))),
 
-      arguments("id=*", array("holdings.sourceId"), mapOf(
-        "holdings.sourceId", facet(facetItem("FOLIO", 1))))
+      arguments("id=*", array("statisticalCodeIds"), mapOf(
+        "statisticalCodeIds", facet(facetItem("b5968c9e-cddc-4576-99e3-8e60aed8b0dd", 1)))),
+
+      arguments("id=*", array("holdings.statisticalCodeIds"), mapOf(
+        "holdings.statisticalCodeIds", facet(facetItem("a2b01891-c9ab-4d04-8af8-8989af1c6aad", 1)))),
+
+      arguments("id=*", array("items.statisticalCodeIds"), mapOf(
+        "items.statisticalCodeIds", facet(facetItem("615e9911-edb1-4ab3-a9c3-a461a3de02f8", 1)))),
+
+      arguments("id=*", array("holdings.sourceId"), mapOf("holdings.sourceId", facet(facetItem("FOLIO", 1))))
     );
   }
 


### PR DESCRIPTION
### Purpose
The existing implementation of Statistical code facets combines statistical codes from instances, holdings, and items into one facet on the instance record level. We need to have the facets separated by each record type

### Approach
- All required configuration is already present so this pull request just adds necessary integration test cases