### PR TITLE
MSEARCH-292 Update Authority Search Options - Corporate/Conference Name & Personal Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,16 +438,19 @@ if it is defined but doesn't match.
 | `saftPersonalName`      | full-text | `saftPersonalName any "john"`                | Matches authorities with `john` saft personal name                               |
 | `personalNameTitle`     | full-text | `personalNameTitle any "personal title"`     | Matches authorities with `personal title` personal name title                    |
 | `sftPersonalNameTitle`  | full-text | `sftPersonalNameTitle any "personal title"`  | Matches authorities with `personal title` sft personal name title                |
+| `saftPersonalNameTitle` | full-text | `saftPersonalNameTitle any "personal title"` | Matches authorities with `personal title` saft personal name title               |
 | `corporateName`         | full-text | `corporateName == "corporate name"`          | Matches authorities with `corporate name` corporate name                         |
 | `sftCorporateName`      | full-text | `sftCorporateName == "corporate name"`       | Matches authorities with `corporate name` sft corporate name                     |
 | `saftCorporateName`     | full-text | `saftCorporateName == "corporate name"`      | Matches authorities with `corporate name` saft corporate name                    |
 | `corporateNameTitle`    | full-text | `corporateNameTitle == "corporate title"`    | Matches authorities with `corporate title` corporate name                        |
-| `sftCorporateNameTitle` | full-text | `sftCorporateNameTitle == "corporate title"` | Matches authorities with `corporate title` corporate name                        |
+| `sftCorporateNameTitle` | full-text | `sftCorporateNameTitle == "corporate title"` | Matches authorities with `corporate title` sft corporate name                    |
+| `saftCorporateNameTitle`| full-text | `saftCorporateNameTitle == "corporate title"`| Matches authorities with `corporate title` saft corporate name                   |
 | `meetingName`           | full-text | `meetingName == "conferenece name"`          | Matches authorities with `conferenece name` meeting name                         |
 | `sftMeetingName`        | full-text | `sftMeetingName == "conferenece name"`       | Matches authorities with `conferenece name` sft meeting name                     |
 | `saftMeetingName`       | full-text | `saftMeetingName == "conferenece name"`      | Matches authorities with `conferenece name` saft meeting name                    |
 | `meetingNameTitle`      | full-text | `meetingNameTitle == "conferenece title"`    | Matches authorities with `conferenece title` meeting name title                  |
 | `sftMeetingNameTitle`   | full-text | `sftMeetingNameTitle == "conferenece title"` | Matches authorities with `conferenece title` sft meeting name title              |
+| `saftMeetingNameTitle`  | full-text | `saftMeetingNameTitle == "conferenece title"`| Matches authorities with `conferenece title` saft meeting name title             |
 | `geographicName`        | full-text | `geographicName == "geographic name"`        | Matches authorities with `geographic name` geographic name                       |
 | `sftGeographicTerm`     | full-text | `sftGeographicTerm == "geographic name"`     | Matches authorities with `geographic name` sft geographic term                   |
 | `saftGeographicTerm`    | full-text | `saftGeographicTerm == "geographic name"`    | Matches authorities with `geographic name` saft geographic term                  |

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -46,6 +46,12 @@
       "headingType": "Personal Name",
       "authRefType": "Reference"
     },
+    "saftPersonalNameTitle": {
+      "type": "authority",
+      "index": "standard",
+      "distinctType": "saftPersonalNameTitle",
+      "authRefType": "Auth/Ref"
+    },
     "corporateName": {
       "type": "authority",
       "index": "standard",
@@ -82,6 +88,12 @@
       "distinctType": "sftCorporateNameTitle",
       "headingType": "Corporate Name",
       "authRefType": "Reference"
+    },
+    "saftCorporateNameTitle": {
+      "type": "authority",
+      "index": "standard",
+      "distinctType": "saftCorporateNameTitle",
+      "authRefType": "Auth/Ref"
     },
     "meetingName": {
       "type": "authority",
@@ -120,6 +132,12 @@
       "distinctType": "sftMeetingNameTitle",
       "headingType": "Conference Name",
       "authRefType": "Reference"
+    },
+    "saftMeetingNameTitle": {
+      "type": "authority",
+      "index": "standard",
+      "distinctType": "saftMeetingNameTitle",
+      "authRefType": "Auth/Ref"
     },
     "geographicName": {
       "type": "authority",

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -50,6 +50,7 @@
     "saftPersonalNameTitle": {
       "type": "authority",
       "index": "standard",
+      "inventorySearchTypes": "keyword",
       "distinctType": "saftPersonalNameTitle",
       "headingType": "Personal Name",
       "authRefType": "Auth/Ref"
@@ -95,6 +96,7 @@
     "saftCorporateNameTitle": {
       "type": "authority",
       "index": "standard",
+      "inventorySearchTypes": "keyword",
       "distinctType": "saftCorporateNameTitle",
       "headingType": "Corporate Name",
       "authRefType": "Auth/Ref"
@@ -141,6 +143,7 @@
     "saftMeetingNameTitle": {
       "type": "authority",
       "index": "standard",
+      "inventorySearchTypes": "keyword",
       "distinctType": "saftMeetingNameTitle",
       "headingType": "Conference Name",
       "authRefType": "Auth/Ref"

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -32,7 +32,7 @@ class SearchAuthorityIT extends BaseIntegrationTest {
 
   @BeforeAll
   static void prepare() {
-    setUpTenant(Authority.class, 27, getAuthoritySampleAsMap());
+    setUpTenant(Authority.class, 30, getAuthoritySampleAsMap());
   }
 
   @AfterAll
@@ -67,6 +67,7 @@ class SearchAuthorityIT extends BaseIntegrationTest {
 
       authority("Personal Name", AUTHORIZED_TYPE, "a personal title"),
       authority("Personal Name", REFERENCE_TYPE, "a sft personal title"),
+      authority(OTHER_HEADING_TYPE, AUTH_REF_TYPE, "a saft personal title"),
 
       authority("Corporate Name", AUTHORIZED_TYPE, "a corporate name"),
       authority("Corporate Name", REFERENCE_TYPE, "a sft corporate name"),
@@ -74,6 +75,7 @@ class SearchAuthorityIT extends BaseIntegrationTest {
 
       authority("Corporate Name", AUTHORIZED_TYPE, "a corporate title"),
       authority("Corporate Name", REFERENCE_TYPE, "a sft corporate title"),
+      authority(OTHER_HEADING_TYPE, AUTH_REF_TYPE, "a saft corporate title"),
 
       authority("Conference Name", AUTHORIZED_TYPE, "a conference name"),
       authority("Conference Name", REFERENCE_TYPE, "a sft conference name"),
@@ -81,6 +83,7 @@ class SearchAuthorityIT extends BaseIntegrationTest {
 
       authority("Conference Name", AUTHORIZED_TYPE, "a conference title"),
       authority("Conference Name", REFERENCE_TYPE, "a sft conference title"),
+      authority(OTHER_HEADING_TYPE, AUTH_REF_TYPE, "a saft conference title"),
 
       authority("Geographic Name", AUTHORIZED_TYPE, "a geographic name"),
       authority("Geographic Name", REFERENCE_TYPE, "a sft geographic name"),
@@ -119,6 +122,8 @@ class SearchAuthorityIT extends BaseIntegrationTest {
       arguments("personalNameTitle == {value}", "\"a personal title\""),
       arguments("sftPersonalNameTitle all {value}", "\"personal title\""),
       arguments("sftPersonalNameTitle == {value}", "\"a sft personal title\""),
+      arguments("saftPersonalNameTitle all {value}", "\"personal title\""),
+      arguments("saftPersonalNameTitle == {value}", "\"a saft personal title\""),
 
       arguments("corporateName = {value}", "\"corporate\""),
       arguments("corporateName == {value}", "\"a corporate name\""),
@@ -132,6 +137,8 @@ class SearchAuthorityIT extends BaseIntegrationTest {
       arguments("corporateNameTitle == {value}", "\"a corporate title\""),
       arguments("sftCorporateNameTitle all {value}", "\"corporate title\""),
       arguments("sftCorporateNameTitle == {value}", "\"a sft corporate title\""),
+      arguments("saftCorporateNameTitle all {value}", "\"corporate title\""),
+      arguments("saftCorporateNameTitle == {value}", "\"a saft corporate title\""),
 
       arguments("meetingName = {value}", "\"conference\""),
       arguments("meetingName == {value}", "\"a conference name\""),
@@ -145,6 +152,8 @@ class SearchAuthorityIT extends BaseIntegrationTest {
       arguments("meetingNameTitle == {value}", "\"a conference title\""),
       arguments("sftMeetingNameTitle all {value}", "\"conference title\""),
       arguments("sftMeetingNameTitle == {value}", "\"a sft conference title\""),
+      arguments("saftMeetingNameTitle all {value}", "\"conference title\""),
+      arguments("saftMeetingNameTitle == {value}", "\"a saft conference title\""),
 
       arguments("geographicName = {value}", "\"geographic\""),
       arguments("geographicName == {value}", "\"a geographic name\""),


### PR DESCRIPTION
### Purpose
Add "saftPersonalNameTitle", "saftCorporateNameTitle" and "saftMeetingNameTitle" as search fields for Authority records.

### Learning
[MSEARCH-292](https://issues.folio.org/browse/MSEARCH-292)
