### PR TITLE
MSEARCH-276 Fix update operation on instance

### DIFF
--- a/src/main/java/org/folio/search/integration/ResourceFetchService.java
+++ b/src/main/java/org/folio/search/integration/ResourceFetchService.java
@@ -1,21 +1,21 @@
 package org.folio.search.integration;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static org.folio.search.model.client.CqlQuery.exactMatchAny;
-import static org.folio.search.utils.CollectionUtils.toLinkedHashSet;
+import static org.folio.search.utils.CollectionUtils.findLast;
 import static org.folio.search.utils.SearchConverterUtils.getResourceEventId;
 import static org.folio.search.utils.SearchUtils.ID_FIELD;
 import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections.CollectionUtils;
 import org.folio.search.client.InventoryViewClient;
 import org.folio.search.client.InventoryViewClient.InstanceView;
@@ -24,6 +24,7 @@ import org.folio.search.domain.dto.ResourceEventType;
 import org.folio.search.service.TenantScopedExecutionService;
 import org.springframework.stereotype.Service;
 
+@Log4j2
 @Service
 @RequiredArgsConstructor
 public class ResourceFetchService {
@@ -39,12 +40,12 @@ public class ResourceFetchService {
    */
   public List<ResourceEvent> fetchInstancesByIds(List<ResourceEvent> events) {
     if (CollectionUtils.isEmpty(events)) {
-      return Collections.emptyList();
+      return emptyList();
     }
 
     var instanceEvents = events.stream()
       .filter(event -> INSTANCE_RESOURCE.equals(event.getResourceName()))
-      .collect(groupingBy(ResourceEvent::getTenant, mapping(ResourceEvent::getId, toLinkedHashSet())));
+      .collect(groupingBy(ResourceEvent::getTenant));
 
     return instanceEvents.entrySet().stream()
       .map(this::fetchInstances)
@@ -52,24 +53,30 @@ public class ResourceFetchService {
       .collect(toList());
   }
 
-  private List<ResourceEvent> fetchInstances(Entry<String, Set<String>> entry) {
+  private List<ResourceEvent> fetchInstances(Entry<String, List<ResourceEvent>> entry) {
+    var eventsById = entry.getValue().stream().collect(groupingBy(ResourceEvent::getId, LinkedHashMap::new, toList()));
     var tenantId = entry.getKey();
     return tenantScopedExecutionService.executeTenantScoped(tenantId, () -> {
-      var instanceIds = entry.getValue();
+      var instanceIds = eventsById.keySet();
       var instanceResultList = inventoryClient.getInstances(exactMatchAny(ID_FIELD, instanceIds), instanceIds.size());
       return instanceResultList.getResult().stream()
         .map(InstanceView::toInstance)
-        .map(instanceMap -> mapToResourceEvent(tenantId, instanceMap))
+        .map(instanceMap -> mapToResourceEvent(tenantId, instanceMap, eventsById))
         .collect(toList());
     });
   }
 
-  private static ResourceEvent mapToResourceEvent(String tenantId, Map<String, Object> instanceMap) {
-    return new ResourceEvent()
-      ._new(instanceMap)
-      .id(getResourceEventId(instanceMap))
-      .tenant(tenantId)
-      .resourceName(INSTANCE_RESOURCE)
-      .type(ResourceEventType.CREATE);
+  private static ResourceEvent mapToResourceEvent(String tenantId, Map<String, Object> instanceMap,
+    Map<String, List<ResourceEvent>> eventsById) {
+    var id = getResourceEventId(instanceMap);
+    var resourceEvent = new ResourceEvent().id(id).resourceName(INSTANCE_RESOURCE)._new(instanceMap).tenant(tenantId);
+    var lastElement = findLast(eventsById.get(id));
+    if (lastElement.isEmpty()) {
+      log.warn("Source event by id not found after fetching, returning fetched value [instanceId: {}]", id);
+      return resourceEvent.type(ResourceEventType.CREATE);
+    }
+
+    var sourceEvent = lastElement.get();
+    return resourceEvent.type(sourceEvent.getType()).old(sourceEvent.getOld());
   }
 }

--- a/src/main/java/org/folio/search/utils/CollectionUtils.java
+++ b/src/main/java/org/folio/search/utils/CollectionUtils.java
@@ -6,6 +6,7 @@ import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.empty;
 import static java.util.stream.StreamSupport.stream;
+import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 
 import java.util.ArrayList;
@@ -14,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -193,6 +195,17 @@ public final class CollectionUtils {
    */
   public static <T> Stream<T> toStreamSafe(List<T> nullableList) {
     return (nullableList != null && !nullableList.isEmpty()) ? nullableList.stream() : empty();
+  }
+
+  /**
+   * Return the last element of the given list.
+   *
+   * @param list - list to process as {@link List} object
+   * @param <T> - generic type for list elements
+   * @return {@link Optional} of the latest element of the list, it will be empty if the given list is empty.
+   */
+  public static <T> Optional<T> findLast(List<T> list) {
+    return isEmpty(list) ? Optional.empty() : Optional.ofNullable(list.get(list.size() - 1));
   }
 
   /**

--- a/src/test/java/org/folio/search/integration/ResourceFetchServiceTest.java
+++ b/src/test/java/org/folio/search/integration/ResourceFetchServiceTest.java
@@ -2,6 +2,8 @@ package org.folio.search.integration;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.domain.dto.ResourceEventType.CREATE;
+import static org.folio.search.domain.dto.ResourceEventType.UPDATE;
 import static org.folio.search.model.client.CqlQuery.exactMatchAny;
 import static org.folio.search.model.service.ResultList.asSinglePage;
 import static org.folio.search.utils.JsonConverter.MAP_TYPE_REFERENCE;
@@ -40,7 +42,7 @@ class ResourceFetchServiceTest {
   @Mock private InventoryViewClient inventoryClient;
 
   @Test
-  void fetchInstancesByIdPositive() {
+  void fetchInstancesById_positive() {
     var events = resourceEvents();
     var instanceId1 = events.get(0).getId();
     var instanceId2 = events.get(1).getId();
@@ -49,16 +51,54 @@ class ResourceFetchServiceTest {
     var instance2 = instanceView(new Instance().id(instanceId2).title("inst2")
       .holdings(List.of(new Holding().id("holdingId"))).items(List.of(new Item().id("itemId"))), true);
 
+    when(executionService.executeTenantScoped(any(), any())).thenAnswer(inv -> inv.<Callable<?>>getArgument(1).call());
     when(inventoryClient.getInstances(exactMatchAny("id", List.of(instanceId1, instanceId2)), 2))
       .thenReturn(asSinglePage(List.of(instance1, instance2)));
-    when(executionService.executeTenantScoped(any(), any())).thenAnswer(inv -> inv.<Callable<?>>getArgument(1).call());
 
     var actual = resourceFetchService.fetchInstancesByIds(events);
 
     assertThat(actual).isEqualTo(List.of(
       resourceEvent(instanceId1, INSTANCE_RESOURCE, mapOf("id", instanceId1, "title", "inst1", "isBoundWith", null)),
-      resourceEvent(instanceId2, INSTANCE_RESOURCE, mapOf("id", instanceId2, "title", "inst2",
-        "holdings", List.of(mapOf("id", "holdingId")), "items", List.of(mapOf("id", "itemId")), "isBoundWith", true))));
+      resourceEvent(instanceId2, INSTANCE_RESOURCE, UPDATE,
+        mapOf("id", instanceId2, "title", "inst2",
+          "holdings", List.of(mapOf("id", "holdingId")), "items", List.of(mapOf("id", "itemId")), "isBoundWith", true),
+        mapOf("id", instanceId2, "title", "old"))
+    ));
+  }
+
+  @Test
+  void fetchInstancesById_negative_oneOfResourcesByIdIsNotFound() {
+    var events = resourceEvents();
+    var instanceId1 = events.get(0).getId();
+    var instanceId2 = events.get(1).getId();
+    var instanceView = instanceView(new Instance().id(instanceId1).title("inst1"), null);
+
+    when(executionService.executeTenantScoped(any(), any())).thenAnswer(inv -> inv.<Callable<?>>getArgument(1).call());
+    when(inventoryClient.getInstances(exactMatchAny("id", List.of(instanceId1, instanceId2)), 2))
+      .thenReturn(asSinglePage(List.of(instanceView)));
+
+    var actual = resourceFetchService.fetchInstancesByIds(events);
+    assertThat(actual).isEqualTo(List.of(
+      resourceEvent(instanceId1, INSTANCE_RESOURCE, mapOf("id", instanceId1, "title", "inst1", "isBoundWith", null))
+    ));
+  }
+
+  @Test
+  void fetchInstancesById_negative_resourceReturnedWithInvalidId() {
+    var id = randomId();
+    var resourceEvent = resourceEvent(id, INSTANCE_RESOURCE, UPDATE,
+      mapOf("id", id, "title", "new"), mapOf("id", id, "title", "old"));
+    var invalidId = randomId();
+    var instanceView = instanceView(new Instance().id(invalidId).title("inst1"), null);
+
+    when(executionService.executeTenantScoped(any(), any())).thenAnswer(inv -> inv.<Callable<?>>getArgument(1).call());
+    when(inventoryClient.getInstances(exactMatchAny("id", List.of(id)), 1))
+      .thenReturn(asSinglePage(List.of(instanceView)));
+
+    var actual = resourceFetchService.fetchInstancesByIds(List.of(resourceEvent));
+    assertThat(actual).isEqualTo(List.of(
+      resourceEvent(invalidId, INSTANCE_RESOURCE, mapOf("id", invalidId, "title", "inst1", "isBoundWith", null))
+    ));
   }
 
   @Test
@@ -68,10 +108,13 @@ class ResourceFetchServiceTest {
   }
 
   private static List<ResourceEvent> resourceEvents() {
+    var updateEventId = randomId();
     return List.of(
-      resourceEvent(randomId(), INSTANCE_RESOURCE, null),
-      resourceEvent(randomId(), INSTANCE_RESOURCE, null),
-      resourceEvent(randomId(), RESOURCE_NAME, null));
+      resourceEvent(randomId(), INSTANCE_RESOURCE, CREATE),
+      resourceEvent(updateEventId, INSTANCE_RESOURCE, UPDATE,
+        mapOf("id", updateEventId, "title", "new"),
+        mapOf("id", updateEventId, "title", "old")),
+      resourceEvent(randomId(), RESOURCE_NAME, CREATE));
   }
 
   private static InstanceView instanceView(Instance instance, Boolean isBoundWith) {

--- a/src/test/java/org/folio/search/support/api/InventoryApi.java
+++ b/src/test/java/org/folio/search/support/api/InventoryApi.java
@@ -2,16 +2,19 @@ package org.folio.search.support.api;
 
 import static java.util.Collections.emptyMap;
 import static org.apache.commons.collections.MapUtils.getString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.domain.dto.ResourceEventType.CREATE;
 import static org.folio.search.domain.dto.ResourceEventType.DELETE;
-import static org.folio.search.utils.JsonConverter.MAP_TYPE_REFERENCE;
+import static org.folio.search.domain.dto.ResourceEventType.UPDATE;
 import static org.folio.search.utils.SearchUtils.INSTANCE_HOLDING_FIELD_NAME;
 import static org.folio.search.utils.SearchUtils.INSTANCE_ITEM_FIELD_NAME;
 import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
 import static org.folio.search.utils.TestConstants.inventoryHoldingTopic;
 import static org.folio.search.utils.TestConstants.inventoryInstanceTopic;
 import static org.folio.search.utils.TestConstants.inventoryItemTopic;
-import static org.folio.search.utils.TestUtils.OBJECT_MAPPER;
+import static org.folio.search.utils.TestUtils.kafkaResourceEvent;
 import static org.folio.search.utils.TestUtils.resourceEvent;
+import static org.folio.search.utils.TestUtils.toMap;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.util.LinkedHashMap;
@@ -21,10 +24,10 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.folio.search.domain.dto.Instance;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -40,52 +43,31 @@ public class InventoryApi {
   private final KafkaTemplate<String, Object> kafkaTemplate;
 
   public void createInstance(String tenantId, Instance instance) {
-    createInstance(tenantId, OBJECT_MAPPER.convertValue(instance, MAP_TYPE_REFERENCE));
+    createInstance(tenantId, toMap(instance));
   }
 
   public void createInstance(String tenantId, Map<String, Object> instance) {
     var instanceId = getString(instance, "id");
     INSTANCE_STORE.computeIfAbsent(tenantId, k -> new LinkedHashMap<>()).put(instanceId, instance);
 
-    kafkaTemplate.send(inventoryInstanceTopic(tenantId), instanceId, resourceEvent(null, instance).tenant(tenantId));
+    var instanceEvent = kafkaResourceEvent(tenantId, CREATE, instance, null);
+    kafkaTemplate.send(inventoryInstanceTopic(tenantId), instanceId, instanceEvent);
     createNestedResources(instance, INSTANCE_HOLDING_FIELD_NAME, hr -> createHolding(tenantId, instanceId, hr));
     createNestedResources(instance, INSTANCE_ITEM_FIELD_NAME, item -> createItem(tenantId, instanceId, item));
   }
 
-  @SuppressWarnings("unchecked")
-  private void createNestedResources(Map<String, Object> instance, String key, Consumer<Map<String, Object>> consumer) {
-    var items = (List<Map<String, Object>>) MapUtils.getObject(instance, key);
-    if (items != null) {
-      items.forEach(consumer);
-    }
+  public void updateInstance(String tenantId, Instance instance) {
+    updateInstance(tenantId, toMap(instance));
   }
 
-  public void createHolding(String tenant, String instanceId, Map<String, Object> holding) {
-    var event = new HoldingEvent(holding, instanceId);
-    HOLDING_STORE.computeIfAbsent(tenant, k -> new LinkedHashMap<>()).put(getString(holding, ID_FIELD), event);
-    kafkaTemplate.send(inventoryHoldingTopic(tenant), instanceId,
-      resourceEvent(INSTANCE_RESOURCE, event).tenant(tenant));
-  }
+  public void updateInstance(String tenantId, Map<String, Object> instance) {
+    var instanceId = getString(instance, "id");
+    var previousInstance = INSTANCE_STORE.getOrDefault(tenantId, emptyMap()).get(instanceId);
+    assertThat(previousInstance).isNotNull();
+    INSTANCE_STORE.computeIfAbsent(tenantId, k -> new LinkedHashMap<>()).put(instanceId, instance);
 
-  public void createItem(String tenant, String instanceId, Map<String, Object> item) {
-    var event = new ItemEvent(item, instanceId);
-    ITEM_STORE.computeIfAbsent(tenant, k -> new LinkedHashMap<>()).put(getString(item, ID_FIELD), event);
-    kafkaTemplate.send(inventoryItemTopic(tenant), instanceId,
-      resourceEvent(INSTANCE_RESOURCE, event).tenant(tenant));
-  }
-
-  public void deleteItem(String tenant, String id) {
-    var item = ITEM_STORE.get(tenant).remove(id);
-
-    kafkaTemplate.send(inventoryItemTopic(tenant), item.getInstanceId(),
-      resourceEvent(INSTANCE_RESOURCE, null).old(item).tenant(tenant).type(DELETE));
-  }
-
-  public void deleteHolding(String tenant, String id) {
-    var hr = HOLDING_STORE.get(tenant).remove(id);
-
-    kafkaTemplate.send(inventoryHoldingTopic(tenant), hr.getInstanceId(),
-      resourceEvent(INSTANCE_RESOURCE, null).old(hr).tenant(tenant).type(DELETE));
+    var instanceEvent = kafkaResourceEvent(tenantId, UPDATE, instance, previousInstance);
+    kafkaTemplate.send(inventoryInstanceTopic(tenantId), instanceId, instanceEvent);
   }
 
   public void deleteInstance(String tenant, String id) {
@@ -93,6 +75,38 @@ public class InventoryApi {
 
     kafkaTemplate.send(inventoryInstanceTopic(tenant), getString(instance, ID_FIELD),
       resourceEvent(INSTANCE_RESOURCE, null).old(instance).tenant(tenant).type(DELETE));
+  }
+
+  public void createHolding(String tenant, String instanceId, Map<String, Object> holding) {
+    var event = new HoldingEvent(holding, instanceId);
+    HOLDING_STORE.computeIfAbsent(tenant, k -> new LinkedHashMap<>()).put(getString(holding, ID_FIELD), event);
+    kafkaTemplate.send(inventoryHoldingTopic(tenant), instanceId, kafkaResourceEvent(tenant, CREATE, event, null));
+  }
+
+  public void deleteHolding(String tenant, String id) {
+    var holdingRecord = HOLDING_STORE.get(tenant).remove(id);
+    var resourceEvent = kafkaResourceEvent(tenant, DELETE, null, holdingRecord);
+    kafkaTemplate.send(inventoryHoldingTopic(tenant), holdingRecord.getInstanceId(), resourceEvent);
+  }
+
+  public void createItem(String tenant, String instanceId, Map<String, Object> item) {
+    var event = new ItemEvent(item, instanceId);
+    ITEM_STORE.computeIfAbsent(tenant, k -> new LinkedHashMap<>()).put(getString(item, ID_FIELD), event);
+    kafkaTemplate.send(inventoryItemTopic(tenant), instanceId, kafkaResourceEvent(tenant, CREATE, event, null));
+  }
+
+  public void deleteItem(String tenant, String id) {
+    var item = ITEM_STORE.get(tenant).remove(id);
+    var resourceEvent = kafkaResourceEvent(tenant, DELETE, null, item);
+    kafkaTemplate.send(inventoryItemTopic(tenant), item.getInstanceId(), resourceEvent);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void createNestedResources(Map<String, Object> instance, String key, Consumer<Map<String, Object>> consumer) {
+    var resourcesByKey = (List<Map<String, Object>>) MapUtils.getObject(instance, key);
+    if (CollectionUtils.isNotEmpty(resourcesByKey)) {
+      resourcesByKey.forEach(consumer);
+    }
   }
 
   public static Optional<Map<String, Object>> getInventoryView(String tenant, String id) {
@@ -131,7 +145,6 @@ public class InventoryApi {
   @Data
   @AllArgsConstructor
   @NoArgsConstructor
-  @Builder
   private static class ItemEvent {
 
     @JsonUnwrapped

--- a/src/test/java/org/folio/search/utils/CollectionUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/CollectionUtilsTest.java
@@ -1,5 +1,6 @@
 package org.folio.search.utils;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -19,6 +20,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.folio.search.utils.types.UnitTest;
@@ -154,6 +156,13 @@ class CollectionUtilsTest {
     assertThat(actual).isInstanceOf(LinkedHashMap.class).isEqualTo(mapOf(1, "1", 2, "2"));
   }
 
+  @ParameterizedTest
+  @MethodSource("findLastElementDataProvider")
+  void findLastElement(List<Object> list, Object expected) {
+    var actual = CollectionUtils.findLast(list);
+    assertThat(actual).isEqualTo(Optional.ofNullable(expected));
+  }
+
   private static Stream<Arguments> getValueByPathTestDataProvider() {
     var map = unstructuredMap();
     return Stream.of(
@@ -195,6 +204,17 @@ class CollectionUtilsTest {
         mapOf("k81", List.of(mapOf("k811", "str1"), mapOf("k811", "str2"))),
         mapOf("k81", List.of(mapOf("k811", "str3")))),
       "k9", List.of(mapOf("k91", "str1"), List.of("str2"), mapOf("k91", mapOf("k911", "str3")), mapOf("k91", "str4"))
+    );
+  }
+
+  private static Stream<Arguments> findLastElementDataProvider() {
+    return Stream.of(
+      arguments(null, null),
+      arguments(emptyList(), null),
+      arguments(asList(1, 2, 3), 3),
+      arguments(List.of(1), 1),
+      arguments(List.of("string"), "string"),
+      arguments(asList(null, null, null), null)
     );
   }
 }

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -211,6 +211,10 @@ public class TestUtils {
     return SearchDocumentBody.of(EMPTY_OBJECT, resourceEvent(), INDEX);
   }
 
+  public static SearchDocumentBody searchDocumentBody(String rawJson) {
+    return SearchDocumentBody.of(rawJson, resourceEvent(), INDEX);
+  }
+
   public static SearchDocumentBody searchDocumentBodyToDelete() {
     return SearchDocumentBody.of(null, resourceEvent(), DELETE);
   }
@@ -354,6 +358,14 @@ public class TestUtils {
 
   public static ResourceEvent resourceEvent(String id, String resource, ResourceEventType type, Object n, Object o) {
     return new ResourceEvent().id(id).type(type).resourceName(resource).tenant(TENANT_ID)._new(n).old(o);
+  }
+
+  public static ResourceEvent kafkaResourceEvent(ResourceEventType type, Object newData, Object oldData) {
+    return kafkaResourceEvent(TENANT_ID, type, newData, oldData);
+  }
+
+  public static ResourceEvent kafkaResourceEvent(String tenant, ResourceEventType type, Object n, Object o) {
+    return new ResourceEvent().type(type).tenant(tenant)._new(n).old(o);
   }
 
   @SafeVarargs


### PR DESCRIPTION
### Purpose
This pull-request fixing issue was noticed in the rancher environment when update events have been ignored

### Approach
- Refactor the ResourceFetchService to pass further the old body within the new resource event
- Fix issue when ResourceService ignores UPDATE events
- Add integration test to verify that update operation works correctly
