### PR TITLE
MSEARCH-288 Update Authority Search Options - Keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ if it is defined but doesn't match.
 
 | Option                  |   Type    | Example                                      | Description                                                                      |
 |:------------------------|:---------:|:---------------------------------------------|:---------------------------------------------------------------------------------|
-| `keyword`               | full-text | `keyword all "web semantic"`                 | An alias for: `personalName`, `sftpersonalName`, `saftPersonalName` and so forth |
+| `keyword`               | full-text | `keyword all "web semantic"`                 | An alias for: `identifiers`, `personalNameTitle`, `sftpersonalNameTitle`, `saftpersonalNameTitle`, `corporateNameTitle`, `sftcorporateNameTitle`, `saftcorporateNameTitle`, `meetingNameTitle`, `sftmeetingNameTitle`, `saftmeetingNameTitle`, `uniformTitle`, `sftUniformTitle`, `saftUniformTitle`, `topicalTerm`, `sftTopicalTerm`, `saftTopicalTerm`, `geographicName`, `sftGeographicTerm`, `saftGeographicTerm`, `genreTerm`, `sftGenreTerm`, `saftGenreTerm` |
 | `id`                    |   term    | `id=="1234567"`                              | Matches authorities with the id                                                  |
 | `headingType`           |   term    | `headingType == "Personal Name"`             | Matches authorities with `Personal Name` heading type                            |
 | `authRefType`           |   term    | `authRefType == "Authorized"`                | Matches authorities with `Authorized` auth/ref type                              |
@@ -454,9 +454,9 @@ if it is defined but doesn't match.
 | `geographicName`        | full-text | `geographicName == "geographic name"`        | Matches authorities with `geographic name` geographic name                       |
 | `sftGeographicTerm`     | full-text | `sftGeographicTerm == "geographic name"`     | Matches authorities with `geographic name` sft geographic term                   |
 | `saftGeographicTerm`    | full-text | `saftGeographicTerm == "geographic name"`    | Matches authorities with `geographic name` saft geographic term                  |
-| `uniformTitle`          |   term    | `uniformTitle == "an uniform title"`         | Matches authorities with `an uniform title` uniform title                        |
-| `sftUniformTitle`       |   term    | `sftUniformTitle == "an uniform title"`      | Matches authorities with `an uniform title` sft uniform title                    |
-| `saftUniformTitle`      |   term    | `saftUniformTitle == "an uniform title"`     | Matches authorities with `an uniform title` saft uniform title                   |
+| `uniformTitle`          | full-text | `uniformTitle == "an uniform title"`         | Matches authorities with `an uniform title` uniform title                        |
+| `sftUniformTitle`       | full-text | `sftUniformTitle == "an uniform title"`      | Matches authorities with `an uniform title` sft uniform title                    |
+| `saftUniformTitle`      | full-text | `saftUniformTitle == "an uniform title"`     | Matches authorities with `an uniform title` saft uniform title                   |
 | `lccn`                  |   term    | `lccn = "LCCN"`                              | Matches authorities with the given lccn                                          |
 | `identifiers.value`     |   term    | `identifiers.value = "1023*"`                | Matches authorities with the given identifier value                              |
 | `metadata.createdDate`  |   term    | `metadata.createdDate > "2020-12-12"`        | Matches authorities that were created after `2020-12-12`                         |

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -12,7 +12,6 @@
     "personalName": {
       "type": "authority",
       "index": "standard",
-      "inventorySearchTypes": "keyword",
       "distinctType": "personalName",
       "headingType": "Personal Name",
       "authRefType": "Authorized"
@@ -20,7 +19,6 @@
     "sftPersonalName": {
       "type": "authority",
       "index": "standard",
-      "inventorySearchTypes": "keyword",
       "distinctType": "sftPersonalName",
       "headingType": "Personal Name",
       "authRefType": "Reference"
@@ -28,7 +26,6 @@
     "saftPersonalName": {
       "type": "authority",
       "index": "standard",
-      "inventorySearchTypes": "keyword",
       "distinctType": "saftPersonalName",
       "headingType": "Personal Name",
       "authRefType": "Auth/Ref"
@@ -36,6 +33,7 @@
     "personalNameTitle": {
       "type": "authority",
       "index": "standard",
+      "inventorySearchTypes": "keyword",
       "distinctType": "personalNameTitle",
       "headingType": "Personal Name",
       "authRefType": "Authorized"
@@ -43,6 +41,7 @@
     "sftPersonalNameTitle": {
       "type": "authority",
       "index": "standard",
+      "inventorySearchTypes": "keyword",
       "distinctType": "sftPersonalNameTitle",
       "headingType": "Personal Name",
       "authRefType": "Reference"
@@ -58,7 +57,6 @@
     "corporateName": {
       "type": "authority",
       "index": "standard",
-      "inventorySearchTypes": "keyword",
       "distinctType": "corporateName",
       "headingType": "Corporate Name",
       "authRefType": "Authorized"
@@ -66,7 +64,6 @@
     "sftCorporateName": {
       "type": "authority",
       "index": "standard",
-      "inventorySearchTypes": "keyword",
       "distinctType": "sftCorporateName",
       "headingType": "Corporate Name",
       "authRefType": "Reference"
@@ -74,7 +71,6 @@
     "saftCorporateName": {
       "type": "authority",
       "index": "standard",
-      "inventorySearchTypes": "keyword",
       "distinctType": "saftCorporateName",
       "headingType": "Corporate Name",
       "authRefType": "Auth/Ref"
@@ -82,6 +78,7 @@
     "corporateNameTitle": {
       "type": "authority",
       "index": "standard",
+      "inventorySearchTypes": "keyword",
       "distinctType": "corporateNameTitle",
       "headingType": "Corporate Name",
       "authRefType": "Authorized"
@@ -89,6 +86,7 @@
     "sftCorporateNameTitle": {
       "type": "authority",
       "index": "standard",
+      "inventorySearchTypes": "keyword",
       "distinctType": "sftCorporateNameTitle",
       "headingType": "Corporate Name",
       "authRefType": "Reference"
@@ -104,7 +102,6 @@
     "meetingName": {
       "type": "authority",
       "index": "standard",
-      "inventorySearchTypes": "keyword",
       "distinctType": "meetingName",
       "headingType": "Conference Name",
       "authRefType": "Authorized"
@@ -112,7 +109,6 @@
     "sftMeetingName": {
       "type": "authority",
       "index": "standard",
-      "inventorySearchTypes": "keyword",
       "distinctType": "sftMeetingName",
       "headingType": "Conference Name",
       "authRefType": "Reference"
@@ -120,7 +116,6 @@
     "saftMeetingName": {
       "type": "authority",
       "index": "standard",
-      "inventorySearchTypes": "keyword",
       "distinctType": "saftMeetingName",
       "headingType": "Conference Name",
       "authRefType": "Auth/Ref"
@@ -128,6 +123,7 @@
     "meetingNameTitle": {
       "type": "authority",
       "index": "standard",
+      "inventorySearchTypes": "keyword",
       "distinctType": "meetingNameTitle",
       "headingType": "Conference Name",
       "authRefType": "Authorized"
@@ -184,6 +180,7 @@
       "type": "authority",
       "index": "standard",
       "distinctType": "sftUniformTitle",
+      "inventorySearchTypes": "keyword",
       "headingType": "Uniform Title",
       "authRefType": "Reference"
     },
@@ -191,6 +188,7 @@
       "type": "authority",
       "index": "standard",
       "distinctType": "saftUniformTitle",
+      "inventorySearchTypes": "keyword",
       "headingType": "Uniform Title",
       "authRefType": "Auth/Ref"
     },

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -104,7 +104,27 @@ class SearchAuthorityIT extends BaseIntegrationTest {
 
   private static Stream<Arguments> testDataProvider() {
     return Stream.of(
-      arguments("keyword all {value}", "\"Gary A. Wills\""),
+      arguments("keyword == {value}", "\"a personal title\""),
+      arguments("keyword all {value}", "\"a sft personal title\""),
+      arguments("keyword all {value}", "\"a saft personal title\""),
+      arguments("keyword == {value}", "\"a corporate title\""),
+      arguments("keyword all {value}", "\"a sft corporate title\""),
+      arguments("keyword all {value}", "\"a saft corporate title\""),
+      arguments("keyword == {value}", "\"a conference title\""),
+      arguments("keyword all {value}", "\"a sft conference title\""),
+      arguments("keyword all {value}", "\"a saft conference title\""),
+      arguments("keyword == {value}", "\"a geographic name\""),
+      arguments("keyword all {value}", "\"a sft geographic name\""),
+      arguments("keyword all {value}", "\"a saft geographic name\""),
+      arguments("keyword == {value}", "\"an uniform title\""),
+      arguments("keyword all {value}", "\"a sft uniform title\""),
+      arguments("keyword all {value}", "\"a saft uniform title\""),
+      arguments("keyword == {value}", "\"a topical term\""),
+      arguments("keyword all {value}", "\"a sft topical term\""),
+      arguments("keyword all {value}", "\"a saft topical term\""),
+      arguments("keyword == {value}", "\"a genre term\""),
+      arguments("keyword all {value}", "\"a sft genre term\""),
+      arguments("keyword all {value}", "\"a saft genre term\""),
 
       arguments("personalName all {value}", "\"Gary A. Wills\""),
       arguments("personalName all {value}", "gary"),


### PR DESCRIPTION
### Purpose
Update Authority Search Options - Keyword
Check that all fields are included into keyword search option:

Authority field
identifiers
personalNameTitle
sftpersonalNameTitle
saftpersonalNameTitle
corporateNameTitle
sftcorporateNameTitle
saftcorporateNameTitle
meetingNameTitle
sftmeetingNameTitle
saftmeetingNameTitle
uniformTitle
sftUniformTitle
saftUniformTitle
topicalTerm
sftTopicalTerm
saftTopicalTerm
geographicName
sftGeographicTerm
saftGeographicTerm
genreTerm
sftGenreTerm
saftGenreTerm

### Approach
 * Update authority index model
 * Update integration test
 * Update documentation