### PR TITLE
FAT-1150 Update module descriptors to correctly delete tenant

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -137,7 +137,7 @@
     },
     {
       "id": "_tenant",
-      "version": "1.2",
+      "version": "2.0",
       "interfaceType": "system",
       "handlers": [
         {
@@ -160,7 +160,7 @@
         },
         {
           "methods": [ "DELETE", "GET" ],
-          "pathPattern": "/_/tenant"
+          "pathPattern": "/_/tenant/{id}"
         }
       ]
     }


### PR DESCRIPTION
### Purpose
Delete tenant operation works incorrectly because module-descirptor.json contains an invalid version of tenant API

### Approach
- Fix the tenant API version in ModuleDescriptor-template.json