### PR TITLE
MSEARCH-298 Remove backward compatibility search options

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,14 +398,6 @@ if it is defined but doesn't match.
 | `holdings.metadata.createdDate`        |   term    | `metadata.createdDate > "2020-12-12"`                | Matches instances with holdings that were created after  `2020-12-12`                                  |
 | `holdings.metadata.updatedDate`        |   term    | `metadata.updatedDate > "2020-12-12"`                | Matches instances with holdings that were updated after  `2020-12-12`                                  |
 
-### Holdings-records backward compatibility search options (Should be removed)
-
-| Option                    | New option            |   Type    | Example                                             | Description                                                                                            |
-|:--------------------------|:----------------------|:---------:|:----------------------------------------------------|:-------------------------------------------------------------------------------------------------------|
-| `holdingTags`             | `holdingsTags`        |   term    | `holdingTags=="important"`                          | Matches instances that have holdings with given tags                                                   |
-| `holdingPublicNotes`      | `holdingsPublicNotes` | full-text | `holdingPublicNotes all "public note"`              | Search by holdings public notes                                                                        |
-| `holdingIdentifiers`      | `holdingsIdentifiers` |   term    | `holdingIdentifiers == "ho00000000006"`             | Search by holdings Identifiers: `holdings.id`, `holdings.hrid`, `holdings.formerIds`                   |
-
 ### Items search options
 
 | Option                              |   Type    | Example                                                      | Description                                                                                                                   |
@@ -430,13 +422,6 @@ if it is defined but doesn't match.
 | `itemIdentifiers`                   |   term    | `itemIdentifiers all "81ae0f60-f2bc-450c-84c8-5a21096daed9"` | Search by item Identifiers: `items.id`, `items.hrid`, `items.formerIds`, `items.accessionNumber`, `items.itemIdentifier`      |
 | `items.metadata.createdDate`        |   term    | `metadata.createdDate > "2020-12-12"`                        | Matches instances with items that were created after  `2020-12-12`                                                            |
 | `items.metadata.updatedDate`        |   term    | `metadata.updatedDate > "2020-12-12"`                        | Matches instances with items that were updated after  `2020-12-12`                                                            |
-
-### Items backward compatibility search options (Should be removed)
-
-| Option                       | New option                  | Type | Example                              | Description                                                                                            |
-|:-----------------------------|:----------------------------|:----:|:-------------------------------------|:-------------------------------------------------------------------------------------------------------|
-| `itemsFullCallNumbers`       | `itemFullCallNumbers`       | term | `itemsFullCallNumbers="cn*434"`      | Matches instances that have items with given call number string (prefix + call number + suffix)        |
-| `itemsNormalizedCallNumbers` | `itemNormalizedCallNumbers` | term | `itemsNormalizedCallNumbers="cn434"` | Matches instances that have items with given call number and might not be formatted correctly          |
 
 ### Authority search options
 

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -481,10 +481,9 @@
       "index": "multilang",
       "processor": "itemPublicNotesProcessor"
     },
-    "holdingPublicNotes": {
+    "holdingsPublicNotes": {
       "type": "search",
       "index": "multilang",
-      "searchAliases": [ "holdingsPublicNotes" ],
       "processor": "holdingsPublicNotesProcessor"
     },
     "isbn": {
@@ -511,11 +510,10 @@
       "index": "keyword",
       "processor": "itemTagsProcessor"
     },
-    "holdingTags": {
+    "holdingsTags": {
       "searchTypes": [ "facet", "filter" ],
       "type": "search",
       "index": "keyword",
-      "searchAliases": [ "holdingsTags" ],
       "processor": "holdingsTagsProcessor"
     },
     "statisticalCodes": {
@@ -524,10 +522,10 @@
       "index": "keyword",
       "processor": "statisticalCodesProcessor"
     },
-    "itemsFullCallNumbers": {
+    "itemFullCallNumbers": {
       "type": "search",
       "index": "keyword",
-      "searchAliases": [ "items.effectiveCallNumberComponents", "items.fullCallNumber", "itemFullCallNumbers" ],
+      "searchAliases": [ "items.effectiveCallNumberComponents", "items.fullCallNumber" ],
       "processor": "effectiveCallNumberComponentsProcessor"
     },
     "holdingsFullCallNumbers": {
@@ -535,12 +533,6 @@
       "index": "keyword",
       "searchAliases": [ "holdings.fullCallNumber" ],
       "processor": "holdingsCallNumberComponentsProcessor"
-    },
-    "itemsNormalizedCallNumbers": {
-      "type": "search",
-      "index": "keyword",
-      "processor": "itemNormalizedCallNumbersProcessor",
-      "searchTermProcessor": "callNumberSearchTermProcessor"
     },
     "itemNormalizedCallNumbers": {
       "type": "search",
@@ -554,10 +546,9 @@
       "processor": "holdingsNormalizedCallNumbersProcessor",
       "searchTermProcessor": "callNumberSearchTermProcessor"
     },
-    "holdingIdentifiers": {
+    "holdingsIdentifiers": {
       "type": "search",
       "index": "keyword",
-      "searchAliases": [ "holdingsIdentifiers" ],
       "processor": "holdingsIdentifiersProcessor"
     },
     "itemIdentifiers": {

--- a/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
@@ -194,7 +194,6 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       arguments(format("(holdings.discoverySuppress==%s) sortby title", false), List.of(IDS[0], IDS[3], IDS[4])),
 
       arguments("(itemTags==itag1) sortby title", List.of(IDS[0], IDS[2])),
-      arguments("(holdingTags==htag1) sortby title", List.of(IDS[0], IDS[4])),
       arguments("(holdingsTags==htag1) sortby title", List.of(IDS[0], IDS[4])),
 
       arguments("(metadata.createdDate>= 2021-03-01) sortby title", List.of(IDS[0], IDS[1], IDS[2], IDS[3])),
@@ -333,9 +332,6 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       arguments("id=*", array("holdings.discoverySuppress"), mapOf(
         "holdings.discoverySuppress", facet(facetItem("false", 3),
           facetItem("true", 1)))),
-
-      arguments("id=*", array("holdingTags"), mapOf(
-        "holdingTags", facet(facetItem("htag2", 3), facetItem("htag1", 2), facetItem("htag3", 2)))),
 
       arguments("id=*", array("holdingsTags"), mapOf(
         "holdingsTags", facet(facetItem("htag2", 3), facetItem("htag1", 2), facetItem("htag3", 2)))),

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -232,15 +232,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("holdingsIdentifiers all {value}", "hold000000000009"),
       arguments("holdingsIdentifiers == {value}", "1d76ee84-d776-48d2-ab96-140c24e39ac5"),
       arguments("holdingsIdentifiers all {value}", "9b8ec096-fa2e-451b-8e7a-6d1c977ee946"),
-      arguments("holdingsIdentifiers all {value}", "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19"),
-
-      // Backward compatibility
-      arguments("holdingIdentifiers all {value}", "hold000000000009"),
-      arguments("holdingIdentifiers == {value}", "1d76ee84-d776-48d2-ab96-140c24e39ac5"),
-      arguments("holdingIdentifiers all {value}", "9b8ec096-fa2e-451b-8e7a-6d1c977ee946"),
-      arguments("holdingIdentifiers all {value}", "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19"),
-
-      arguments("holdingPublicNotes all {value}", "bibliographical references")
+      arguments("holdingsIdentifiers all {value}", "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19")
       );
   }
 }

--- a/src/test/java/org/folio/search/controller/SearchItemIT.java
+++ b/src/test/java/org/folio/search/controller/SearchItemIT.java
@@ -38,15 +38,6 @@ class SearchItemIT extends BaseIntegrationTest {
     "itemNormalizedCallNumbers=={value}, tk510588815",
     "itemNormalizedCallNumbers=={value}, TK5105.88815.A58 2004 FT MEADE suffix-90000",
     "itemNormalizedCallNumbers=={value}, TK510588815A582004FT MEADE suffix90000",
-    "itemsNormalizedCallNumbers=={value}, prefix-90000",
-    "itemsNormalizedCallNumbers=={value}, prefix90000",
-    "itemsNormalizedCallNumbers=={value}, prefix.9",
-    "itemsNormalizedCallNumbers=={value}, TK5105.88815.A58 2004 FT MEADE",
-    "itemsNormalizedCallNumbers=={value}, TK5105.88815",
-    "itemsNormalizedCallNumbers=={value}, prefix90000 TK510588815",
-    "itemsNormalizedCallNumbers=={value}, tk510588815",
-    "itemsNormalizedCallNumbers=={value}, TK5105.88815.A58 2004 FT MEADE suffix-90000",
-    "itemsNormalizedCallNumbers=={value}, TK510588815A582004FT MEADE suffix90000",
   })
   @ParameterizedTest(name = "[{index}] {0}: {1}")
   void canSearchByItems_wildcardMatch(String query, String value) throws Throwable {
@@ -63,13 +54,6 @@ class SearchItemIT extends BaseIntegrationTest {
     "itemNormalizedCallNumbers=={value}, prefix TK510588815",
     "itemNormalizedCallNumbers=={value}, 510588815",
     "itemNormalizedCallNumbers=={value}, TK5105.88815.A58 2004 FT MEADE 90000",
-    "itemsNormalizedCallNumbers=={value}, fix-90000",
-    "itemsNormalizedCallNumbers=={value}, 90000",
-    "itemsNormalizedCallNumbers=={value}, 88815.A58 2004 FT MEADE",
-    "itemsNormalizedCallNumbers=={value}, 88815 suffix90000",
-    "itemsNormalizedCallNumbers=={value}, prefix TK510588815",
-    "itemsNormalizedCallNumbers=={value}, 510588815",
-    "itemsNormalizedCallNumbers=={value}, TK5105.88815.A58 2004 FT MEADE 90000",
   })
   @ParameterizedTest(name = "[{index}] {0}: {1}")
   void canSearchByItems_negative(String query, String value) throws Throwable {

--- a/src/test/java/org/folio/search/service/setter/item/ItemAllFieldValuesProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemAllFieldValuesProcessorTest.java
@@ -60,15 +60,13 @@ class ItemAllFieldValuesProcessorTest {
   void getFieldValue_holdingFieldsFromSearchGeneratedValues() {
     when(searchFieldProvider.isMultilangField(INSTANCE_RESOURCE, "itemPublicNotes")).thenReturn(true);
     when(searchFieldProvider.isMultilangField(INSTANCE_RESOURCE, "itemFullCallNumbers")).thenReturn(false);
-    when(searchFieldProvider.isMultilangField(INSTANCE_RESOURCE, "itemsFullCallNumbers")).thenReturn(false);
 
     var actual = processor.getFieldValue(mapOf(
       "itemPublicNotes", List.of("note1", "note2"),
-      "itemFullCallNumbers", List.of("callNumber1", "callNumber2"),
-       "itemsFullCallNumbers", List.of("callNumber3", "callNumber4")));
+      "itemFullCallNumbers", List.of("callNumber1", "callNumber2")));
 
     assertThat(actual).isEqualTo(MultilangValue.of(
-      newLinkedHashSet("callNumber1", "callNumber2", "callNumber3", "callNumber4"),
+      newLinkedHashSet("callNumber1", "callNumber2"),
       newLinkedHashSet("note1", "note2")));
   }
 


### PR DESCRIPTION
### Requirements/Scope:
Remove search aliases and rename fields:

- itemsFullCallNumbers  -> itemFullCallNumbers
- itemsNormalizedCallNumbers -> itemNormalizedCallNumbers
- holdingTags ->holdingsTags
- holdingPublicNotes -> holdingsPublicNotes
- holdingIdentifiers  -> holdingsIdentifiers

### Acceptance criteria:
- Updated documentation
- After renaming we should run reindex on all environments

### Learn
https://issues.folio.org/browse/MSEARCH-298
