### PR TITLE
MSEARCH-308 Optimize call-number browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ with less powerful configuration (see [High availability](https://www.elastic.co
 | SCROLL_QUERY_SIZE                         | 1000                      | The number of records to be loaded by each scroll query. 10_000 is a max value                                                                                                        |
 | STREAM_ID_RETRY_INTERVAL_MS               | 1000                      | Specifies time to wait before reattempting query.                                                                                                                                     |
 | STREAM_ID_RETRY_ATTEMPTS                  | 3                         | Specifies how many queries attempt to perform after the first one failed.                                                                                                             |
+| CN_BROWSE_OPTIMIZATION_ENABLED            | true                      | Defines if call-number browse optimization is enabled or not                                                                                                                          |
 
 The module uses system user to communicate with other modules from Kafka consumers.
 For production deployments you MUST specify the password for this system user via env variable:
@@ -413,6 +414,8 @@ if it is defined but doesn't match.
 | `itemNormalizedCallNumbers`         |   term    | `itemNormalizedCallNumbers="cn434"`                          | Matches instances that have items with given call number and might not be formatted correctly                                 |
 | `itemTags`                          |   term    | `itemTags="important"`                                       | Matches instances that have items with given tag                                                                              |
 | `items.electronicAccess`            | full-text | `items.electronicAccess any "resource"`                      | An alias for all `electronicAccess` fields - `uri`, `linkText`, `materialsSpecification`, `publicNote`                        |
+| `callNumber`                        |   term    | `callNumber="A 12"`                                          | An alias for search by `items.effectiveShelvingOrder` field                                                                   |
+| `items.effectiveShelvingOrder`      |   term    | `items.effectiveShelvingOrder="A 12"`                        | Matches instances that have items with given `effectiveShelvingOrder` value                                                   |
 | `items.electronicAccess.uri`        |   term    | `items.electronicAccess.uri="http://folio.org*"`             | Search by electronic access URI                                                                                               |
 | `items.electronicAccess.linkText`   | full-text | `items.electronicAccess.linkText="Folio website"`            | Search by electronic access link text                                                                                         |
 | `items.electronicAccess.publicNote` | full-text | `items.electronicAccess.publicNote="a rare book"`            | Search by electronic access public note                                                                                       |

--- a/src/main/java/org/folio/search/configuration/CacheConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/CacheConfiguration.java
@@ -1,0 +1,24 @@
+package org.folio.search.configuration;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.List;
+import org.folio.search.configuration.properties.SearchCacheConfigurationProperties;
+import org.folio.search.model.service.CallNumberBrowseRangeValue;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CacheConfiguration {
+
+  /**
+   * Creates a {@link Cache} bean for call-number browsing optimization.
+   *
+   * @return created {@link Cache} bean
+   */
+  @Bean
+  public Cache<String, List<CallNumberBrowseRangeValue>> callNumberRangesCache(
+    SearchCacheConfigurationProperties configuration) {
+    return Caffeine.from(configuration.getCallNumberBrowseRangesCacheSpec()).build();
+  }
+}

--- a/src/main/java/org/folio/search/configuration/properties/SearchCacheConfigurationProperties.java
+++ b/src/main/java/org/folio/search/configuration/properties/SearchCacheConfigurationProperties.java
@@ -1,0 +1,16 @@
+package org.folio.search.configuration.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "application.cache")
+public class SearchCacheConfigurationProperties {
+
+  /**
+   * Caffeine cache configuration as {@link String} for call-number browsing.
+   */
+  private String callNumberBrowseRangesCacheSpec;
+}

--- a/src/main/java/org/folio/search/configuration/properties/SearchQueryConfigurationProperties.java
+++ b/src/main/java/org/folio/search/configuration/properties/SearchQueryConfigurationProperties.java
@@ -17,4 +17,9 @@ public class SearchQueryConfigurationProperties {
    * Provides range query limit multiplier as double.
    */
   private double rangeQueryLimitMultiplier = 3d;
+
+  /**
+   * Defines if call-number browse optimization is enabled or not.
+   */
+  private boolean callNumberBrowseOptimizationEnabled = true;
 }

--- a/src/main/java/org/folio/search/controller/FolioTenantController.java
+++ b/src/main/java/org/folio/search/controller/FolioTenantController.java
@@ -41,7 +41,7 @@ public class FolioTenantController extends TenantController {
   @Override
   public void disableTenant() {
     super.disableTenant();
-    tenantService.removeElasticsearchIndexes();
+    tenantService.disableTenant();
   }
 
   private static boolean isDeleteJob(TenantAttributes tenantAttributes) {

--- a/src/main/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessor.java
@@ -16,11 +16,10 @@ import org.springframework.stereotype.Component;
 public class EffectiveShelvingOrderTermProcessor implements SearchTermProcessor {
 
   private static final Pattern DEWEY_NUMBER_PATTERN = Pattern.compile("\\d{4}(\\.\\d+)?(\\s.*)*");
-  private static final Pattern SIMPLE_DIGITS_PATTERN = Pattern.compile("\\d{1,2}\\s?");
   private static final Pattern SHELF_KEY_PATTERN =
     Pattern.compile("([A-Z]+)\\s(\\d{2,}(\\.\\d+)?)(\\s[A-Z]\\d{1,10}){0,2}(\\s.*)*");
 
-  private static final List<Pattern> PATTERNS = List.of(SHELF_KEY_PATTERN, DEWEY_NUMBER_PATTERN, SIMPLE_DIGITS_PATTERN);
+  private static final List<Pattern> PATTERNS = List.of(SHELF_KEY_PATTERN, DEWEY_NUMBER_PATTERN);
 
   @Override
   public String getSearchTerm(String inputTerm) {

--- a/src/main/java/org/folio/search/model/service/CallNumberBrowseRangeValue.java
+++ b/src/main/java/org/folio/search/model/service/CallNumberBrowseRangeValue.java
@@ -1,0 +1,31 @@
+package org.folio.search.model.service;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.lang.NonNull;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class CallNumberBrowseRangeValue implements Comparable<CallNumberBrowseRangeValue> {
+
+  /**
+   * Value for call number browse range cache.
+   */
+  private final String key;
+
+  /**
+   * Numeric representation of key.
+   */
+  private final long keyAsLong;
+
+  /**
+   * Amount of result above the current key and before the next one.
+   */
+  private final long count;
+
+  @Override
+  public int compareTo(@NonNull CallNumberBrowseRangeValue value) {
+    return StringUtils.compare(key, value.getKey());
+  }
+}

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseQueryProvider.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseQueryProvider.java
@@ -34,6 +34,7 @@ public class CallNumberBrowseQueryProvider {
   private final SearchFieldProvider searchFieldProvider;
   private final CallNumberTermConverter callNumberTermConverter;
   private final SearchQueryConfigurationProperties queryConfiguration;
+  private final CallNumberBrowseRangeService callNumberBrowseRangeService;
 
   /**
    * Creates query as {@link SearchSourceBuilder} object for call number browsing.
@@ -48,9 +49,9 @@ public class CallNumberBrowseQueryProvider {
     var script = new Script(INLINE, DEFAULT_SCRIPT_LANG, scriptCode, singletonMap("cn", ctx.getAnchor()));
 
     var multiplier = queryConfiguration.getRangeQueryLimitMultiplier();
-    var searchSource = searchSource().from(0)
-      .query(getQuery(ctx, isForwardBrowsing))
-      .size((int) (Math.max(MIN_QUERY_SIZE, Math.ceil(ctx.getLimit(isForwardBrowsing) * multiplier))))
+    var pageSize = (int) Math.max(MIN_QUERY_SIZE, Math.ceil(ctx.getLimit(isForwardBrowsing) * multiplier));
+    var searchSource = searchSource().from(0).size(pageSize)
+      .query(getQuery(ctx, request.getTenantId(), pageSize, isForwardBrowsing))
       .sort(scriptSort(script, STRING).order(isForwardBrowsing ? ASC : DESC));
 
     if (isFalse(request.getExpandAll())) {
@@ -61,10 +62,19 @@ public class CallNumberBrowseQueryProvider {
     return searchSource;
   }
 
-  private QueryBuilder getQuery(BrowseContext ctx, boolean isBrowsingForward) {
-    var callNumberAsLong = callNumberTermConverter.convert(ctx.getAnchor());
+  private QueryBuilder getQuery(BrowseContext ctx, String tenantId, int size, boolean isBrowsingForward) {
+    var anchor = ctx.getAnchor();
+    var callNumberAsLong = callNumberTermConverter.convert(anchor);
     var rangeQuery = rangeQuery(CALL_NUMBER_RANGE_FIELD);
     rangeQuery = isBrowsingForward ? rangeQuery.gte(callNumberAsLong) : rangeQuery.lte(callNumberAsLong);
+
+    if (queryConfiguration.isCallNumberBrowseOptimizationEnabled()) {
+      var boundary = callNumberBrowseRangeService
+        .getRangeBoundaryForBrowsing(tenantId, anchor, size, isBrowsingForward)
+        .orElse(null);
+      rangeQuery = isBrowsingForward ? rangeQuery.lte(boundary) : rangeQuery.gte(boundary);
+    }
+
     var filters = ctx.getFilters();
     if (filters.isEmpty()) {
       return rangeQuery;

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseRangeService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseRangeService.java
@@ -55,7 +55,7 @@ public class CallNumberBrowseRangeService {
   public Optional<Long> getRangeBoundaryForBrowsing(String tenant, String anchor, int size, boolean isBrowsingForward) {
     var ranges = getBrowseRanges(tenant);
     return isNotEmpty(ranges) && isRangeBoundaryCanBeProvided(anchor, isBrowsingForward, ranges)
-      ? Optional.ofNullable(getUpperRangeForBrowsingForward(ranges, anchor, size, isBrowsingForward))
+      ? Optional.ofNullable(getRangeBoundaryFromCachedValue(ranges, anchor, size, isBrowsingForward))
       : Optional.empty();
   }
 
@@ -138,7 +138,7 @@ public class CallNumberBrowseRangeService {
     return rangeAggregation;
   }
 
-  private static Long getUpperRangeForBrowsingForward(List<CallNumberBrowseRangeValue> ranges,
+  private static Long getRangeBoundaryFromCachedValue(List<CallNumberBrowseRangeValue> ranges,
     String anchor, int expectedPageSize, boolean isBrowsingForward) {
     var foundPosition = getClosestPosition(ranges, CallNumberBrowseRangeValue.of(anchor, 0, 0), isBrowsingForward);
     return isBrowsingForward

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseRangeService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseRangeService.java
@@ -1,0 +1,175 @@
+package org.folio.search.service.browse;
+
+import static java.lang.String.valueOf;
+import static java.util.Collections.emptyList;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.concat;
+import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
+import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.range;
+import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
+import static org.folio.search.service.browse.CallNumberBrowseQueryProvider.CALL_NUMBER_RANGE_FIELD;
+import static org.folio.search.utils.CollectionUtils.toLinkedHashMap;
+import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.aggregations.bucket.range.ParsedRange;
+import org.elasticsearch.search.aggregations.bucket.range.Range.Bucket;
+import org.elasticsearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator.Range;
+import org.folio.search.model.SimpleResourceRequest;
+import org.folio.search.model.service.CallNumberBrowseRangeValue;
+import org.folio.search.repository.SearchRepository;
+import org.folio.search.service.setter.instance.CallNumberProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CallNumberBrowseRangeService {
+
+  public static final String AGGREGATION_NAME = "cnRanges";
+  private final SearchRepository searchRepository;
+  private final CallNumberProcessor callNumberProcessor;
+  private final Cache<String, List<CallNumberBrowseRangeValue>> cache;
+
+  /**
+   * Get range boundary to optimize call-number browsing.
+   *
+   * @param tenant - tenant id to retrieve range facet if it's not loaded yet
+   * @param anchor - call-number browsing anchor as {@link String}
+   * @param size - requested page size for Elasticsearch query
+   * @param isBrowsingForward - browsing direction
+   * @return {@link Optional} of {@link Long} value as range boundary
+   */
+  public Optional<Long> getRangeBoundaryForBrowsing(String tenant, String anchor, int size, boolean isBrowsingForward) {
+    var ranges = getBrowseRanges(tenant);
+    return isNotEmpty(ranges) && isRangeBoundaryCanBeProvided(anchor, isBrowsingForward, ranges)
+      ? getUpperRangeForBrowsingForward(ranges, anchor, size, isBrowsingForward)
+      : Optional.empty();
+  }
+
+  /**
+   * Provides call-number ranges as {@link Map} object.
+   *
+   * @param tenantId - tenant id for call-number ranges retrieval
+   * @return {@link Map} with call-number ranges, where key is the lower boundary and the value is the amount of
+   *   resources after it
+   */
+  public List<CallNumberBrowseRangeValue> getBrowseRanges(String tenantId) {
+    return cache.get(tenantId, this::getCallNumberRanges);
+  }
+
+  /**
+   * Evicts cache for the given {@link String} tenant id.
+   *
+   * @param tenantId - tenant id as {@link String} object
+   */
+  public void evictRangeCache(String tenantId) {
+    cache.invalidate(tenantId);
+  }
+
+  private static boolean isRangeBoundaryCanBeProvided(
+    String anchor, boolean isBrowsingForward, List<CallNumberBrowseRangeValue> ranges) {
+    return anchor.compareTo(ranges.get(0).getKey()) > 0 && !isBrowsingForward
+      || anchor.compareTo(ranges.get(ranges.size() - 1).getKey()) < 0 && isBrowsingForward;
+  }
+
+  private List<CallNumberBrowseRangeValue> getCallNumberRanges(String tenantId) {
+    var callNumbersMap = concat(getCallNumbersRange('0', '9'), getCallNumbersRange('A', 'Z'))
+      .collect(toLinkedHashMap(identity(), callNumberProcessor::getCallNumberAsLong));
+    var searchSource = searchSource().from(0).size(0)
+      .query(existsQuery(CALL_NUMBER_RANGE_FIELD))
+      .aggregation(prepareRangeAggregation(callNumbersMap));
+    var searchResponse = searchRepository.search(SimpleResourceRequest.of(INSTANCE_RESOURCE, tenantId), searchSource);
+
+    return Optional.ofNullable(searchResponse)
+      .map(SearchResponse::getAggregations)
+      .map(aggs -> aggs.get(AGGREGATION_NAME))
+      .filter(ParsedRange.class::isInstance)
+      .map(ParsedRange.class::cast)
+      .map(ParsedRange::getBuckets)
+      .map(buckets -> mapBucketsToCacheValuesList(buckets, callNumbersMap))
+      .orElse(emptyList());
+  }
+
+  private static List<CallNumberBrowseRangeValue> mapBucketsToCacheValuesList(
+    List<? extends Bucket> buckets, Map<String, Long> callNumbersMap) {
+    return buckets.stream()
+      .map(bucket -> mapBucketToCacheValue(bucket, callNumbersMap))
+      .sorted()
+      .collect(toList());
+  }
+
+  private static CallNumberBrowseRangeValue mapBucketToCacheValue(Bucket bucket, Map<String, Long> callNumbers) {
+    var key = bucket.getKeyAsString();
+    var keyAsLong = callNumbers.get(key);
+    return CallNumberBrowseRangeValue.of(key, keyAsLong, bucket.getDocCount());
+  }
+
+  private static Stream<String> getCallNumbersRange(char lower, char upper) {
+    return IntStream.range(lower, upper + 1).mapToObj(character -> valueOf((char) character));
+  }
+
+  private static RangeAggregationBuilder prepareRangeAggregation(Map<String, Long> callNumbersMap) {
+    var rangeAggregation = range(AGGREGATION_NAME).field(CALL_NUMBER_RANGE_FIELD);
+    var callNumbers = new ArrayList<>(callNumbersMap.keySet());
+
+    for (int i = 0; i < callNumbers.size() - 1; i++) {
+      var current = callNumbers.get(i);
+      var next = callNumbers.get(i + 1);
+      rangeAggregation.addRange(new Range(current,
+        callNumbersMap.get(current).doubleValue(),
+        callNumbersMap.get(next).doubleValue()));
+    }
+
+    var lastCharacter = callNumbers.get(callNumbers.size() - 1);
+    rangeAggregation.addRange(new Range(lastCharacter, callNumbersMap.get(lastCharacter).doubleValue(), null));
+    return rangeAggregation;
+  }
+
+  private static Optional<Long> getUpperRangeForBrowsingForward(List<CallNumberBrowseRangeValue> ranges,
+    String anchor, int expectedPageSize, boolean isBrowsingForward) {
+    var foundPosition = getClosestPosition(ranges, CallNumberBrowseRangeValue.of(anchor, 0, 0), isBrowsingForward);
+    var loopCondition = (Predicate<Integer>) i -> isBrowsingForward ? i < ranges.size() : i >= 0;
+    var element = ranges.get(foundPosition);
+    var startPosition = foundPosition + getPositionOffset(element.getKey(), anchor, isBrowsingForward);
+    long sum = isBrowsingForward && Objects.equals(element.getKey(), anchor) ? element.getCount() : 0L;
+    for (int i = startPosition; loopCondition.test(i); i += isBrowsingForward ? 1 : -1) {
+      var current = ranges.get(i);
+      sum += current.getCount();
+      if (sum >= expectedPageSize) {
+        return Optional.of(current.getKeyAsLong());
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  private static int getPositionOffset(String foundValue, String anchor, boolean isBrowsingForward) {
+    if (isBrowsingForward) {
+      return 1;
+    }
+    return Objects.equals(foundValue, anchor) ? -1 : -2;
+  }
+
+  private static <T extends Comparable<T>> int getClosestPosition(List<T> list, T value, boolean isBrowsingForward) {
+    var foundPosition = Collections.binarySearch(list, value);
+    if (foundPosition >= 0) {
+      return foundPosition;
+    }
+    foundPosition = -foundPosition - (isBrowsingForward ? 1 : 2);
+    return Math.min(foundPosition, list.size() - 1);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,6 @@ spring:
       key-store-location: ${KAFKA_SSL_KEYSTORE_LOCATION:}
       trust-store-password: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:}
       trust-store-location: ${KAFKA_SSL_TRUSTSTORE_LOCATION:}
-
   datasource:
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:postgres}
@@ -47,6 +46,11 @@ application:
     indexing:
       instance-subjects:
         retry-attempts: ${INSTANCE_SUBJECTS_INDEXING_RETRY_ATTEMPTS:3}
+  query:
+    properties:
+      call-number-browse-optimization-enabled: ${CN_BROWSE_OPTIMIZATION_ENABLED:true}
+  cache:
+    call-number-browse-ranges-cache-spec: maximumSize=50,expireAfterAccess=300s
   system-user:
     username: mod-search
     password: ${SYSTEM_USER_PASSWORD:Mod-search-1-0-0}

--- a/src/test/java/org/folio/search/configuration/CacheConfigurationTest.java
+++ b/src/test/java/org/folio/search/configuration/CacheConfigurationTest.java
@@ -1,0 +1,27 @@
+package org.folio.search.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.folio.search.configuration.properties.SearchCacheConfigurationProperties;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class CacheConfigurationTest {
+
+  @InjectMocks private CacheConfiguration cacheConfiguration;
+  @Mock private SearchCacheConfigurationProperties cacheConfigurationProperties;
+
+  @Test
+  void createCallNumberRangesCache() {
+    when(cacheConfigurationProperties.getCallNumberBrowseRangesCacheSpec()).thenReturn("expireAfterAccess=5m");
+    var cache = cacheConfiguration.callNumberRangesCache(cacheConfigurationProperties);
+    assertThat(cache).isNotNull();
+  }
+}

--- a/src/test/java/org/folio/search/controller/CallNumberBrowseIT.java
+++ b/src/test/java/org/folio/search/controller/CallNumberBrowseIT.java
@@ -186,7 +186,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
       ))),
 
       // checks if collapsing by the same result works correctly
-      arguments(aroundIncludingQuery, "FC", 5, cnBrowseResult(47, List.of(
+      arguments(aroundIncludingQuery, "FC", 5, cnBrowseResult(43, List.of(
         cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
         cnBrowseItem(instance("instance #42"), "FA 46252 3977 12 237"),
         cnBrowseItem(0, "FC", null, true),
@@ -195,7 +195,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
       ))),
 
       // checks if collapsing by the same result works correctly
-      arguments(aroundIncludingQuery, "fc", 5, cnBrowseResult(47, List.of(
+      arguments(aroundIncludingQuery, "fc", 5, cnBrowseResult(43, List.of(
         cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
         cnBrowseItem(instance("instance #42"), "FA 46252 3977 12 237"),
         cnBrowseItem(0, "FC", null, true),
@@ -265,7 +265,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
       ))),
 
       // check that collapsing works for browsing backward
-      arguments(backwardQuery, "G", 5, cnBrowseResult(40, List.of(
+      arguments(backwardQuery, "G", 5, cnBrowseResult(32, List.of(
         cnBrowseItem(instance("instance #12"), "E 211 N52 VOL 14"),
         cnBrowseItem(instance("instance #27"), "F 43733 L370 41992"),
         cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),

--- a/src/test/java/org/folio/search/controller/FolioTenantControllerTest.java
+++ b/src/test/java/org/folio/search/controller/FolioTenantControllerTest.java
@@ -64,6 +64,6 @@ class FolioTenantControllerTest {
   void postTenant_positive_disableTenant() {
     tenantController.postTenant(new TenantAttributes().moduleFrom("mod-search").purge(true));
     verify(baseTenantService).deleteTenant();
-    verify(tenantService).removeElasticsearchIndexes();
+    verify(tenantService).disableTenant();
   }
 }

--- a/src/test/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessorTest.java
@@ -39,7 +39,8 @@ class EffectiveShelvingOrderTermProcessorTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"782", "123", "185.25", "350.21", "362.82/92 / 20", "591.52/63 / 20", "641.5943 M68l"})
+  @ValueSource(strings = {"782", "123", "185.25", "350.21", "362.82/92 / 20",
+    "591.52/63 / 20", "641.5943 M68l", "12", "11", "25", "1"})
   void getSearchTerm_parameterized_deweyDecimalNumbers(String given) {
     var expected = new DeweyCallNumber(given).getShelfKey();
     var actual = searchTermProcessor.getSearchTerm(given);
@@ -56,7 +57,7 @@ class EffectiveShelvingOrderTermProcessorTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"rack №1", "raw", "unknown", "12", "11", "25"})
+  @ValueSource(strings = {"rack №1", "raw", "unknown"})
   void getSearchTerm_parameterized_freeText(String given) {
     var actual = searchTermProcessor.getSearchTerm(given);
     assertThat(actual).isEqualTo(given.toUpperCase(Locale.ROOT));

--- a/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
+++ b/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import org.folio.search.configuration.properties.SearchConfigurationProperties;
 import org.folio.search.domain.dto.LanguageConfig;
 import org.folio.search.domain.dto.ReindexRequest;
+import org.folio.search.service.browse.CallNumberBrowseRangeService;
 import org.folio.search.service.metadata.ResourceDescriptionService;
 import org.folio.search.service.systemuser.SystemUserService;
 import org.folio.search.utils.types.UnitTest;
@@ -38,6 +39,7 @@ class SearchTenantServiceTest {
   @Mock private FolioExecutionContext context;
   @Mock private SystemUserService systemUserService;
   @Mock private LanguageConfigService languageConfigService;
+  @Mock private CallNumberBrowseRangeService callNumberBrowseRangeService;
   @Mock private ResourceDescriptionService resourceDescriptionService;
   @Mock private SearchConfigurationProperties searchConfigurationProperties;
 
@@ -107,11 +109,12 @@ class SearchTenantServiceTest {
   }
 
   @Test
-  void removeElasticsearchIndices_positive() {
+  void disableTenant_positive() {
     when(context.getTenantId()).thenReturn(TENANT_ID);
     when(resourceDescriptionService.getResourceNames()).thenReturn(List.of(RESOURCE_NAME));
+    doNothing().when(callNumberBrowseRangeService).evictRangeCache(TENANT_ID);
 
-    searchTenantService.removeElasticsearchIndexes();
+    searchTenantService.disableTenant();
 
     verify(indexService).dropIndex(RESOURCE_NAME, TENANT_ID);
     verifyNoMoreInteractions(indexService);

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseRangeServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseRangeServiceTest.java
@@ -1,0 +1,161 @@
+package org.folio.search.service.browse;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.JsonUtils.jsonArray;
+import static org.folio.search.utils.JsonUtils.jsonObject;
+import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.folio.search.utils.TestUtils.aggregationsFromJson;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.folio.search.model.SimpleResourceRequest;
+import org.folio.search.model.service.CallNumberBrowseRangeValue;
+import org.folio.search.repository.SearchRepository;
+import org.folio.search.service.setter.instance.CallNumberProcessor;
+import org.folio.search.utils.types.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.lang.NonNull;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class CallNumberBrowseRangeServiceTest {
+
+  @InjectMocks private CallNumberBrowseRangeService callNumberBrowseRangeService;
+
+  @Spy private final Cache<String, List<CallNumberBrowseRangeValue>> cache = Caffeine.from("maximumSize=50").build();
+  @Spy private final CallNumberProcessor callNumberProcessor = new CallNumberProcessor();
+  @Captor private ArgumentCaptor<SearchSourceBuilder> searchSourceCaptor;
+
+  @Mock private SearchRepository searchRepository;
+  @Mock private SearchResponse searchResponse;
+
+  @BeforeEach
+  void setUp() {
+    cache.cleanUp();
+  }
+
+  @Test
+  void getBrowseRanges_positive() {
+    var request = SimpleResourceRequest.of(INSTANCE_RESOURCE, TENANT_ID);
+    when(searchRepository.search(eq(request), searchSourceCaptor.capture())).thenReturn(searchResponse);
+    when(callNumberProcessor.getCallNumberAsLong(anyString())).thenReturn(1L);
+    when(searchResponse.getAggregations()).thenReturn(aggregationsFromJson(jsonObject(
+      "range#cnRanges", jsonObject("buckets", jsonArray(bucket("A", 10), bucket("B", 20))))));
+
+    var firstAttempt = callNumberBrowseRangeService.getBrowseRanges(TENANT_ID);
+
+    var expectedRanges = List.of(rangeValue("A", 10), rangeValue("B", 20));
+    assertThat(firstAttempt).isEqualTo(expectedRanges);
+
+    var secondAttempt = callNumberBrowseRangeService.getBrowseRanges(TENANT_ID);
+    assertThat(secondAttempt).isEqualTo(expectedRanges);
+
+    verify(callNumberProcessor, times(36)).getCallNumberAsLong(anyString());
+
+    var searchSource = searchSourceCaptor.getValue();
+    var aggregations = searchSource.aggregations();
+    var rangeAggregation = (RangeAggregationBuilder) aggregations.getAggregatorFactories().iterator().next();
+    assertThat(aggregations.count()).isEqualTo(1);
+    assertThat(rangeAggregation.ranges()).hasSize(36);
+  }
+
+  @Test
+  void evictCache_positive() {
+    var cachedValue = singletonList(rangeValue("A", 10, 10));
+    cache.put(TENANT_ID, cachedValue);
+    var actual = callNumberBrowseRangeService.getBrowseRanges(TENANT_ID);
+    assertThat(actual).isEqualTo(cachedValue);
+    callNumberBrowseRangeService.evictRangeCache(TENANT_ID);
+
+    assertThat(cache.asMap()).isEmpty();
+  }
+
+  @Test
+  void getRangeBoundaryForBrowsing_positive_emptyRanges() {
+    cache.put(TENANT_ID, emptyList());
+    var actual = callNumberBrowseRangeService.getRangeBoundaryForBrowsing(TENANT_ID, "A", 30, true);
+    assertThat(actual).isEmpty();
+  }
+
+
+  @ParameterizedTest
+  @MethodSource("getRangeBoundaryDataSource")
+  void getRangeBoundaryForBrowsing_parameterized(String anchor, int size, boolean isBrowsingForward, Long expected) {
+    cache.put(TENANT_ID, getCallNumberBrowseRangeValues());
+    var actual = callNumberBrowseRangeService.getRangeBoundaryForBrowsing(TENANT_ID, anchor, size, isBrowsingForward);
+    assertThat(actual).isEqualTo(Optional.ofNullable(expected));
+  }
+
+  public static Stream<Arguments> getRangeBoundaryDataSource() {
+    return Stream.of(
+      // browse forward
+      arguments("A", 10, true, 2L),
+      arguments(".", 10, true, 2L),
+      arguments("1", 10, true, 2L),
+      arguments("A", 50, true, 4L),
+      arguments("AZ", 10, true, 3L),
+      arguments("AZ", 50, true, 5L),
+      arguments("E", 10, true, 6L),
+      arguments("A", 200, true, null),
+      arguments("F", 20, true, null),
+      arguments("Z", 20, true, null),
+
+      //browse backward
+      arguments("A", 50, false, null),
+      arguments("1", 50, false, null),
+      arguments("C", 10, false, 2L),
+      arguments("C", 30, false, 1L),
+      arguments("F", 40, false, 4L),
+      arguments("EZ", 40, false, 1L),
+      arguments("EZ", 60, false, null),
+      arguments("CZ", 10, false, 1L)
+    );
+  }
+
+  @NonNull
+  private static List<CallNumberBrowseRangeValue> getCallNumberBrowseRangeValues() {
+    return List.of(
+      rangeValue("A", 1, 20), rangeValue("B", 2, 12),
+      rangeValue("C", 3, 15), rangeValue("D", 4, 25),
+      rangeValue("E", 5, 30), rangeValue("F", 6, 9));
+  }
+
+  private static CallNumberBrowseRangeValue rangeValue(String key, long count) {
+    return rangeValue(key, 1L, count);
+  }
+
+  private static CallNumberBrowseRangeValue rangeValue(String key, long keyAsLong, long count) {
+    return CallNumberBrowseRangeValue.of(key, keyAsLong, count);
+  }
+
+  private static JsonNode bucket(String key, int count) {
+    return jsonObject("key", key, "doc_count", count);
+  }
+}

--- a/src/test/java/org/folio/search/utils/SearchUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchUtilsTest.java
@@ -245,6 +245,11 @@ class SearchUtilsTest {
     assertThat(actual).isEqualTo(expected);
   }
 
+  @Test
+  void getClosestElement() {
+
+  }
+
   private static Stream<Arguments> isEmptyStringDataSource() {
     return Stream.of(
       arguments(new Object(), false),

--- a/src/test/java/org/folio/search/utils/SearchUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchUtilsTest.java
@@ -245,11 +245,6 @@ class SearchUtilsTest {
     assertThat(actual).isEqualTo(expected);
   }
 
-  @Test
-  void getClosestElement() {
-
-  }
-
   private static Stream<Arguments> isEmptyStringDataSource() {
     return Stream.of(
       arguments(new Object(), false),

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -54,6 +54,7 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
+import org.elasticsearch.search.aggregations.bucket.range.ParsedRange;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
 import org.folio.search.domain.dto.Authority;
 import org.folio.search.domain.dto.AuthorityBrowseItem;
@@ -456,6 +457,7 @@ public class TestUtils {
   public static List<NamedXContentRegistry.Entry> elasticsearchClientNamedContentRegistryEntries() {
     Map<String, ContextParser<Object, ? extends Aggregation>> map = new HashMap<>();
     map.put("sterms", (p, c) -> ParsedStringTerms.fromXContent(p, (String) c));
+    map.put("range", (p, c) -> ParsedRange.fromXContent(p, (String) c));
     map.put("filter", (p, c) -> ParsedFilter.fromXContent(p, (String) c));
     map.put("string_stats", (p, c) -> ParsedStringStats.PARSER.parse(p, (String) c));
     return map.entrySet().stream()

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -40,7 +40,9 @@ application:
         retry-attempts: 3
   query:
     properties:
-      call-number-range-offset: 1e20
+      call-number-browse-optimization-enabled: true
+  cache:
+    call-number-browse-ranges-cache-spec: maximumSize=50,expireAfterAccess=300s
   system-user:
     username: mod-search
     password: Mod-search-1-0-0


### PR DESCRIPTION
### Purpose
The existing browsing solution performance can be optimized by:
- Using small range query to retrieve results and then, if the result is not enough - use range query without top\lower boundaries
- Using a range aggregation request to cache numeric values intervals and use them to define appropriate lower\top boundaries

### Approach
_Optmization is based on retrieving from Elasticsearch count for the interval between the first character (0-9, A-Z) of the call number, then the counts can be transformed to a list and with a special algorithm._

Steps of development:
- Implement range count uploading from Elasticsearch
- Apply algorithm to select minimal boundary value from received ranges
- Fix/update unit and integration tests
