### PR TITLE
MSEARCH-322 Downgrade version of elasticsearch from 7.13.4 to 7.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <java.version>11</java.version>
     <folio-spring-base.version>3.0.1</folio-spring-base.version>
     <openapi-generator.version>5.3.1</openapi-generator.version>
-    <es-client.version>7.13.4</es-client.version>
+    <es-client.version>7.10.2</es-client.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
     <apache-commons-io.version>2.7</apache-commons-io.version>
     <apache-commons-collections.version>4.4</apache-commons-collections.version>

--- a/src/main/java/org/folio/search/service/ResourceIdService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdService.java
@@ -77,7 +77,7 @@ public class ResourceIdService {
     var searchSource = queryConverter.convert(request.getQuery(), resource)
       .size(streamIdsProperties.getScrollQuerySize())
       .fetchSource(new String[] {request.getSourceFieldPath()}, null)
-      .sort(List.of(fieldSort("_doc")));
+      .sort(fieldSort("_doc"));
 
     searchRepository.streamResourceIds(request, searchSource, idsConsumer);
   }

--- a/src/test/java/org/folio/search/repository/IndexRepositoryTest.java
+++ b/src/test/java/org/folio/search/repository/IndexRepositoryTest.java
@@ -1,6 +1,5 @@
 package org.folio.search.repository;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.client.RequestOptions.DEFAULT;
@@ -134,7 +133,7 @@ class IndexRepositoryTest {
     var deleteIndexRequestCaptor = ArgumentCaptor.forClass(DeleteIndexRequest.class);
 
     when(restHighLevelClient.indices()).thenReturn(indices);
-    when(indices.delete(deleteIndexRequestCaptor.capture(), eq(DEFAULT))).thenReturn(AcknowledgedResponse.TRUE);
+    when(indices.delete(deleteIndexRequestCaptor.capture(), eq(DEFAULT))).thenReturn(new AcknowledgedResponse(true));
 
     indexRepository.dropIndex(INDEX_NAME);
 
@@ -144,7 +143,7 @@ class IndexRepositoryTest {
   @Test
   void refreshIndex_positive() throws IOException {
     var refreshRequest = ArgumentCaptor.forClass(RefreshRequest.class);
-    var refreshResponse = new RefreshResponse(1, 1, 0, emptyList());
+    var refreshResponse = mock(RefreshResponse.class);
 
     when(restHighLevelClient.indices()).thenReturn(indices);
     when(indices.refresh(refreshRequest.capture(), eq(DEFAULT))).thenReturn(refreshResponse);


### PR DESCRIPTION
### Purpose
downgrade version of elasticsearch from 7.13.4 to 7.10.2 to match apache license
see for more details https://issues.folio.org/browse/MSEARCH-322

### Approach
changed version of the elasticsearch im pom.xml
as a result made minor change in ResourceIdService.class and some changes in IndexRepositoryTest.class to match downgraded version of the elasticsearch