### PR TITLE
MSEARCH-315 Implement cursor parameters for browsing

### DIFF
--- a/src/main/java/org/folio/search/controller/BrowseController.java
+++ b/src/main/java/org/folio/search/controller/BrowseController.java
@@ -41,7 +41,9 @@ public class BrowseController implements BrowseApi {
     var instanceByCallNumber = callNumberBrowseService.browse(browseRequest);
     return ResponseEntity.ok(new CallNumberBrowseResult()
       .items(instanceByCallNumber.getRecords())
-      .totalRecords(instanceByCallNumber.getTotalRecords()));
+      .totalRecords(instanceByCallNumber.getTotalRecords())
+      .prev(instanceByCallNumber.getPrev())
+      .next(instanceByCallNumber.getNext()));
   }
 
   @Override
@@ -53,7 +55,9 @@ public class BrowseController implements BrowseApi {
     var browseResult = subjectBrowseService.browse(browseRequest);
     return ResponseEntity.ok(new SubjectBrowseResult()
       .items(browseResult.getRecords())
-      .totalRecords(browseResult.getTotalRecords()));
+      .totalRecords(browseResult.getTotalRecords())
+      .prev(browseResult.getPrev())
+      .next(browseResult.getNext()));
   }
 
   @Override
@@ -64,7 +68,9 @@ public class BrowseController implements BrowseApi {
     var browseResult = authorityBrowseService.browse(browseRequest);
     return ResponseEntity.ok(new AuthorityBrowseResult()
       .items(browseResult.getRecords())
-      .totalRecords(browseResult.getTotalRecords()));
+      .totalRecords(browseResult.getTotalRecords())
+      .prev(browseResult.getPrev())
+      .next(browseResult.getNext()));
   }
 
   private static BrowseRequestBuilder getBrowseRequestBuilder(String query, String tenant, Integer limit,

--- a/src/main/java/org/folio/search/model/BrowseResult.java
+++ b/src/main/java/org/folio/search/model/BrowseResult.java
@@ -1,0 +1,139 @@
+package org.folio.search.model;
+
+import static java.util.Collections.emptyList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.collections.CollectionUtils;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor(staticName = "of")
+public class BrowseResult<T> {
+
+  /**
+   * Amount of records found.
+   */
+  private int totalRecords;
+
+  /**
+   * Previous value for browsing backward.
+   */
+  private String prev;
+
+  /**
+   * Next value for browsing forward.
+   */
+  private String next;
+
+  /**
+   * List with found records.
+   */
+  private List<T> records;
+
+  /**
+   * Creates {@link BrowseResult} object from {@link SearchResult} value.
+   *
+   * @param result - {@link SearchResult} object to be processed
+   * @param <R> - generic type for {@link BrowseResult} records
+   * @return created {@link BrowseResult} object
+   */
+  public static <R> BrowseResult<R> of(SearchResult<R> result) {
+    return new BrowseResult<>(result.getTotalRecords(), null, null, result.getRecords());
+  }
+
+  /**
+   * Creates {@link BrowseResult} object from the number of total records and list of items.
+   *
+   * @param totalRecords - number of found items
+   * @param records - found items
+   * @param <R> - generic type for {@link BrowseResult} records
+   * @return created {@link BrowseResult} object
+   */
+  public static <R> BrowseResult<R> of(int totalRecords, List<R> records) {
+    return new BrowseResult<>(totalRecords, null, null, records);
+  }
+
+  /**
+   * Creates empty {@link BrowseResult} object.
+   *
+   * @param <R> - generic type for result elements
+   * @return empty {@link BrowseResult} object
+   */
+  public static <R> BrowseResult<R> empty() {
+    return new BrowseResult<>(0, null, null, emptyList());
+  }
+
+  /**
+   * Sets total records and returns {@link BrowseResult} object.
+   *
+   * @param totalRecords - amount of records in search response
+   * @return {@link SearchResult} with new total records value
+   */
+  public BrowseResult<T> totalRecords(int totalRecords) {
+    this.totalRecords = totalRecords;
+    return this;
+  }
+
+  /**
+   * Sets records and returns {@link BrowseResult} object.
+   *
+   * @param records - list of records to set
+   * @return {@link SearchResult} with new records value
+   */
+  public BrowseResult<T> records(List<T> records) {
+    this.records = records;
+    return this;
+  }
+
+  /**
+   * Sets the previous value to the {@link BrowseResult} value.
+   *
+   * @param prev - previous value for browsing backward
+   * @return {@link SearchResult} with new prev value
+   */
+  public BrowseResult<T> prev(String prev) {
+    this.prev = prev;
+    return this;
+  }
+
+  /**
+   * Sets the next value to the {@link BrowseResult} value.
+   *
+   * @param next - next value for browsing forward
+   * @return {@link SearchResult} with new next value
+   */
+  public BrowseResult<T> next(String next) {
+    this.next = next;
+    return this;
+  }
+
+  /**
+   * Checks if search result is empty or not.
+   *
+   * @return true - if search result is empty, false - otherwise.
+   */
+  public boolean isEmpty() {
+    return CollectionUtils.isEmpty(records);
+  }
+
+  /**
+   * Maps search result records using given mapping function.
+   *
+   * @param mappingFunction - mapping function for result element conversion
+   * @param <R> - generic type for search result elements.
+   * @return new search result object with mapped elements
+   */
+  public <R> BrowseResult<R> map(Function<T, R> mappingFunction) {
+    var resultList = new ArrayList<R>();
+    for (T record : this.records) {
+      resultList.add(mappingFunction.apply(record));
+    }
+
+    return new BrowseResult<>(this.totalRecords, this.prev, this.next, resultList);
+  }
+}

--- a/src/main/java/org/folio/search/model/SearchResult.java
+++ b/src/main/java/org/folio/search/model/SearchResult.java
@@ -1,11 +1,8 @@
 package org.folio.search.model;
 
 import static java.util.Collections.emptyList;
-import static org.folio.search.utils.CollectionUtils.reverse;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -19,28 +16,12 @@ public class SearchResult<T> {
   /**
    * Amount of records found.
    */
-  private int totalRecords;
+  protected int totalRecords;
 
   /**
    * List with found records.
    */
-  private List<T> records;
-
-  /**
-   * Maps search result records using given mapping function.
-   *
-   * @param mappingFunction - mapping function for result element conversion
-   * @param <R> - generic type for search result elements.
-   * @return new search result object with mapped elements
-   */
-  public <R> SearchResult<R> map(Function<T, R> mappingFunction) {
-    var resultList = new ArrayList<R>();
-    for (T record : this.records) {
-      resultList.add(mappingFunction.apply(record));
-    }
-
-    return new SearchResult<>(this.totalRecords, resultList);
-  }
+  protected List<T> records;
 
   /**
    * Creates empty {@link SearchResult} object.
@@ -71,11 +52,6 @@ public class SearchResult<T> {
    */
   public SearchResult<T> records(List<T> records) {
     this.records = records;
-    return this;
-  }
-
-  public SearchResult<T> withReversedRecords() {
-    this.records = reverse(this.records);
     return this;
   }
 

--- a/src/main/java/org/folio/search/model/service/BrowseContext.java
+++ b/src/main/java/org/folio/search/model/service/BrowseContext.java
@@ -31,7 +31,7 @@ public class BrowseContext {
    *
    * @return true - if context is purposed for browsing around
    */
-  public boolean isAroundBrowsing() {
+  public boolean isBrowsingAround() {
     return this.precedingQuery != null && this.succeedingQuery != null;
   }
 

--- a/src/main/java/org/folio/search/model/service/BrowseContext.java
+++ b/src/main/java/org/folio/search/model/service/BrowseContext.java
@@ -40,7 +40,7 @@ public class BrowseContext {
    *
    * @return true - if context is purposed for browsing forward
    */
-  public boolean isForwardBrowsing() {
+  public boolean isBrowsingForward() {
     return this.succeedingQuery != null;
   }
 

--- a/src/main/java/org/folio/search/service/browse/AbstractBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/AbstractBrowseService.java
@@ -21,7 +21,7 @@ public abstract class AbstractBrowseService<T> {
    */
   public BrowseResult<T> browse(BrowseRequest request) {
     var context = browseContextProvider.get(request);
-    return context.isAroundBrowsing() ? browseAround(request, context) : browseInOneDirection(request, context);
+    return context.isBrowsingAround() ? browseAround(request, context) : browseInOneDirection(request, context);
   }
 
   /**

--- a/src/main/java/org/folio/search/service/browse/AbstractBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/AbstractBrowseService.java
@@ -1,6 +1,10 @@
 package org.folio.search.service.browse;
 
-import org.folio.search.model.SearchResult;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+import java.util.List;
+import org.folio.search.model.BrowseResult;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.model.service.BrowseRequest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,9 +17,9 @@ public abstract class AbstractBrowseService<T> {
    * Finds related instances for call number browsing using given {@link BrowseRequest} object.
    *
    * @param request - service request as {@link BrowseRequest} object
-   * @return search result with related instances by virtual shelf.
+   * @return {@link BrowseResult} with related instances by virtual shelf.
    */
-  public SearchResult<T> browse(BrowseRequest request) {
+  public BrowseResult<T> browse(BrowseRequest request) {
     var context = browseContextProvider.get(request);
     return context.isAroundBrowsing() ? browseAround(request, context) : browseInOneDirection(request, context);
   }
@@ -25,18 +29,18 @@ public abstract class AbstractBrowseService<T> {
    *
    * @param request - {@link BrowseRequest} object for browsing
    * @param context - {@link BrowseContext} object with query, limits, etc.
-   * @return {@link SearchResult} with browsing items
+   * @return {@link BrowseResult} with browsing items
    */
-  protected abstract SearchResult<T> browseInOneDirection(BrowseRequest request, BrowseContext context);
+  protected abstract BrowseResult<T> browseInOneDirection(BrowseRequest request, BrowseContext context);
 
   /**
    * Defines the approach for browsing around.
    *
    * @param request - {@link BrowseRequest} object for browsing
    * @param context - {@link BrowseContext} object with query, limits, and etc.
-   * @return {@link SearchResult} with browsing items
+   * @return {@link BrowseResult} with browsing items
    */
-  protected abstract SearchResult<T> browseAround(BrowseRequest request, BrowseContext context);
+  protected abstract BrowseResult<T> browseAround(BrowseRequest request, BrowseContext context);
 
   /**
    * Injects {@link BrowseContextProvider} bean from spring context.
@@ -46,5 +50,11 @@ public abstract class AbstractBrowseService<T> {
   @Autowired
   public void setBrowseContextProvider(BrowseContextProvider browseContextProvider) {
     this.browseContextProvider = browseContextProvider;
+  }
+
+  protected static <T> List<T> trim(List<T> items, BrowseContext ctx, boolean isBrowsingForward) {
+    return isBrowsingForward
+      ? items.subList(0, min(ctx.getLimit(true), items.size()))
+      : items.subList(max(items.size() - ctx.getLimit(false), 0), items.size());
   }
 }

--- a/src/main/java/org/folio/search/service/browse/AbstractBrowseServiceBySearchAfter.java
+++ b/src/main/java/org/folio/search/service/browse/AbstractBrowseServiceBySearchAfter.java
@@ -119,17 +119,6 @@ public abstract class AbstractBrowseServiceBySearchAfter<T, R> extends AbstractB
    */
   protected abstract String getValueForBrowsing(T browseItem);
 
-  /**
-   * Checks if browsing result anchor value must be highlighted or not.
-   *
-   * @param request - {@link BrowseRequest} object with inputs from a user
-   * @param context - {@link BrowseContext} with necessary information for browsing.
-   * @return true - if anchor result must be highlighted, false - otherwise
-   */
-  protected static boolean isHighlightedResult(BrowseRequest request, BrowseContext context) {
-    return isTrue(request.getHighlightMatch()) && context.isAroundBrowsing();
-  }
-
   private BrowseResult<T> createBrowseResult(Item[] responses, BrowseRequest request, BrowseContext context) {
     var precedingResult = documentConverter.convertToSearchResult(responses[0].getResponse(), browseResponseClass);
     var succeedingResult = documentConverter.convertToSearchResult(responses[1].getResponse(), browseResponseClass);
@@ -148,16 +137,17 @@ public abstract class AbstractBrowseServiceBySearchAfter<T, R> extends AbstractB
   }
 
   private BrowseResult<T> getAnchorSearchResult(BrowseRequest request, BrowseContext context, Item[] responses) {
+    var isAnchorHighlighted = isTrue(request.getHighlightMatch());
     if (!context.isAnchorIncluded()) {
-      return isHighlightedResult(request, context)
+      return isAnchorHighlighted
         ? BrowseResult.of(0, singletonList(getEmptyBrowseItem(context)))
         : BrowseResult.empty();
     }
 
     var anchorResult = documentConverter.convertToSearchResult(responses[2].getResponse(), browseResponseClass);
-    return isHighlightedResult(request, context) && anchorResult.getTotalRecords() == 0
+    return isAnchorHighlighted && anchorResult.getTotalRecords() == 0
       ? BrowseResult.of(1, singletonList(getEmptyBrowseItem(context)))
-      : mapToBrowseResult(anchorResult, isHighlightedResult(request, context));
+      : mapToBrowseResult(anchorResult, isAnchorHighlighted);
   }
 
   private BrowseResult<T> getSearchResultWithAnchor(BrowseRequest request, BrowseContext context) {

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseQueryProvider.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseQueryProvider.java
@@ -41,18 +41,18 @@ public class CallNumberBrowseQueryProvider {
    *
    * @param request - {@link BrowseRequest} object
    * @param ctx - {@link BrowseContext} object with parsed and validated queries, anchor, limits
-   * @param isForwardBrowsing - defines the direction of browsing
+   * @param isBrowsingForward - defines the direction of browsing
    * @return created Elasticsearch query as {@link SearchSourceBuilder} object
    */
-  public SearchSourceBuilder get(BrowseRequest request, BrowseContext ctx, boolean isForwardBrowsing) {
-    var scriptCode = isForwardBrowsing ? SORT_SCRIPT_FOR_SUCCEEDING_QUERY : SORT_SCRIPT_FOR_PRECEDING_QUERY;
+  public SearchSourceBuilder get(BrowseRequest request, BrowseContext ctx, boolean isBrowsingForward) {
+    var scriptCode = isBrowsingForward ? SORT_SCRIPT_FOR_SUCCEEDING_QUERY : SORT_SCRIPT_FOR_PRECEDING_QUERY;
     var script = new Script(INLINE, DEFAULT_SCRIPT_LANG, scriptCode, singletonMap("cn", ctx.getAnchor()));
 
     var multiplier = queryConfiguration.getRangeQueryLimitMultiplier();
-    var pageSize = (int) Math.max(MIN_QUERY_SIZE, Math.ceil(ctx.getLimit(isForwardBrowsing) * multiplier));
+    var pageSize = (int) Math.max(MIN_QUERY_SIZE, Math.ceil(ctx.getLimit(isBrowsingForward) * multiplier));
     var searchSource = searchSource().from(0).size(pageSize)
-      .query(getQuery(ctx, request.getTenantId(), pageSize, isForwardBrowsing))
-      .sort(scriptSort(script, STRING).order(isForwardBrowsing ? ASC : DESC));
+      .query(getQuery(ctx, request.getTenantId(), pageSize, isBrowsingForward))
+      .sort(scriptSort(script, STRING).order(isBrowsingForward ? ASC : DESC));
 
     if (isFalse(request.getExpandAll())) {
       var includes = searchFieldProvider.getSourceFields(request.getResource()).toArray(String[]::new);

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseResultConverter.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseResultConverter.java
@@ -23,6 +23,7 @@ import org.elasticsearch.search.SearchHit;
 import org.folio.search.domain.dto.CallNumberBrowseItem;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
+import org.folio.search.model.BrowseResult;
 import org.folio.search.model.SearchResult;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.service.converter.ElasticsearchDocumentConverter;
@@ -42,16 +43,17 @@ public class CallNumberBrowseResultConverter {
    * @param isForwardBrowsing - direction of browsing
    * @return converted {@link SearchResult} object with {@link CallNumberBrowseItem} values
    */
-  public SearchResult<CallNumberBrowseItem> convert(SearchResponse resp, BrowseContext ctx, boolean isForwardBrowsing) {
+  public BrowseResult<CallNumberBrowseItem> convert(SearchResponse resp, BrowseContext ctx, boolean isForwardBrowsing) {
     var searchResult = documentConverter.convertToSearchResult(resp, Instance.class, this::mapToBrowseItem);
-    var browseItems = searchResult.getRecords();
+    var browseResult = BrowseResult.of(searchResult);
+    var browseItems = browseResult.getRecords();
     if (CollectionUtils.isEmpty(browseItems)) {
-      return searchResult;
+      return browseResult;
     }
 
     var items = isForwardBrowsing ? browseItems : reverse(browseItems);
     var populatedItems = populateCallNumberBrowseItems(items, ctx, isForwardBrowsing);
-    return searchResult.records(collapseCallNumberBrowseItems(populatedItems));
+    return browseResult.records(collapseCallNumberBrowseItems(populatedItems));
   }
 
   private CallNumberBrowseItem mapToBrowseItem(SearchHit searchHit, Instance instance) {

--- a/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
@@ -68,7 +68,7 @@ public class SubjectBrowseService extends AbstractBrowseServiceBySearchAfter<Sub
   @Override
   protected BrowseResult<SubjectBrowseItem> mapToBrowseResult(SearchResult<SubjectBrowseItem> res, boolean isAnchor) {
     var browseResult = BrowseResult.of(res);
-    return isAnchor ? browseResult.map(record -> record.isAnchor(true)) : browseResult;
+    return isAnchor ? browseResult.map(item -> item.isAnchor(true)) : browseResult;
   }
 
   @Override

--- a/src/main/java/org/folio/search/utils/CollectionUtils.java
+++ b/src/main/java/org/folio/search/utils/CollectionUtils.java
@@ -134,7 +134,6 @@ public final class CollectionUtils {
     initial.addAll(startIndex, sourceValues);
   }
 
-
   /**
    * Returns a Collector that accumulates the input elements into a new {@link LinkedHashSet}, in encounter order.
    *

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -59,7 +59,6 @@ public class SearchUtils {
   public static final String KEYWORD_FIELD_INDEX = "keyword";
   public static final float CONST_SIZE_LOAD_FACTOR = 1.0f;
 
-
   /**
    * Performs elasticsearch exceptional operation and returns the received result.
    *

--- a/src/main/resources/swagger.api/schemas/response/authorityBrowseResult.json
+++ b/src/main/resources/swagger.api/schemas/response/authorityBrowseResult.json
@@ -7,6 +7,14 @@
       "type": "integer",
       "description": "Amount of items to display"
     },
+    "prev": {
+      "type": "string",
+      "description": "Previous value for browsing backward"
+    },
+    "next": {
+      "type": "string",
+      "description": "Next value for browsing forward"
+    },
     "items": {
       "type": "array",
       "description": "List of authority browse items",

--- a/src/main/resources/swagger.api/schemas/response/callNumberBrowseResult.json
+++ b/src/main/resources/swagger.api/schemas/response/callNumberBrowseResult.json
@@ -7,6 +7,14 @@
       "type": "integer",
       "description": "Amount of items to display"
     },
+    "prev": {
+      "type": "string",
+      "description": "Previous value for browsing backward"
+    },
+    "next": {
+      "type": "string",
+      "description": "Next value for browsing forward"
+    },
     "items": {
       "type": "array",
       "description": "List of call number browse items",

--- a/src/main/resources/swagger.api/schemas/response/subjectBrowseResult.json
+++ b/src/main/resources/swagger.api/schemas/response/subjectBrowseResult.json
@@ -7,6 +7,14 @@
       "type": "integer",
       "description": "Amount of items to display"
     },
+    "prev": {
+      "type": "string",
+      "description": "Previous value for browsing backward"
+    },
+    "next": {
+      "type": "string",
+      "description": "Next value for browsing forward"
+    },
     "items": {
       "type": "array",
       "description": "List of subject browse items",

--- a/src/test/java/org/folio/search/controller/BrowseControllerTest.java
+++ b/src/test/java/org/folio/search/controller/BrowseControllerTest.java
@@ -11,7 +11,7 @@ import static org.folio.search.utils.SearchUtils.INSTANCE_SUBJECT_RESOURCE;
 import static org.folio.search.utils.TestConstants.RESOURCE_ID;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.authorityBrowseItem;
-import static org.folio.search.utils.TestUtils.searchResult;
+import static org.folio.search.utils.TestUtils.browseResult;
 import static org.folio.search.utils.TestUtils.subjectBrowseItem;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
@@ -48,7 +48,7 @@ class BrowseControllerTest {
   void browseInstancesByCallNumber_positive() throws Exception {
     var query = "callNumber > PR4034 .P7 2019";
     var request = browseRequest(query, 5);
-    when(callNumberBrowseService.browse(request)).thenReturn(searchResult());
+    when(callNumberBrowseService.browse(request)).thenReturn(browseResult());
     var requestBuilder = get(instanceCallNumberBrowsePath())
       .queryParam("query", query)
       .queryParam("limit", "5")
@@ -65,7 +65,7 @@ class BrowseControllerTest {
   void browseInstancesByCallNumber_positive_allFields() throws Exception {
     var query = "callNumber > B";
     var request = BrowseRequest.of(INSTANCE_RESOURCE, TENANT_ID, query, 20, CALL_NUMBER_BROWSING_FIELD, true, true, 5);
-    when(callNumberBrowseService.browse(request)).thenReturn(searchResult());
+    when(callNumberBrowseService.browse(request)).thenReturn(browseResult());
 
     var requestBuilder = get(instanceCallNumberBrowsePath())
       .queryParam("query", query)
@@ -86,7 +86,7 @@ class BrowseControllerTest {
   void browseInstancesBySubject_positive() throws Exception {
     var query = "subject > water";
     var request = BrowseRequest.of(INSTANCE_SUBJECT_RESOURCE, TENANT_ID, query, 25, "subject", null, true, 12);
-    when(subjectBrowseService.browse(request)).thenReturn(searchResult(subjectBrowseItem(10, "water treatment")));
+    when(subjectBrowseService.browse(request)).thenReturn(browseResult(subjectBrowseItem(10, "water treatment")));
     var requestBuilder = get(instanceSubjectBrowsePath())
       .queryParam("query", query)
       .queryParam("limit", "25")
@@ -105,7 +105,7 @@ class BrowseControllerTest {
     var query = "headingRef > mark";
     var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 25, "headingRef", false, true, 12);
     var authority = new Authority().id(RESOURCE_ID).headingRef("mark twain");
-    when(authorityBrowseService.browse(request)).thenReturn(searchResult(authorityBrowseItem("mark twain", authority)));
+    when(authorityBrowseService.browse(request)).thenReturn(browseResult(authorityBrowseItem("mark twain", authority)));
     var requestBuilder = get(authorityBrowsePath())
       .queryParam("query", query)
       .queryParam("limit", "25")

--- a/src/test/java/org/folio/search/controller/SearchAuthorityFilterIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityFilterIT.java
@@ -149,7 +149,6 @@ class SearchAuthorityFilterIT extends BaseIntegrationTest {
       arguments("headingType==(\"Topical\" or \"Other\")", array("headingType:2"),
         mapOf("headingType", facet(facetItem("Topical", 1)))),
 
-
       arguments("id=*", array("subjectHeadings:2"), mapOf("subjectHeadings", facet(
         facetItem("a", 4), facetItem("c", 3)))),
 

--- a/src/test/java/org/folio/search/controller/SubjectBrowseIT.java
+++ b/src/test/java/org/folio/search/controller/SubjectBrowseIT.java
@@ -77,15 +77,16 @@ class SubjectBrowseIT extends BaseIntegrationTest {
       .param("limit", "7")
       .param("precedingRecordsCount", "2");
     var actual = parseResponse(doGet(request), SubjectBrowseResult.class);
-    assertThat(actual).isEqualTo(subjectBrowseResult(22, List.of(
-      subjectBrowseItem(1, "Textbooks"),
-      subjectBrowseItem(1, "United States"),
-      subjectBrowseItem(1, "Water", true),
-      subjectBrowseItem(1, "Water--Analysis"),
-      subjectBrowseItem(1, "Water--Microbiology"),
-      subjectBrowseItem(1, "Water--Purification"),
-      subjectBrowseItem(1, "Water-supply")
-    )));
+    assertThat(actual).isEqualTo(new SubjectBrowseResult()
+      .totalRecords(22).prev("Textbooks")
+      .items(List.of(
+        subjectBrowseItem(1, "Textbooks"),
+        subjectBrowseItem(1, "United States"),
+        subjectBrowseItem(1, "Water", true),
+        subjectBrowseItem(1, "Water--Analysis"),
+        subjectBrowseItem(1, "Water--Microbiology"),
+        subjectBrowseItem(1, "Water--Purification"),
+        subjectBrowseItem(1, "Water-supply"))));
   }
 
   @Test
@@ -96,13 +97,14 @@ class SubjectBrowseIT extends BaseIntegrationTest {
       .param("highlightMatch", "false");
     var actual = parseResponse(doGet(request), SubjectBrowseResult.class);
 
-    assertThat(actual).isEqualTo(subjectBrowseResult(22, List.of(
-      subjectBrowseItem(1, "Database management"),
-      subjectBrowseItem(1, "Europe"),
-      subjectBrowseItem(1, "Fantasy"),
-      subjectBrowseItem(3, "History"),
-      subjectBrowseItem(3, "Music")
-    )));
+    assertThat(actual).isEqualTo(new SubjectBrowseResult()
+      .totalRecords(22).prev("Database management").next("Music")
+      .items(List.of(
+        subjectBrowseItem(1, "Database management"),
+        subjectBrowseItem(1, "Europe"),
+        subjectBrowseItem(1, "Fantasy"),
+        subjectBrowseItem(3, "History"),
+        subjectBrowseItem(3, "Music"))));
   }
 
   private static Stream<Arguments> subjectBrowsingDataProvider() {
@@ -114,152 +116,182 @@ class SubjectBrowseIT extends BaseIntegrationTest {
     var backwardIncludingQuery = "subject <= {value}";
 
     return Stream.of(
-      arguments(aroundQuery, "water", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Textbooks"),
-        subjectBrowseItem(1, "United States"),
-        subjectBrowseItem(0, "water", true),
-        subjectBrowseItem(1, "Water--Analysis"),
-        subjectBrowseItem(1, "Water--Microbiology")
-      ))),
+      arguments(aroundQuery, "water", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev("Textbooks").next("Water--Microbiology")
+        .items(List.of(
+          subjectBrowseItem(1, "Textbooks"),
+          subjectBrowseItem(1, "United States"),
+          subjectBrowseItem(0, "water", true),
+          subjectBrowseItem(1, "Water--Analysis"),
+          subjectBrowseItem(1, "Water--Microbiology")))),
 
-      arguments(aroundQuery, "biology", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(2, "Biography"),
-        subjectBrowseItem(0, "biology", true),
-        subjectBrowseItem(1, "Book"),
-        subjectBrowseItem(1, "Database design")
-      ))),
+      arguments(aroundQuery, "biology", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev(null).next("Database design")
+        .items(List.of(
+          subjectBrowseItem(2, "Biography"),
+          subjectBrowseItem(0, "biology", true),
+          subjectBrowseItem(1, "Book"),
+          subjectBrowseItem(1, "Database design")))),
 
-      arguments(aroundIncludingQuery, "water", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Textbooks"),
-        subjectBrowseItem(1, "United States"),
-        subjectBrowseItem(1, "Water", true),
-        subjectBrowseItem(1, "Water--Analysis"),
-        subjectBrowseItem(1, "Water--Microbiology")
-      ))),
+      arguments(aroundIncludingQuery, "water", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev("Textbooks").next("Water--Microbiology")
+        .items(List.of(
+          subjectBrowseItem(1, "Textbooks"),
+          subjectBrowseItem(1, "United States"),
+          subjectBrowseItem(1, "Water", true),
+          subjectBrowseItem(1, "Water--Analysis"),
+          subjectBrowseItem(1, "Water--Microbiology")))),
 
-      arguments(aroundIncludingQuery, "biology", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(2, "Biography"),
-        subjectBrowseItem(0, "biology", true),
-        subjectBrowseItem(1, "Book"),
-        subjectBrowseItem(1, "Database design")
-      ))),
+      arguments(aroundIncludingQuery, "biology", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev(null).next("Database design")
+        .items(List.of(
+          subjectBrowseItem(2, "Biography"),
+          subjectBrowseItem(0, "biology", true),
+          subjectBrowseItem(1, "Book"),
+          subjectBrowseItem(1, "Database design")))),
 
-      arguments(aroundIncludingQuery, "music", 25, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(2, "Biography"),
-        subjectBrowseItem(1, "Book"),
-        subjectBrowseItem(1, "Database design"),
-        subjectBrowseItem(1, "Database management"),
-        subjectBrowseItem(1, "Europe"),
-        subjectBrowseItem(1, "Fantasy"),
-        subjectBrowseItem(3, "History"),
-        subjectBrowseItem(3, "Music", true),
-        subjectBrowseItem(1, "Philosophy"),
-        subjectBrowseItem(1, "Religion"),
-        subjectBrowseItem(1, "Rules"),
-        subjectBrowseItem(1, "Science"),
-        subjectBrowseItem(1, "Science--Methodology"),
-        subjectBrowseItem(1, "Science--Philosophy"),
-        subjectBrowseItem(1, "Text"),
-        subjectBrowseItem(1, "Textbooks"),
-        subjectBrowseItem(1, "United States"),
-        subjectBrowseItem(1, "Water"),
-        subjectBrowseItem(1, "Water--Analysis"),
-        subjectBrowseItem(1, "Water--Microbiology")
-      ))),
+      arguments(aroundIncludingQuery, "music", 25, new SubjectBrowseResult()
+        .totalRecords(22).prev(null).next("Water--Microbiology")
+        .items(List.of(
+          subjectBrowseItem(2, "Biography"),
+          subjectBrowseItem(1, "Book"),
+          subjectBrowseItem(1, "Database design"),
+          subjectBrowseItem(1, "Database management"),
+          subjectBrowseItem(1, "Europe"),
+          subjectBrowseItem(1, "Fantasy"),
+          subjectBrowseItem(3, "History"),
+          subjectBrowseItem(3, "Music", true),
+          subjectBrowseItem(1, "Philosophy"),
+          subjectBrowseItem(1, "Religion"),
+          subjectBrowseItem(1, "Rules"),
+          subjectBrowseItem(1, "Science"),
+          subjectBrowseItem(1, "Science--Methodology"),
+          subjectBrowseItem(1, "Science--Philosophy"),
+          subjectBrowseItem(1, "Text"),
+          subjectBrowseItem(1, "Textbooks"),
+          subjectBrowseItem(1, "United States"),
+          subjectBrowseItem(1, "Water"),
+          subjectBrowseItem(1, "Water--Analysis"),
+          subjectBrowseItem(1, "Water--Microbiology")))),
 
-      arguments(aroundIncludingQuery, "FC", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Europe"),
-        subjectBrowseItem(1, "Fantasy"),
-        subjectBrowseItem(0, "FC", true),
-        subjectBrowseItem(3, "History"),
-        subjectBrowseItem(3, "Music")
-      ))),
+      arguments(aroundIncludingQuery, "FC", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev("Europe").next("Music")
+        .items(List.of(
+          subjectBrowseItem(1, "Europe"),
+          subjectBrowseItem(1, "Fantasy"),
+          subjectBrowseItem(0, "FC", true),
+          subjectBrowseItem(3, "History"),
+          subjectBrowseItem(3, "Music")))),
+
+      arguments(aroundIncludingQuery, "a", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev(null).next("Book")
+        .items(List.of(
+          subjectBrowseItem(0, "a", true),
+          subjectBrowseItem(2, "Biography"),
+          subjectBrowseItem(1, "Book")))),
+
+      arguments(aroundIncludingQuery, "z", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev("Water--Purification").next(null)
+        .items(List.of(
+          subjectBrowseItem(1, "Water--Purification"),
+          subjectBrowseItem(1, "Water-supply"),
+          subjectBrowseItem(0, "z", true)))),
 
       // browsing forward
-      arguments(forwardQuery, "water", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Water--Analysis"),
-        subjectBrowseItem(1, "Water--Microbiology"),
-        subjectBrowseItem(1, "Water--Purification"),
-        subjectBrowseItem(1, "Water-supply")
-      ))),
+      arguments(forwardQuery, "water", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev(null).next(null)
+        .items(List.of(
+          subjectBrowseItem(1, "Water--Analysis"),
+          subjectBrowseItem(1, "Water--Microbiology"),
+          subjectBrowseItem(1, "Water--Purification"),
+          subjectBrowseItem(1, "Water-supply")))),
 
-      arguments(forwardQuery, "biology", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Book"),
-        subjectBrowseItem(1, "Database design"),
-        subjectBrowseItem(1, "Database management"),
-        subjectBrowseItem(1, "Europe"),
-        subjectBrowseItem(1, "Fantasy")
-      ))),
+      arguments(forwardQuery, "biology", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev(null).next("Fantasy")
+        .items(List.of(
+          subjectBrowseItem(1, "Book"),
+          subjectBrowseItem(1, "Database design"),
+          subjectBrowseItem(1, "Database management"),
+          subjectBrowseItem(1, "Europe"),
+          subjectBrowseItem(1, "Fantasy")))),
 
       // checks if collapsing works in forward direction
-      arguments(forwardQuery, "F", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Fantasy"),
-        subjectBrowseItem(3, "History"),
-        subjectBrowseItem(3, "Music"),
-        subjectBrowseItem(1, "Philosophy"),
-        subjectBrowseItem(1, "Religion")
-      ))),
+      arguments(forwardQuery, "F", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev(null).next("Religion")
+        .items(List.of(
+          subjectBrowseItem(1, "Fantasy"),
+          subjectBrowseItem(3, "History"),
+          subjectBrowseItem(3, "Music"),
+          subjectBrowseItem(1, "Philosophy"),
+          subjectBrowseItem(1, "Religion")))),
 
       arguments(forwardQuery, "Z", 10, subjectBrowseResult(22, emptyList())),
 
-      arguments(forwardIncludingQuery, "water", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Water"),
-        subjectBrowseItem(1, "Water--Analysis"),
-        subjectBrowseItem(1, "Water--Microbiology"),
-        subjectBrowseItem(1, "Water--Purification"),
-        subjectBrowseItem(1, "Water-supply")
-      ))),
+      arguments(forwardIncludingQuery, "water", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev(null).next(null)
+        .items(List.of(
+          subjectBrowseItem(1, "Water"),
+          subjectBrowseItem(1, "Water--Analysis"),
+          subjectBrowseItem(1, "Water--Microbiology"),
+          subjectBrowseItem(1, "Water--Purification"),
+          subjectBrowseItem(1, "Water-supply")))),
 
-      arguments(forwardIncludingQuery, "biology", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Book"),
-        subjectBrowseItem(1, "Database design"),
-        subjectBrowseItem(1, "Database management"),
-        subjectBrowseItem(1, "Europe"),
-        subjectBrowseItem(1, "Fantasy")
-      ))),
+      arguments(forwardIncludingQuery, "biology", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev(null).next("Fantasy")
+        .items(List.of(
+          subjectBrowseItem(1, "Book"),
+          subjectBrowseItem(1, "Database design"),
+          subjectBrowseItem(1, "Database management"),
+          subjectBrowseItem(1, "Europe"),
+          subjectBrowseItem(1, "Fantasy")))),
 
       // browsing backward
-      arguments(backwardQuery, "water", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Science--Methodology"),
-        subjectBrowseItem(1, "Science--Philosophy"),
-        subjectBrowseItem(1, "Text"),
-        subjectBrowseItem(1, "Textbooks"),
-        subjectBrowseItem(1, "United States")
-      ))),
+      arguments(backwardQuery, "water", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev("Science--Methodology").next(null)
+        .items(List.of(
+          subjectBrowseItem(1, "Science--Methodology"),
+          subjectBrowseItem(1, "Science--Philosophy"),
+          subjectBrowseItem(1, "Text"),
+          subjectBrowseItem(1, "Textbooks"),
+          subjectBrowseItem(1, "United States")))),
 
-      arguments(backwardQuery, "fun", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Book"),
-        subjectBrowseItem(1, "Database design"),
-        subjectBrowseItem(1, "Database management"),
-        subjectBrowseItem(1, "Europe"),
-        subjectBrowseItem(1, "Fantasy")
-      ))),
+      arguments(backwardQuery, "fun", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev("Book").next(null)
+        .items(List.of(
+          subjectBrowseItem(1, "Book"),
+          subjectBrowseItem(1, "Database design"),
+          subjectBrowseItem(1, "Database management"),
+          subjectBrowseItem(1, "Europe"),
+          subjectBrowseItem(1, "Fantasy")))),
 
-      arguments(backwardQuery, "G", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Book"),
-        subjectBrowseItem(1, "Database design"),
-        subjectBrowseItem(1, "Database management"),
-        subjectBrowseItem(1, "Europe"),
-        subjectBrowseItem(1, "Fantasy")
-      ))),
+      arguments(backwardQuery, "G", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev("Book").next(null)
+        .items(List.of(
+          subjectBrowseItem(1, "Book"),
+          subjectBrowseItem(1, "Database design"),
+          subjectBrowseItem(1, "Database management"),
+          subjectBrowseItem(1, "Europe"),
+          subjectBrowseItem(1, "Fantasy")))),
 
       arguments(backwardQuery, "A", 10, subjectBrowseResult(22, emptyList())),
 
-      arguments(backwardIncludingQuery, "water", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Science--Philosophy"),
-        subjectBrowseItem(1, "Text"),
-        subjectBrowseItem(1, "Textbooks"),
-        subjectBrowseItem(1, "United States"),
-        subjectBrowseItem(1, "Water")
-      ))),
+      arguments(backwardIncludingQuery, "water", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev("Science--Philosophy").next(null)
+        .items(List.of(
+          subjectBrowseItem(1, "Science--Philosophy"),
+          subjectBrowseItem(1, "Text"),
+          subjectBrowseItem(1, "Textbooks"),
+          subjectBrowseItem(1, "United States"),
+          subjectBrowseItem(1, "Water")))),
 
-      arguments(backwardIncludingQuery, "fun", 5, subjectBrowseResult(22, List.of(
-        subjectBrowseItem(1, "Book"),
-        subjectBrowseItem(1, "Database design"),
-        subjectBrowseItem(1, "Database management"),
-        subjectBrowseItem(1, "Europe"),
-        subjectBrowseItem(1, "Fantasy")
-      )))
+      arguments(backwardIncludingQuery, "fun", 5, new SubjectBrowseResult()
+        .totalRecords(22).prev("Book").next(null)
+        .items(List.of(
+          subjectBrowseItem(1, "Book"),
+          subjectBrowseItem(1, "Database design"),
+          subjectBrowseItem(1, "Database management"),
+          subjectBrowseItem(1, "Europe"),
+          subjectBrowseItem(1, "Fantasy"))))
     );
   }
 

--- a/src/test/java/org/folio/search/service/browse/AbstractBrowseServiceBySearchAfterTest.java
+++ b/src/test/java/org/folio/search/service/browse/AbstractBrowseServiceBySearchAfterTest.java
@@ -3,6 +3,7 @@ package org.folio.search.service.browse;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.folio.search.model.BrowseResult;
 import org.folio.search.model.SearchResult;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.model.service.BrowseRequest;
@@ -38,7 +39,12 @@ class AbstractBrowseServiceBySearchAfterTest {
     }
 
     @Override
-    protected SearchResult mapToBrowseResult(SearchResult result, boolean isAnchor) {
+    protected BrowseResult mapToBrowseResult(SearchResult searchResult, boolean isAnchor) {
+      return null;
+    }
+
+    @Override
+    protected String getValueForBrowsing(Object browseItem) {
       return null;
     }
   }

--- a/src/test/java/org/folio/search/service/browse/AuthorityBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/AuthorityBrowseServiceTest.java
@@ -25,6 +25,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.folio.search.domain.dto.Authority;
 import org.folio.search.domain.dto.AuthorityBrowseItem;
+import org.folio.search.model.BrowseResult;
 import org.folio.search.model.ResourceRequest;
 import org.folio.search.model.SearchResult;
 import org.folio.search.model.service.BrowseContext;
@@ -70,13 +71,13 @@ class AuthorityBrowseServiceTest {
     var context = BrowseContext.builder().succeedingQuery(esQuery).succeedingLimit(5).anchor("s0").build();
 
     when(browseContextProvider.get(request)).thenReturn(context);
-    when(searchRepository.search(request, searchSource("s0", 5, ASC))).thenReturn(searchResponse);
+    when(searchRepository.search(request, searchSource("s0", 6, ASC))).thenReturn(searchResponse);
     when(documentConverter.convertToSearchResult(searchResponse, Authority.class))
       .thenReturn(searchResult(authorities("s1", "s2", "s3", "s4", "s5")));
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(SearchResult.of(5, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, null, null, List.of(
       browseItem("s1"), browseItem("s2"), browseItem("s3"), browseItem("s4"), browseItem("s5"))));
   }
 
@@ -86,7 +87,7 @@ class AuthorityBrowseServiceTest {
     var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, false, false, 5);
     var esQuery = rangeQuery(TARGET_FIELD).gt("s0");
     var context = BrowseContext.builder().succeedingQuery(esQuery).succeedingLimit(5).anchor("s0").build();
-    var expectedSearchSource = searchSource("s0", 5, ASC).fetchSource(new String[] {"id", "headingRef"}, null);
+    var expectedSearchSource = searchSource("s0", 6, ASC).fetchSource(new String[] {"id", "headingRef"}, null);
 
     when(browseContextProvider.get(request)).thenReturn(context);
     when(searchRepository.search(request, expectedSearchSource)).thenReturn(searchResponse);
@@ -96,7 +97,7 @@ class AuthorityBrowseServiceTest {
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(SearchResult.of(5, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, null, null, List.of(
       browseItem("s1"), browseItem("s2"), browseItem("s3"), browseItem("s4"), browseItem("s5"))));
   }
 
@@ -108,13 +109,13 @@ class AuthorityBrowseServiceTest {
     var context = BrowseContext.builder().precedingQuery(esQuery).precedingLimit(3).anchor("s4").build();
 
     when(browseContextProvider.get(request)).thenReturn(context);
-    when(searchRepository.search(request, searchSource("s4", 3, DESC))).thenReturn(searchResponse);
+    when(searchRepository.search(request, searchSource("s4", 4, DESC))).thenReturn(searchResponse);
     when(documentConverter.convertToSearchResult(searchResponse, Authority.class))
       .thenReturn(searchResult(authorities("s3", "s2", "s1")));
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(SearchResult.of(3, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(3, null, null, List.of(
       browseItem("s1"), browseItem("s2"), browseItem("s3"))));
   }
 
@@ -128,12 +129,12 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(context);
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 5, ASC), anchorSearchSource("s0")),
+      List.of(searchSource("s0", 6, ASC), anchorSearchSource("s0")),
       List.of(searchResult(authorities("s1", "s2", "s3", "s4", "s5")), searchResult(authority("s0"))));
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(SearchResult.of(5, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, null, "s4", List.of(
       browseItem("s0"), browseItem("s1"), browseItem("s2"), browseItem("s3"), browseItem("s4"))));
   }
 
@@ -147,12 +148,12 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(context);
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 10, ASC), anchorSearchSource("s0")),
+      List.of(searchSource("s0", 11, ASC), anchorSearchSource("s0")),
       List.of(SearchResult.of(10, authorities("s1", "s2", "s3")), searchResult(authority("s0"))));
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(SearchResult.of(10, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(10, null, null, List.of(
       browseItem("s0"), browseItem("s1"), browseItem("s2"), browseItem("s3"))));
   }
 
@@ -166,12 +167,12 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(context);
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 5, ASC), anchorSearchSource("s0")),
-      List.of(searchResult(authorities("s1", "s2", "s3", "s4", "s5")), SearchResult.empty()));
+      List.of(searchSource("s0", 6, ASC), anchorSearchSource("s0")),
+      List.of(searchResult(authorities("s1", "s2", "s3", "s4", "s5", "s6")), SearchResult.empty()));
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(SearchResult.of(5, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(6, null, "s5", List.of(
       browseItem("s1"), browseItem("s2"), browseItem("s3"), browseItem("s4"), browseItem("s5"))));
   }
 
@@ -185,12 +186,12 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(context);
     mockMultiSearchRequest(request,
-      List.of(searchSource("s4", 3, DESC), anchorSearchSource("s4")),
+      List.of(searchSource("s4", 4, DESC), anchorSearchSource("s4")),
       List.of(searchResult(authorities("s3", "s2", "s1")), searchResult(authority("s4"))));
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(SearchResult.of(3, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(3, "s2", null, List.of(
       browseItem("s2"), browseItem("s3"), browseItem("s4"))));
   }
 
@@ -201,11 +202,11 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(false));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 2, DESC), searchSource("s0", 3, ASC)),
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)),
       List.of(SearchResult.of(10, authorities("r2", "r1")), searchResult(authorities("s1", "s2", "s3"))));
 
     var actual = authorityBrowseService.browse(request);
-    assertThat(actual).isEqualTo(SearchResult.of(10, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(10, null, "s2", List.of(
       browseItem("r1"), browseItem("r2"), authorityBrowseItem("s0", null, true), browseItem("s1"), browseItem("s2"))));
   }
 
@@ -216,11 +217,11 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(false));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 2, DESC), searchSource("s0", 3, ASC)),
-      List.of(SearchResult.of(10, authorities("r2", "r1")), searchResult(authorities("s1", "s2", "s3"))));
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)),
+      List.of(SearchResult.of(10, authorities("r2", "r1", "r0")), searchResult(authorities("s1", "s2", "s3", "s4"))));
 
     var actual = authorityBrowseService.browse(request);
-    assertThat(actual).isEqualTo(SearchResult.of(10, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(10, "r1", "s3", List.of(
       browseItem("r1"), browseItem("r2"), browseItem("s1"), browseItem("s2"), browseItem("s3"))));
   }
 
@@ -231,14 +232,14 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 2, DESC), searchSource("s0", 3, ASC), anchorSearchSource("s0")),
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), anchorSearchSource("s0")),
       List.of(
-        SearchResult.of(10, authorities("r2", "r1")),
-        searchResult(authorities("s1", "s2", "s3")),
+        SearchResult.of(10, authorities("r2", "r1", "r0")),
+        searchResult(authorities("s1", "s2", "s3", "s4")),
         searchResult(authority("s0"))));
 
     var actual = authorityBrowseService.browse(request);
-    assertThat(actual).isEqualTo(SearchResult.of(10, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(10, "r1", "s2", List.of(
       browseItem("r1"), browseItem("r2"), browseItem("s0").isAnchor(true), browseItem("s1"), browseItem("s2"))));
   }
 
@@ -249,14 +250,14 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 2, DESC), searchSource("s0", 3, ASC), anchorSearchSource("s0")),
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), anchorSearchSource("s0")),
       List.of(
         SearchResult.of(10, authorities("r2", "r1")),
-        searchResult(authorities("s1", "s2", "s3")),
+        searchResult(authorities("s1", "s2", "s3", "s4")),
         searchResult(authority("s0"))));
 
     var actual = authorityBrowseService.browse(request);
-    assertThat(actual).isEqualTo(SearchResult.of(10, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(10, null, "s2", List.of(
       browseItem("r1"), browseItem("r2"), browseItem("s0"), browseItem("s1"), browseItem("s2"))));
   }
 
@@ -267,14 +268,14 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 2, DESC), searchSource("s0", 3, ASC), anchorSearchSource("s0")),
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), anchorSearchSource("s0")),
       List.of(
         SearchResult.of(10, authorities("r2", "r1")),
         searchResult(authorities("s1", "s2", "s3")),
         SearchResult.empty()));
 
     var actual = authorityBrowseService.browse(request);
-    assertThat(actual).isEqualTo(SearchResult.of(10, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(10, null, "s2", List.of(
       browseItem("r1"), browseItem("r2"), authorityBrowseItem("s0", null, true), browseItem("s1"), browseItem("s2"))));
   }
 
@@ -285,14 +286,14 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 2, DESC), searchSource("s0", 3, ASC), anchorSearchSource("s0")),
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), anchorSearchSource("s0")),
       List.of(
         SearchResult.of(10, authorities("r2", "r1")),
         searchResult(authorities("s1", "s2", "s3")),
         SearchResult.empty()));
 
     var actual = authorityBrowseService.browse(request);
-    assertThat(actual).isEqualTo(SearchResult.of(10, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(10, null, null, List.of(
       browseItem("r1"), browseItem("r2"), browseItem("s1"), browseItem("s2"), browseItem("s3"))));
   }
 

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseRangeServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseRangeServiceTest.java
@@ -104,7 +104,6 @@ class CallNumberBrowseRangeServiceTest {
     assertThat(actual).isEmpty();
   }
 
-
   @ParameterizedTest
   @MethodSource("getRangeBoundaryDataSource")
   void getRangeBoundaryForBrowsing_parameterized(String anchor, int size, boolean isBrowsingForward, Long expected) {

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseResultConverterTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseResultConverterTest.java
@@ -28,7 +28,7 @@ import org.folio.search.domain.dto.CallNumberBrowseItem;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
-import org.folio.search.model.SearchResult;
+import org.folio.search.model.BrowseResult;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.service.FeatureConfigService;
 import org.folio.search.service.converter.ElasticsearchDocumentConverter;
@@ -67,7 +67,7 @@ class CallNumberBrowseResultConverterTest {
 
     var actual = resultConverter.convert(searchResponse, ctx, isBrowsingForward);
 
-    assertThat(actual).isEqualTo(SearchResult.of(100, expected));
+    assertThat(actual).isEqualTo(BrowseResult.of(100, expected));
     verify(documentConverter).convertToSearchResult(any(SearchResponse.class), eq(Instance.class), any());
   }
 
@@ -79,7 +79,7 @@ class CallNumberBrowseResultConverterTest {
 
     var actual = resultConverter.convert(searchResponse, forwardContext(), true);
 
-    assertThat(actual).isEqualTo(SearchResult.empty());
+    assertThat(actual).isEqualTo(BrowseResult.empty());
     verify(documentConverter).convertToSearchResult(any(SearchResponse.class), eq(Instance.class), any());
   }
 
@@ -91,7 +91,7 @@ class CallNumberBrowseResultConverterTest {
 
     var actual = resultConverter.convert(searchResponse, backwardContext(), false);
 
-    assertThat(actual).isEqualTo(SearchResult.empty());
+    assertThat(actual).isEqualTo(BrowseResult.empty());
     verify(documentConverter).convertToSearchResult(any(SearchResponse.class), eq(Instance.class), any());
   }
 
@@ -108,7 +108,7 @@ class CallNumberBrowseResultConverterTest {
 
     var actual = resultConverter.convert(searchResponse, forwardContext(), true);
 
-    assertThat(actual).isEqualTo(SearchResult.of(10, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(10, List.of(
       cnBrowseItem(instance("B1", "B2", "C2"), "B1"), cnBrowseItem(instance("C1", "C2"), "C1"))));
     verify(documentConverter).convertToSearchResult(any(SearchResponse.class), eq(Instance.class), any());
   }
@@ -126,7 +126,7 @@ class CallNumberBrowseResultConverterTest {
 
     var actual = resultConverter.convert(searchResponse, backwardContext(), false);
 
-    assertThat(actual).isEqualTo(SearchResult.of(10, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(10, List.of(
       cnBrowseItem(instance("B1", "B2"), "B2"), cnBrowseItem(instance("C1", "C2", "C4"), "C4"))));
     verify(documentConverter).convertToSearchResult(any(SearchResponse.class), eq(Instance.class), any());
   }

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
@@ -7,8 +7,8 @@ import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.folio.search.utils.SearchUtils.CALL_NUMBER_BROWSING_FIELD;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.folio.search.utils.TestUtils.browseResult;
 import static org.folio.search.utils.TestUtils.cnBrowseItem;
-import static org.folio.search.utils.TestUtils.searchResult;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -19,7 +19,7 @@ import org.folio.search.domain.dto.CallNumberBrowseItem;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
-import org.folio.search.model.SearchResult;
+import org.folio.search.model.BrowseResult;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.model.service.BrowseRequest;
 import org.folio.search.repository.SearchRepository;
@@ -58,12 +58,12 @@ class CallNumberBrowseServiceTest {
     var request = request("callNumber >= B or callNumber < B", true);
     prepareMockForBrowsingAround(request,
       contextAroundIncluding(),
-      searchResult(browseItems("A1", "A2", "A3", "A4")),
-      searchResult(browseItems("C1", "C2", "C3", "C4", "C5", "C6", "C7")));
+      browseResult(browseItems("A1", "A2", "A3", "A4")),
+      browseResult(browseItems("C1", "C2", "C3", "C4", "C5", "C6", "C7")));
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(SearchResult.of(11, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(11, null, null, List.of(
       cnBrowseItem(instance("A3"), "A3"),
       cnBrowseItem(instance("A4"), "A4"),
       cnBrowseItem(0, "B", null, true),
@@ -77,12 +77,12 @@ class CallNumberBrowseServiceTest {
 
     prepareMockForBrowsingAround(request,
       contextAroundIncluding(),
-      searchResult(browseItem("A 11")),
-      searchResult(browseItem("B"), browseItem("C 11")));
+      browseResult(browseItem("A 11")),
+      browseResult(browseItem("B"), browseItem("C 11")));
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(SearchResult.of(3, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(3, null, null, List.of(
       cnBrowseItem(instance("A 11"), "A 11"),
       cnBrowseItem(instance("B"), "B", "B", true),
       cnBrowseItem(instance("C 11"), "C 11"))));
@@ -91,11 +91,11 @@ class CallNumberBrowseServiceTest {
   @Test
   void browse_positive_around_emptySucceedingResults() {
     var request = request("callNumber >= B or callNumber < B", true);
-    prepareMockForBrowsingAround(request, contextAroundIncluding(), searchResult(browseItem("A 11")), searchResult());
+    prepareMockForBrowsingAround(request, contextAroundIncluding(), browseResult(browseItem("A 11")), browseResult());
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(SearchResult.of(1, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(1, null, null, List.of(
       cnBrowseItem(instance("A 11"), "A 11"),
       cnBrowseItem(0, "B", null, true))));
   }
@@ -105,11 +105,11 @@ class CallNumberBrowseServiceTest {
     var request = request("callNumber >= B or callNumber < B", false);
     var context = contextAroundIncluding();
 
-    prepareMockForBrowsingAround(request, context, searchResult(browseItem("A 11")), searchResult(browseItem("C 11")));
+    prepareMockForBrowsingAround(request, context, browseResult(browseItem("A 11")), browseResult(browseItem("C 11")));
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(SearchResult.of(2, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(2, null, null, List.of(
       cnBrowseItem(instance("A 11"), "A 11"),
       cnBrowseItem(instance("C 11"), "C 11"))));
   }
@@ -123,11 +123,11 @@ class CallNumberBrowseServiceTest {
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, true)).thenReturn(succeedingQuery);
     when(searchRepository.search(request, succeedingQuery)).thenReturn(succeedingResponse);
-    when(resultConverter.convert(succeedingResponse, context, true)).thenReturn(searchResult(browseItems("C1", "C2")));
+    when(resultConverter.convert(succeedingResponse, context, true)).thenReturn(browseResult(browseItems("C1", "C2")));
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(SearchResult.of(2, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(2, null, null, List.of(
       cnBrowseItem(instance("C1"), "C1"), cnBrowseItem(instance("C2"), "C2"))));
   }
 
@@ -140,16 +140,16 @@ class CallNumberBrowseServiceTest {
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, false)).thenReturn(precedingQuery);
     when(searchRepository.search(request, precedingQuery)).thenReturn(precedingResponse);
-    when(resultConverter.convert(precedingResponse, context, false)).thenReturn(searchResult(browseItems("A1", "A2")));
+    when(resultConverter.convert(precedingResponse, context, false)).thenReturn(browseResult(browseItems("A1", "A2")));
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(SearchResult.of(2, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(2, null, null, List.of(
       cnBrowseItem(instance("A1"), "A1"), cnBrowseItem(instance("A2"), "A2"))));
   }
 
   private void prepareMockForBrowsingAround(BrowseRequest request, BrowseContext context,
-    SearchResult<CallNumberBrowseItem> precedingResult, SearchResult<CallNumberBrowseItem> succeedingResult) {
+    BrowseResult<CallNumberBrowseItem> precedingResult, BrowseResult<CallNumberBrowseItem> succeedingResult) {
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, false)).thenReturn(precedingQuery);
     when(browseQueryProvider.get(request, context, true)).thenReturn(succeedingQuery);

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
@@ -41,7 +41,7 @@ class CallNumberBrowseServiceTest {
   @Mock private SearchRepository searchRepository;
   @Mock private BrowseContextProvider browseContextProvider;
   @Mock private CallNumberBrowseQueryProvider browseQueryProvider;
-  @Mock private CallNumberBrowseResultConverter resultConverter;
+  @Mock private CallNumberBrowseResultConverter browseResultConverter;
 
   @Mock private SearchResponse precedingResponse;
   @Mock private SearchResponse succeedingResponse;
@@ -123,7 +123,8 @@ class CallNumberBrowseServiceTest {
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, true)).thenReturn(succeedingQuery);
     when(searchRepository.search(request, succeedingQuery)).thenReturn(succeedingResponse);
-    when(resultConverter.convert(succeedingResponse, context, true)).thenReturn(browseResult(browseItems("C1", "C2")));
+    when(browseResultConverter.convert(succeedingResponse, context, true)).thenReturn(
+      browseResult(browseItems("C1", "C2")));
 
     var actual = callNumberBrowseService.browse(request);
 
@@ -140,7 +141,8 @@ class CallNumberBrowseServiceTest {
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, false)).thenReturn(precedingQuery);
     when(searchRepository.search(request, precedingQuery)).thenReturn(precedingResponse);
-    when(resultConverter.convert(precedingResponse, context, false)).thenReturn(browseResult(browseItems("A1", "A2")));
+    when(browseResultConverter.convert(precedingResponse, context, false)).thenReturn(
+      browseResult(browseItems("A1", "A2")));
 
     var actual = callNumberBrowseService.browse(request);
 
@@ -156,8 +158,8 @@ class CallNumberBrowseServiceTest {
 
     var msearchResponse = msearchResponse(precedingResponse, succeedingResponse);
     when(searchRepository.msearch(request, List.of(precedingQuery, succeedingQuery))).thenReturn(msearchResponse);
-    when(resultConverter.convert(precedingResponse, context, false)).thenReturn(precedingResult);
-    when(resultConverter.convert(succeedingResponse, context, true)).thenReturn(succeedingResult);
+    when(browseResultConverter.convert(precedingResponse, context, false)).thenReturn(precedingResult);
+    when(browseResultConverter.convert(succeedingResponse, context, true)).thenReturn(succeedingResult);
   }
 
   private static MultiSearchResponse msearchResponse(SearchResponse... responses) {

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.folio.search.utils.TestConstants.inventoryAuthorityTopic;
 import static org.folio.search.utils.TestUtils.asJsonString;
 import static org.folio.search.utils.TestUtils.doIfNotNull;
 import static org.folio.search.utils.TestUtils.randomId;
+import static org.folio.search.utils.TestUtils.removeEnvProperty;
 import static org.folio.search.utils.TestUtils.resourceEvent;
 import static org.folio.search.utils.TestUtils.setEnvProperty;
 import static org.hamcrest.Matchers.is;
@@ -41,6 +42,7 @@ import org.folio.search.support.extension.impl.OkapiConfiguration;
 import org.folio.search.utils.TestUtils;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.tenant.domain.dto.TenantAttributes;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -79,6 +81,11 @@ public abstract class BaseIntegrationTest {
   @BeforeAll
   static void cleanUpCaches(@Autowired CacheManager cacheManager) {
     TestUtils.cleanUpCaches(cacheManager);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    removeEnvProperty();
   }
 
   public static HttpHeaders defaultHeaders() {

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -58,7 +58,6 @@ import org.elasticsearch.search.aggregations.bucket.range.ParsedRange;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
 import org.folio.search.domain.dto.Authority;
 import org.folio.search.domain.dto.AuthorityBrowseItem;
-import org.folio.search.domain.dto.AuthorityBrowseResult;
 import org.folio.search.domain.dto.CallNumberBrowseItem;
 import org.folio.search.domain.dto.CallNumberBrowseResult;
 import org.folio.search.domain.dto.Facet;
@@ -73,6 +72,7 @@ import org.folio.search.domain.dto.ResourceEventType;
 import org.folio.search.domain.dto.SubjectBrowseItem;
 import org.folio.search.domain.dto.SubjectBrowseResult;
 import org.folio.search.domain.dto.Tags;
+import org.folio.search.model.BrowseResult;
 import org.folio.search.model.SearchResult;
 import org.folio.search.model.index.SearchDocumentBody;
 import org.folio.search.model.metadata.FieldDescription;
@@ -184,10 +184,6 @@ public class TestUtils {
 
   public static SubjectBrowseItem subjectBrowseItem(String subject) {
     return new SubjectBrowseItem().subject(subject);
-  }
-
-  public static AuthorityBrowseResult authorityBrowseResult(int totalRecords, List<AuthorityBrowseItem> items) {
-    return new AuthorityBrowseResult().totalRecords(totalRecords).items(items);
   }
 
   public static AuthorityBrowseItem authorityBrowseItem(String heading, Authority authority) {
@@ -368,8 +364,18 @@ public class TestUtils {
     return new SearchResult<T>().totalRecords(records.length).records(List.of(records));
   }
 
+  @SafeVarargs
+  public static <T> SearchResult<T> searchResult(int totalRecords, T... records) {
+    return new SearchResult<T>().totalRecords(totalRecords).records(List.of(records));
+  }
+
   public static <T> SearchResult<T> searchResult(List<T> records) {
     return new SearchResult<T>().totalRecords(records.size()).records(records);
+  }
+
+  @SafeVarargs
+  public static <T> BrowseResult<T> browseResult(T... records) {
+    return new BrowseResult<T>().totalRecords(records.length).records(List.of(records));
   }
 
   public static Facet facet(List<FacetItem> items) {


### PR DESCRIPTION
### Purpose
Next\Prev buttons must be disabled on UI if there is no data in forward\backward directions, mod-search must mark the first and last pages of browse results.

### Approach
- It's impossible to mark the first and the last page because browsing operates with a term - `anchor` which is actually cursor, and `prev`/`next` values can be helpful to implement it.
- Add cursor parameters for browsing for backward and forward directions:
  - **around/around_including**: the `prev` and `next` values will be filled with values for forward and backward queries if there are any records, one of them can be null or undefined if browsing in the following direction will produce zero results.
  - **forward/foward_including**: only `next` value is specified, it can be null if there are no records ahead
  - **backward/bacward_including**: only `prev` value is specified, it can be null if there are no records below
