### PR TITLE
MSEARCH-323 Make populating of intermediate shelf-keys configurable

### DIFF
--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseResultConverter.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseResultConverter.java
@@ -5,6 +5,7 @@ import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.toRootUpperCase;
+import static org.folio.search.domain.dto.TenantConfiguredFeature.BROWSE_CN_INTERMEDIATE_VALUES;
 import static org.folio.search.utils.CollectionUtils.findFirst;
 import static org.folio.search.utils.CollectionUtils.reverse;
 import static org.folio.search.utils.CollectionUtils.toStreamSafe;
@@ -15,6 +16,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -25,6 +27,7 @@ import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.model.SearchResult;
 import org.folio.search.model.service.BrowseContext;
+import org.folio.search.service.FeatureConfigService;
 import org.folio.search.service.converter.ElasticsearchDocumentConverter;
 import org.springframework.stereotype.Component;
 
@@ -33,6 +36,7 @@ import org.springframework.stereotype.Component;
 public class CallNumberBrowseResultConverter {
 
   private final ElasticsearchDocumentConverter documentConverter;
+  private final FeatureConfigService featureConfigService;
 
   /**
    * Converts received {@link SearchResponse} from Elasticsearch to browsing {@link SearchResult} object.
@@ -50,7 +54,10 @@ public class CallNumberBrowseResultConverter {
     }
 
     var items = isForwardBrowsing ? browseItems : reverse(browseItems);
-    var populatedItems = populateCallNumberBrowseItems(items, ctx, isForwardBrowsing);
+    var populatedItems = featureConfigService.isEnabled(BROWSE_CN_INTERMEDIATE_VALUES)
+      ? populateItemsWithIntermediateResults(items, ctx, isForwardBrowsing)
+      : fillItemsWithFullCallNumbers(items, ctx, isForwardBrowsing);
+
     return searchResult.records(collapseCallNumberBrowseItems(populatedItems));
   }
 
@@ -59,7 +66,7 @@ public class CallNumberBrowseResultConverter {
     return new CallNumberBrowseItem().totalRecords(1).instance(instance).shelfKey(shelfKey);
   }
 
-  private static List<CallNumberBrowseItem> populateCallNumberBrowseItems(List<CallNumberBrowseItem> browseItems,
+  private static List<CallNumberBrowseItem> populateItemsWithIntermediateResults(List<CallNumberBrowseItem> browseItems,
     BrowseContext ctx, boolean isBrowsingForward) {
     var lower = browseItems.get(0).getShelfKey();
     var upper = browseItems.get(browseItems.size() - 1).getShelfKey();
@@ -68,6 +75,14 @@ public class CallNumberBrowseResultConverter {
       .flatMap(Collection::stream)
       .filter(browseItem -> isValidBrowseItem(browseItem, ctx, isBrowsingForward))
       .sorted(comparing(CallNumberBrowseItem::getShelfKey))
+      .collect(toList());
+  }
+
+  private static List<CallNumberBrowseItem> fillItemsWithFullCallNumbers(
+    List<CallNumberBrowseItem> items, BrowseContext ctx, boolean isBrowsingForward) {
+    return items.stream()
+      .filter(item -> isValidBrowseItem(item, ctx, isBrowsingForward))
+      .map(browseItem -> browseItem.fullCallNumber(getFullCallNumber(browseItem)))
       .collect(toList());
   }
 
@@ -92,22 +107,34 @@ public class CallNumberBrowseResultConverter {
       .distinct()
       .map(StringUtils::toRootUpperCase)
       .filter(shelfKey -> shelfKey.compareTo(lower) >= 0 && shelfKey.compareTo(upper) <= 0)
-      .map(shelfKey -> mapToCallNumberBrowseItem(browseItem, shelfKey, itemsByShelfKeys.get(shelfKey)))
+      .map(shelfKey -> mapToCallNumberBrowseItem(browseItem, shelfKey, findFirst(itemsByShelfKeys.get(shelfKey))))
       .collect(toList());
   }
 
-  private static CallNumberBrowseItem mapToCallNumberBrowseItem(CallNumberBrowseItem browseItem,
-    String shelfKey, List<Item> relatedItems) {
-    var fullCallNumber = findFirst(relatedItems)
+  private static CallNumberBrowseItem mapToCallNumberBrowseItem(
+    CallNumberBrowseItem browseItem, String shelfKey, Optional<Item> optionalOfItem) {
+    return new CallNumberBrowseItem()
+      .shelfKey(shelfKey)
+      .fullCallNumber(getFullCallNumber(optionalOfItem))
+      .instance(browseItem.getInstance())
+      .totalRecords(1);
+  }
+
+  private static String getFullCallNumber(CallNumberBrowseItem browseItem) {
+    return getFullCallNumber(
+      Optional.ofNullable(browseItem.getInstance())
+        .map(Instance::getItems)
+        .stream()
+        .flatMap(Collection::stream)
+        .filter(item -> Objects.equals(browseItem.getShelfKey(), item.getEffectiveShelvingOrder()))
+        .findFirst());
+  }
+
+  private static String getFullCallNumber(Optional<Item> optionalOfItem) {
+    return optionalOfItem
       .map(Item::getEffectiveCallNumberComponents)
       .map(cn -> getEffectiveCallNumber(cn.getPrefix(), cn.getCallNumber(), cn.getSuffix()))
       .orElse(null);
-
-    return new CallNumberBrowseItem()
-      .shelfKey(shelfKey)
-      .fullCallNumber(fullCallNumber)
-      .instance(browseItem.getInstance())
-      .totalRecords(1);
   }
 
   private static List<CallNumberBrowseItem> collapseCallNumberBrowseItems(List<CallNumberBrowseItem> items) {

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -31,10 +31,8 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
     var isForwardBrowsing = context.isForwardBrowsing();
     var searchSource = callNumberBrowseQueryProvider.get(request, context, isForwardBrowsing);
     var searchResponse = searchRepository.search(request, searchSource);
-
     var searchResult = callNumberBrowseResultConverter.convert(searchResponse, context, isForwardBrowsing);
-    searchResult.setRecords(trim(searchResult.getRecords(), context, isForwardBrowsing));
-    return searchResult;
+    return searchResult.records(trim(searchResult.getRecords(), context, isForwardBrowsing));
   }
 
   @Override

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -531,6 +531,7 @@ components:
         type: string
         enum:
           - search.all.fields
+          - browse.cn.intermediate.values
     x-okapi-tenant-header:
       name: x-okapi-tenant
       in: header

--- a/src/main/resources/swagger.api/schemas/tenantConfiguredFeature.json
+++ b/src/main/resources/swagger.api/schemas/tenantConfiguredFeature.json
@@ -3,6 +3,7 @@
   "type": "string",
   "description": "The feature name.",
   "enum": [
-    "search.all.fields"
+    "search.all.fields",
+    "browse.cn.intermediate.values"
   ]
 }

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseResultConverterTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseResultConverterTest.java
@@ -5,6 +5,7 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
+import static org.folio.search.domain.dto.TenantConfiguredFeature.BROWSE_CN_INTERMEDIATE_VALUES;
 import static org.folio.search.utils.SearchUtils.CALL_NUMBER_BROWSING_FIELD;
 import static org.folio.search.utils.TestUtils.OBJECT_MAPPER;
 import static org.folio.search.utils.TestUtils.cnBrowseItem;
@@ -27,10 +28,13 @@ import org.folio.search.domain.dto.CallNumberBrowseItem;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
+import org.folio.search.model.SearchResult;
 import org.folio.search.model.service.BrowseContext;
+import org.folio.search.service.FeatureConfigService;
 import org.folio.search.service.converter.ElasticsearchDocumentConverter;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -47,8 +51,9 @@ class CallNumberBrowseResultConverterTest {
   @InjectMocks private CallNumberBrowseResultConverter resultConverter;
   @Spy private ElasticsearchDocumentConverter documentConverter = new ElasticsearchDocumentConverter(OBJECT_MAPPER);
 
-  @Mock private SearchResponse searchResponse;
   @Mock private SearchHits searchHits;
+  @Mock private SearchResponse searchResponse;
+  @Mock private FeatureConfigService featureConfigService;
 
   @MethodSource("testDataProvider")
   @DisplayName("convert_positive_parameterized")
@@ -58,17 +63,76 @@ class CallNumberBrowseResultConverterTest {
     when(searchResponse.getHits()).thenReturn(searchHits);
     when(searchHits.getHits()).thenReturn(hits.toArray(SearchHit[]::new));
     when(searchHits.getTotalHits()).thenReturn(new TotalHits(100, Relation.EQUAL_TO));
+    when(featureConfigService.isEnabled(BROWSE_CN_INTERMEDIATE_VALUES)).thenReturn(true);
 
     var actual = resultConverter.convert(searchResponse, ctx, isBrowsingForward);
 
-    assertThat(actual.getRecords()).isEqualTo(expected);
-    assertThat(actual.getTotalRecords()).isEqualTo(100);
+    assertThat(actual).isEqualTo(SearchResult.of(100, expected));
+    verify(documentConverter).convertToSearchResult(any(SearchResponse.class), eq(Instance.class), any());
+  }
+
+  @Test
+  void convert_positive_forwardZeroResults() {
+    when(searchResponse.getHits()).thenReturn(searchHits);
+    when(searchHits.getHits()).thenReturn(new SearchHit[0]);
+    when(searchHits.getTotalHits()).thenReturn(new TotalHits(0, Relation.EQUAL_TO));
+
+    var actual = resultConverter.convert(searchResponse, forwardContext(), true);
+
+    assertThat(actual).isEqualTo(SearchResult.empty());
+    verify(documentConverter).convertToSearchResult(any(SearchResponse.class), eq(Instance.class), any());
+  }
+
+  @Test
+  void convert_positive_backwardZeroResults() {
+    when(searchResponse.getHits()).thenReturn(searchHits);
+    when(searchHits.getHits()).thenReturn(new SearchHit[0]);
+    when(searchHits.getTotalHits()).thenReturn(new TotalHits(0, Relation.EQUAL_TO));
+
+    var actual = resultConverter.convert(searchResponse, backwardContext(), false);
+
+    assertThat(actual).isEqualTo(SearchResult.empty());
+    verify(documentConverter).convertToSearchResult(any(SearchResponse.class), eq(Instance.class), any());
+  }
+
+  @Test
+  void convert_positive_intermediateResultsNotPopulatedForBrowsingForward() {
+    var hits = new SearchHit[] {
+      searchHit("A", instance("A", "A1", "A2")),
+      searchHit("B1", instance("B1", "B2", "C2")),
+      searchHit("C1", instance("C1", "C2"))};
+    when(searchResponse.getHits()).thenReturn(searchHits);
+    when(searchHits.getHits()).thenReturn(hits);
+    when(searchHits.getTotalHits()).thenReturn(new TotalHits(10, Relation.EQUAL_TO));
+    when(featureConfigService.isEnabled(BROWSE_CN_INTERMEDIATE_VALUES)).thenReturn(false);
+
+    var actual = resultConverter.convert(searchResponse, forwardContext(), true);
+
+    assertThat(actual).isEqualTo(SearchResult.of(10, List.of(
+      cnBrowseItem(instance("B1", "B2", "C2"), "B1"), cnBrowseItem(instance("C1", "C2"), "C1"))));
+    verify(documentConverter).convertToSearchResult(any(SearchResponse.class), eq(Instance.class), any());
+  }
+
+  @Test
+  void convert_positive_intermediateResultsNotPopulatedForBrowsingBackward() {
+    var hits = new SearchHit[] {
+      searchHit("F", instance("E1", "E2", "F")),
+      searchHit("C4", instance("C1", "C2", "C4")),
+      searchHit("B2", instance("B1", "B2"))};
+    when(searchResponse.getHits()).thenReturn(searchHits);
+    when(searchHits.getHits()).thenReturn(hits);
+    when(searchHits.getTotalHits()).thenReturn(new TotalHits(10, Relation.EQUAL_TO));
+    when(featureConfigService.isEnabled(BROWSE_CN_INTERMEDIATE_VALUES)).thenReturn(false);
+
+    var actual = resultConverter.convert(searchResponse, backwardContext(), false);
+
+    assertThat(actual).isEqualTo(SearchResult.of(10, List.of(
+      cnBrowseItem(instance("B1", "B2"), "B2"), cnBrowseItem(instance("C1", "C2", "C4"), "C4"))));
     verify(documentConverter).convertToSearchResult(any(SearchResponse.class), eq(Instance.class), any());
   }
 
   private static Stream<Arguments> testDataProvider() {
     return Stream.of(
-      arguments("forward: 0 resources", emptyList(), forwardContext(), true, emptyList()),
       arguments("forward: 1 resource", searchHits("B1"), forwardContext(), true, List.of(browseItem("B1"))),
       arguments("forward: 1 resource(included anchor)", searchHits("A"), forwardContext(), true, emptyList()),
       arguments("forward: 1 resource(excluded anchor)",
@@ -100,7 +164,6 @@ class CallNumberBrowseResultConverterTest {
       arguments("forward: n resources, invalid resources are ignored (anchor excluded)",
         searchHits("0", "123", "928", "A", "A1", "A2"), forwardContext(), true, browseItems("A1", "A2")),
 
-      arguments("backward: 0 resources", emptyList(), backwardContext(), false, emptyList()),
       arguments("backward: 1 resource", searchHits("C"), backwardContext(), false, browseItems("C")),
       arguments("backward: 1 resource (excluding anchor)", searchHits("F"), backwardContext(), false, emptyList()),
       arguments("backward: 1 resource (including anchor)",

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
@@ -41,7 +41,7 @@ class CallNumberBrowseServiceTest {
   @Mock private SearchRepository searchRepository;
   @Mock private BrowseContextProvider browseContextProvider;
   @Mock private CallNumberBrowseQueryProvider browseQueryProvider;
-  @Mock private CallNumberBrowseResultConverter resultConverter;
+  @Mock private CallNumberBrowseResultConverter browseResultConverter;
 
   @Mock private SearchResponse precedingResponse;
   @Mock private SearchResponse succeedingResponse;
@@ -123,7 +123,8 @@ class CallNumberBrowseServiceTest {
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, true)).thenReturn(succeedingQuery);
     when(searchRepository.search(request, succeedingQuery)).thenReturn(succeedingResponse);
-    when(resultConverter.convert(succeedingResponse, context, true)).thenReturn(searchResult(browseItems("C1", "C2")));
+    when(browseResultConverter.convert(succeedingResponse, context, true)).thenReturn(
+      searchResult(browseItems("C1", "C2")));
 
     var actual = callNumberBrowseService.browse(request);
 
@@ -140,7 +141,8 @@ class CallNumberBrowseServiceTest {
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, false)).thenReturn(precedingQuery);
     when(searchRepository.search(request, precedingQuery)).thenReturn(precedingResponse);
-    when(resultConverter.convert(precedingResponse, context, false)).thenReturn(searchResult(browseItems("A1", "A2")));
+    when(browseResultConverter.convert(precedingResponse, context, false)).thenReturn(
+      searchResult(browseItems("A1", "A2")));
 
     var actual = callNumberBrowseService.browse(request);
 
@@ -156,8 +158,8 @@ class CallNumberBrowseServiceTest {
 
     var msearchResponse = msearchResponse(precedingResponse, succeedingResponse);
     when(searchRepository.msearch(request, List.of(precedingQuery, succeedingQuery))).thenReturn(msearchResponse);
-    when(resultConverter.convert(precedingResponse, context, false)).thenReturn(precedingResult);
-    when(resultConverter.convert(succeedingResponse, context, true)).thenReturn(succeedingResult);
+    when(browseResultConverter.convert(precedingResponse, context, false)).thenReturn(precedingResult);
+    when(browseResultConverter.convert(succeedingResponse, context, true)).thenReturn(succeedingResult);
   }
 
   private static MultiSearchResponse msearchResponse(SearchResponse... responses) {

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -291,7 +291,6 @@ public abstract class BaseIntegrationTest {
   }
 
   @SneakyThrows
-  @SuppressWarnings("SameParameterValue")
   protected static void enableFeature(TenantConfiguredFeature feature) {
     enableFeature(TENANT_ID, feature);
   }
@@ -302,6 +301,21 @@ public abstract class BaseIntegrationTest {
     mockMvc.perform(post(ApiEndpoints.featureConfig())
         .headers(defaultHeaders(tenantId))
         .content(asJsonString(new FeatureConfig().feature(feature).enabled(true))))
+      .andExpect(status().isOk());
+  }
+
+  @SneakyThrows
+  @SuppressWarnings("SameParameterValue")
+  protected static void disableFeature(TenantConfiguredFeature feature) {
+    disableFeature(TENANT_ID, feature);
+  }
+
+  @SneakyThrows
+  @SuppressWarnings("SameParameterValue")
+  protected static void disableFeature(String tenantId, TenantConfiguredFeature feature) {
+    mockMvc.perform(put(ApiEndpoints.featureConfig(feature))
+        .headers(defaultHeaders(tenantId))
+        .content(asJsonString(new FeatureConfig().feature(feature).enabled(false))))
       .andExpect(status().isOk());
   }
 


### PR DESCRIPTION
### Purpose
The current implementation of call-number browsing by all schemas allows mod-search to populate new rows from the instance level items if they have shelf keys between the found value by Elasticsearch and the next value. This feature sometimes can provide a list of rows for UI with the same title and call number, which is confusing.

### Approach
- Implement a new feature called - `browse.cn.intermediate.values`
- Add an integration test to validate that intermediate values can be populated
- Make this option disabled by default
