### PR TITLE
MSEARCH-268 Application must stop if port is already in use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <openapi-generator.version>5.3.1</openapi-generator.version>
     <es-client.version>7.10.2</es-client.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
+    <spring-kafka.version>2.8.4</spring-kafka.version>
     <apache-commons-io.version>2.7</apache-commons-io.version>
     <apache-commons-collections.version>4.4</apache-commons-collections.version>
     <marc4j.version>2.9.1</marc4j.version>
@@ -76,6 +77,7 @@
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
+      <version>${spring-kafka.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Purpose
When deploying mod-search and port is already in use, the service keeps running
Expected behavior: service (process) should abort/exit

### Approach
- Increment the minor version of spring-kafka to fix the issue

### Learning
Related issues and pull-requests:
- https://github.com/spring-projects/spring-kafka/issues/2055
- https://github.com/spring-projects/spring-kafka/pull/2060
