### PR TITLE
MSEARCH-331 Fix unsupported 'not' operator for search aliases

### DIFF
--- a/src/main/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessor.java
@@ -15,9 +15,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class EffectiveShelvingOrderTermProcessor implements SearchTermProcessor {
 
-  private static final Pattern DEWEY_NUMBER_PATTERN = Pattern.compile("\\d{4}(\\.\\d+)?(\\s.*)*");
+  private static final Pattern DEWEY_NUMBER_PATTERN = Pattern.compile("\\d{4}(\\.\\d+)?(\\s.{0,10}){0,10}");
   private static final Pattern SHELF_KEY_PATTERN =
-    Pattern.compile("([A-Z]+)\\s(\\d{2,}(\\.\\d+)?)(\\s[A-Z]\\d{1,10}){0,2}(\\s.*)*");
+    Pattern.compile("([A-Z]+)\\s(\\d{2,}(\\.\\d+)?)(\\s[A-Z]\\d{1,10}){0,2}(\\s.{0,10}){0,10}");
 
   private static final List<Pattern> PATTERNS = List.of(SHELF_KEY_PATTERN, DEWEY_NUMBER_PATTERN);
 

--- a/src/main/java/org/folio/search/cql/builders/NotEqualToTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/NotEqualToTermQueryBuilder.java
@@ -1,18 +1,31 @@
 package org.folio.search.cql.builders;
 
+import static org.elasticsearch.index.query.MultiMatchQueryBuilder.Type.CROSS_FIELDS;
+import static org.elasticsearch.index.query.Operator.AND;
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 
 import java.util.Set;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.springframework.stereotype.Component;
 
 @Component
-public class NotEqualToTermQueryBuilder implements TermQueryBuilder {
+public class NotEqualToTermQueryBuilder extends FulltextQueryBuilder {
+
+  @Override
+  public QueryBuilder getQuery(Object term, String resource, String... fields) {
+    return boolQuery().mustNot(multiMatchQuery(term, fields).operator(AND).type(CROSS_FIELDS));
+  }
+
+  @Override
+  public QueryBuilder getFulltextQuery(Object term, String fieldName, String resource) {
+    return getQuery(term, resource, updatePathForFulltextQuery(resource, fieldName));
+  }
 
   @Override
   public QueryBuilder getTermLevelQuery(Object term, String fieldName, String resource, String fieldIndex) {
-    return QueryBuilders.boolQuery().mustNot(termQuery(fieldName, term));
+    return boolQuery().mustNot(termQuery(fieldName, term));
   }
 
   @Override

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -46,7 +46,9 @@ class SearchInstanceIT extends BaseIntegrationTest {
   @ParameterizedTest(name = "[{index}] {0}")
   @CsvSource({
     "title == {value}, web semantic",
+    "title <> {value}, A semantic web primer",
     "title all {value}, semantic web word",
+    "indexTitle <> {value}, Semantic web primer",
     "uniformTitle all {value}, deja vu",
     "uniformTitle all {value}, déjà vu",
     "contributors.name all {value}, franks",
@@ -62,7 +64,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
   })
   @DisplayName("can search by instances (nothing found)")
   void searchByInstances_parameterized_zeroResults(String query, String value) throws Throwable {
-    doSearchByInstances(prepareQuery(query, value)).andExpect(jsonPath("$.totalRecords", is(0)));
+    doSearchByInstances(prepareQuery(query, '"' + value + '"')).andExpect(jsonPath("$.totalRecords", is(0)));
   }
 
   @Test
@@ -91,6 +93,9 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("id = {value}", getSemanticWebId()),
       arguments("id = {value}", "5bf370e0*a0a39"),
       arguments("id == {value}", getSemanticWebId()),
+
+      arguments("title <> {value}", "unknown value"),
+      arguments("indexTitle <> {value}", "unknown value"),
 
       arguments("title all {value}", "semantic"),
       arguments("title all {value}", "primers"),
@@ -239,6 +244,6 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("holdingsIdentifiers == {value}", "1d76ee84-d776-48d2-ab96-140c24e39ac5"),
       arguments("holdingsIdentifiers all {value}", "9b8ec096-fa2e-451b-8e7a-6d1c977ee946"),
       arguments("holdingsIdentifiers all {value}", "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19")
-      );
+    );
   }
 }


### PR DESCRIPTION
### Purpose
Since the refactoring of the query builder mechanism one of operator became unsupported.

### Approach
- Support `<>` operator for full-text fields and search aliases.
- Add additional integration test cases
- Fix the sonarcloud issue with regular expressions in EffectiveShelvingOrderTermProcessor.java