### PR TITLE
MSEARCH-334 Fix the invalid search results for call-number with 2+ spaces

### DIFF
--- a/src/main/java/org/folio/search/service/setter/instance/CallNumberProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/CallNumberProcessor.java
@@ -49,7 +49,7 @@ public class CallNumberProcessor implements FieldProcessor<Instance, Set<Long>> 
    * </p>
    */
   public Long getCallNumberAsLong(String callNumber) {
-    var cleanCallNumber = callNumber.toUpperCase(ROOT).replaceAll("[^A-Z0-9. /]", " ").replaceAll("\\s+", " ").trim();
+    var cleanCallNumber = callNumber.toUpperCase(ROOT).replaceAll("[^A-Z0-9. /]", " ").trim();
     cleanCallNumber = cleanCallNumber.substring(0, Math.min(MAX_CHARS, cleanCallNumber.length()));
     long result = 0L;
     for (int i = 0; i < cleanCallNumber.length(); i++) {

--- a/src/test/java/org/folio/search/controller/CallNumberBrowseIT.java
+++ b/src/test/java/org/folio/search/controller/CallNumberBrowseIT.java
@@ -214,7 +214,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
         cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
         cnBrowseItem(instance("instance #42"), "FA 46252 3977 12 237"),
         cnBrowseItem(0, "FC", null, true),
-        cnBrowseItem(3, "FC 17 B89"),
+        cnBrowseItem(2, "FC 17 B89"),
         cnBrowseItem(instance("instance #31"), "G 45831 S2")
       ))),
 
@@ -223,7 +223,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
         cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
         cnBrowseItem(instance("instance #42"), "FA 46252 3977 12 237"),
         cnBrowseItem(0, "FC", null, true),
-        cnBrowseItem(3, "FC 17 B89"),
+        cnBrowseItem(2, "FC 17 B89"),
         cnBrowseItem(instance("instance #31"), "G 45831 S2")
       ))),
 
@@ -246,11 +246,11 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
 
       // checks if collapsing works in forward direction
       arguments(forwardQuery, "F", 5, cnBrowseResult(13, List.of(
+        cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1"),
         cnBrowseItem(instance("instance #27"), "F 43733 L370 41992"),
         cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
         cnBrowseItem(instance("instance #42"), "FA 46252 3977 12 237"),
-        cnBrowseItem(3, "FC 17 B89"),
-        cnBrowseItem(instance("instance #31"), "G 45831 S2")
+        cnBrowseItem(2, "FC 17 B89")
       ))),
 
       arguments(forwardQuery, "Z", 10, cnBrowseResult(0, emptyList())),
@@ -290,11 +290,19 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
 
       // check that collapsing works for browsing backward
       arguments(backwardQuery, "G", 5, cnBrowseResult(32, List.of(
-        cnBrowseItem(instance("instance #12"), "E 211 N52 VOL 14"),
+        cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1"),
         cnBrowseItem(instance("instance #27"), "F 43733 L370 41992"),
         cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
         cnBrowseItem(instance("instance #42"), "FA 46252 3977 12 237"),
-        cnBrowseItem(3, "FC 17 B89")
+        cnBrowseItem(2, "FC 17 B89")
+      ))),
+
+      arguments(backwardQuery, "F 1", 5, cnBrowseResult(32, List.of(
+        cnBrowseItem(instance("instance #35"), "E 12.11 I12 288 D"),
+        cnBrowseItem(instance("instance #33"), "E 12.11 I2 298"),
+        cnBrowseItem(instance("instance #27"), "E 211 A506"),
+        cnBrowseItem(instance("instance #12"), "E 211 N52 VOL 14"),
+        cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1")
       ))),
 
       arguments(backwardQuery, "A", 10, cnBrowseResult(0, emptyList())),
@@ -394,7 +402,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
       List.of("instance #43", List.of("FA 42010 3546 256")),
       List.of("instance #44", List.of("CE 16 B6713 X 41993")),
       List.of("instance #45", List.of("CE 16 B6724 41993")),
-      List.of("instance #46", List.of("FC 17 B89"))
+      List.of("instance #46", List.of("F  PR1866.S63 V.1 C.1"))
     );
   }
 }

--- a/src/test/java/org/folio/search/service/setter/instance/CallNumberProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/instance/CallNumberProcessorTest.java
@@ -32,7 +32,8 @@ class CallNumberProcessorTest {
     "A, AA", "A, AB", "AB, ABB", "A,AZ", "NZ,O", "EZ,F", "Z, ZZ", "1 1,1.2", "1,2", "EZZZZZZZZ,F", "EZ,G",
     "199999999,2", "0,1", "9,A", "9999999999, A", "99999999,a", "YZ,Z", "Z 12,Z12", "Z 12,Z.12",
     "HD 11, HD 22", "ZZ 8982, ZZ 9999999", "ABC, abc aab", "3327.21, 3327.21 OVERSIZE", "3325.21, 3325.22",
-    "HD 11.2,HD 225.6", "HD 45214.8, HD 45214.9", "3100.12345, 3100.12346", "3100.12345, 3100/12346"
+    "HD 11.2,HD 225.6", "HD 45214.8, HD 45214.9", "3100.12345, 3100.12346", "3100.12345, 3100/12346",
+    "F  PR1866.S63 V.1 C.1, F 11"
   })
   @DisplayName("getFieldValue_parameterized_comparePairs")
   @ParameterizedTest(name = "[{index}] cn1={0}, cn2={1}")


### PR DESCRIPTION
### Purpose
Call-numbers with double spaces after leading letter prevents from browsing in backward direction.

### Approach
- Fix the `CallNumberProcessor` to correctly process values with double-spaces
