### PR TITLE
MSEARCH-324 Use match all query for 'keyword=*'

### DIFF
--- a/src/main/java/org/folio/search/cql/CqlTermQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlTermQueryConverter.java
@@ -29,6 +29,7 @@ public class CqlTermQueryConverter {
 
   public static final String WILDCARD_OPERATOR = "wildcard";
   private static final String MATCH_ALL_CQL_QUERY = "cql.allRecords = 1";
+  private static final String KEYWORD_ALL_CQL_QUERY = "keyword = *";
 
   private final SearchFieldProvider searchFieldProvider;
   private final Map<String, TermQueryBuilder> termQueryBuilders;
@@ -58,7 +59,7 @@ public class CqlTermQueryConverter {
    * @return created Elasticsearch {@link QueryBuilder} object
    */
   public QueryBuilder getQuery(CQLTermNode termNode, String resource) {
-    if (MATCH_ALL_CQL_QUERY.equals(termNode.toCQL())) {
+    if (isMatchAllQuery(termNode.toCQL())) {
       return matchAllQuery();
     }
 
@@ -126,5 +127,9 @@ public class CqlTermQueryConverter {
     }
 
     return unmodifiableMap(queryBuildersMap);
+  }
+
+  private static boolean isMatchAllQuery(String cqlQuery) {
+    return MATCH_ALL_CQL_QUERY.equals(cqlQuery) || KEYWORD_ALL_CQL_QUERY.equals(cqlQuery);
   }
 }

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -160,6 +160,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("hrid == {value}", "*00022"),
       arguments("hrid == {value}", "*00000002*"),
 
+      arguments("keyword = *", ""),
       arguments("keyword all {value}", "semantic web primer"),
       arguments("subjects all {value}", "semantic"),
 

--- a/src/test/java/org/folio/search/cql/CqlTermQueryConverterTest.java
+++ b/src/test/java/org/folio/search/cql/CqlTermQueryConverterTest.java
@@ -26,6 +26,8 @@ import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.z3950.zing.cql.CQLParseException;
@@ -51,9 +53,10 @@ class CqlTermQueryConverterTest {
     cqlTermQueryConverter = new CqlTermQueryConverter(searchFieldProvider, termQueryBuilders, searchTermProcessors);
   }
 
-  @Test
-  void getQuery_positive_matchAll() {
-    var actual = cqlTermQueryConverter.getQuery(cqlTermNode("cql.allRecords=1"), RESOURCE_NAME);
+  @ParameterizedTest
+  @ValueSource(strings = {"cql.allRecords=1", "cql.allRecords = 1", "keyword=*", "keyword = *", "keyword = \"*\""})
+  void getQuery_positive_matchAll(String query) {
+    var actual = cqlTermQueryConverter.getQuery(cqlTermNode(query), RESOURCE_NAME);
     assertThat(actual).isEqualTo(matchAllQuery());
   }
 


### PR DESCRIPTION
### Purpose
Assuming that the instance title is mandatory for each resource - the wildcard query can be replaced with match_all query, which will increase the performance when the user will want to check the number of results.

### Approach
- Use elasticsearch `match_all` query for input like `keyword = *`
- Add integration and unit tests to validate it
