### PR TITLE
MSEARCH-333 Optimize the query to retrieve subject counts

### DIFF
--- a/src/main/java/org/folio/search/utils/SearchQueryUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchQueryUtils.java
@@ -3,8 +3,11 @@ package org.folio.search.utils;
 import static java.util.Locale.ROOT;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
+import static org.folio.search.utils.SearchUtils.SUBJECT_AGGREGATION_NAME;
+import static org.folio.search.utils.SearchUtils.getPathToFulltextPlainValue;
 
 import java.util.Collection;
 import java.util.Objects;
@@ -84,9 +87,11 @@ public class SearchQueryUtils {
    */
   public static SearchSourceBuilder getSubjectCountsQuery(Collection<String> subjects) {
     var lowercaseSubjects = subjects.stream().map(subject -> subject.toLowerCase(ROOT)).toArray(String[]::new);
-    var aggregation = AggregationBuilders.terms(SearchUtils.SUBJECT_AGGREGATION_NAME)
-      .size(subjects.size()).field(SearchUtils.getPathToFulltextPlainValue(SearchUtils.SUBJECT_AGGREGATION_NAME))
+    var keywordField = getPathToFulltextPlainValue(SUBJECT_AGGREGATION_NAME);
+    var query = boolQuery().filter(termsQuery(keywordField, lowercaseSubjects));
+    var aggregation = AggregationBuilders.terms(SUBJECT_AGGREGATION_NAME)
+      .size(subjects.size()).field(keywordField)
       .includeExclude(new IncludeExclude(lowercaseSubjects, null));
-    return searchSource().query(matchAllQuery()).size(0).from(0).aggregation(aggregation);
+    return searchSource().query(query).size(0).from(0).aggregation(aggregation);
   }
 }

--- a/src/test/java/org/folio/search/utils/SearchQueryUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchQueryUtilsTest.java
@@ -5,10 +5,15 @@ import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
+import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import java.util.List;
 import java.util.stream.Stream;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.folio.search.utils.types.UnitTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,6 +63,16 @@ class SearchQueryUtilsTest {
   void isFilterQuery_parameterized(QueryBuilder queryBuilder, boolean expected) {
     var actual = SearchQueryUtils.isFilterQuery(queryBuilder, FIELD::equals);
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void getSubjectCountsQuery_positive() {
+    var actual = SearchQueryUtils.getSubjectCountsQuery(List.of("s1", "s2"));
+    assertThat(actual).isEqualTo(searchSource().from(0).size(0)
+      .query(boolQuery().filter(termsQuery("plain_subjects", "s1", "s2")))
+      .aggregation(terms("subjects").size(2).field("plain_subjects")
+        .includeExclude(new IncludeExclude(new String[] {"s1", "s2"}, null)))
+    );
   }
 
   private static Stream<Arguments> isDisjunctionFilterQueryDataProvider() {


### PR DESCRIPTION
### Purpose
Current query to retrieve the subject counts provides results in 4-6 second. It can be optimized by moving filters from the aggregation to the query level.

### Approach
- Optimize the Elasticsearch query by adding filter query
- Add unit test to validate changes

### Learning
- https://wiki.folio.org/display/FOLIJET/MSEARCH-333+Optimize+query+for+subject+browsing
