### PR TITLE
MSEARCH-342 Add default prev/next values for browsing forward/backward

### DIFF
--- a/src/main/java/org/folio/search/service/browse/AbstractBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/AbstractBrowseService.java
@@ -2,6 +2,7 @@ package org.folio.search.service.browse;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.util.List;
@@ -56,9 +57,41 @@ public abstract class AbstractBrowseService<T> {
     this.browseContextProvider = browseContextProvider;
   }
 
+  /**
+   * Returns the value for browsing as {@link String} from {@link T} item.
+   *
+   * @param browseItem - browse item to process.
+   * @return value for next/prev field in browse response
+   */
+  protected abstract String getValueForBrowsing(T browseItem);
+
   protected static <T> List<T> trim(List<T> items, BrowseContext ctx, boolean isBrowsingForward) {
     return isBrowsingForward
       ? items.subList(0, min(ctx.getLimit(true), items.size()))
       : items.subList(max(items.size() - ctx.getLimit(false), 0), items.size());
+  }
+
+  protected String getPrevBrowsingValue(List<T> records, BrowseContext ctx, boolean isBrowsingForward) {
+    if (isBrowsingForward) {
+      return getShelfKeyByIndex(records, 0);
+    }
+    var limit = ctx.getLimit(false);
+    return getShelfKeyByIndex(records, limit, records.size() - limit);
+  }
+
+  protected String getNextBrowsingValue(List<T> records, BrowseContext ctx, boolean isBrowsingForward) {
+    if (isBrowsingForward) {
+      var limit = ctx.getLimit(true);
+      return getShelfKeyByIndex(records, limit, limit - 1);
+    }
+    return getShelfKeyByIndex(records, records.size() - 1);
+  }
+
+  private String getShelfKeyByIndex(List<T> items, int index) {
+    return isNotEmpty(items) ? getValueForBrowsing(items.get(index)) : null;
+  }
+
+  private String getShelfKeyByIndex(List<T> items, int limit, int idx) {
+    return items.size() <= limit ? null : getValueForBrowsing(items.get(idx));
   }
 }

--- a/src/main/java/org/folio/search/service/browse/AbstractBrowseServiceBySearchAfter.java
+++ b/src/main/java/org/folio/search/service/browse/AbstractBrowseServiceBySearchAfter.java
@@ -110,14 +110,6 @@ public abstract class AbstractBrowseServiceBySearchAfter<T, R> extends AbstractB
    */
   protected abstract BrowseResult<T> mapToBrowseResult(SearchResult<R> searchResult, boolean isAnchor);
 
-  /**
-   * Returns the value for browsing as {@link String} from {@link T} item.
-   *
-   * @param browseItem - browse item to process.
-   * @return value for next/prev field in browse response
-   */
-  protected abstract String getValueForBrowsing(T browseItem);
-
   private BrowseResult<T> createBrowseResult(Item[] responses, BrowseRequest request, BrowseContext context) {
     var precedingResult = documentConverter.convertToSearchResult(responses[0].getResponse(), browseResponseClass);
     var succeedingResult = documentConverter.convertToSearchResult(responses[1].getResponse(), browseResponseClass);
@@ -128,8 +120,8 @@ public abstract class AbstractBrowseServiceBySearchAfter<T, R> extends AbstractB
 
     return new BrowseResult<T>()
       .totalRecords(precedingResult.getTotalRecords())
-      .prev(getNextValueForBrowsing(precedingRecords, context.getPrecedingLimit()))
-      .next(getNextValueForBrowsing(succeedingRecords, context.getSucceedingLimit()))
+      .prev(getPrevBrowsingValue(precedingRecords, context, false))
+      .next(getNextBrowsingValue(succeedingRecords, context, true))
       .records(mergeSafelyToList(
         trim(reverse(precedingRecords), context, false),
         trim(succeedingRecords, context, true)));
@@ -157,7 +149,7 @@ public abstract class AbstractBrowseServiceBySearchAfter<T, R> extends AbstractB
     var browseResult = documentConverter.convertToSearchResult(responses[0].getResponse(), browseResponseClass);
     var anchorResult = documentConverter.convertToSearchResult(responses[1].getResponse(), browseResponseClass);
     var records = mergeSafelyToList(anchorResult.getRecords(), browseResult.getRecords());
-    return getBrowseResult(SearchResult.of(browseResult.getTotalRecords(), records), request, context);
+    return getBrowseResult(SearchResult.of(browseResult.getTotalRecords(), records), context);
   }
 
   private BrowseResult<T> getSearchResultWithoutAnchor(BrowseRequest request, BrowseContext context) {
@@ -165,19 +157,17 @@ public abstract class AbstractBrowseServiceBySearchAfter<T, R> extends AbstractB
     var searchSource = getSearchQuery(request, context, isBrowsingForward);
     var searchResponse = searchRepository.search(request, searchSource);
     var searchResult = documentConverter.convertToSearchResult(searchResponse, browseResponseClass);
-    return getBrowseResult(searchResult, request, context);
+    return getBrowseResult(searchResult, context);
   }
 
-  private BrowseResult<T> getBrowseResult(SearchResult<R> result, BrowseRequest request, BrowseContext context) {
+  private BrowseResult<T> getBrowseResult(SearchResult<R> result, BrowseContext context) {
     var isBrowsingForward = context.isBrowsingForward();
     var browseResult = mapToBrowseResult(result, false);
-    var nextValue = getNextValueForBrowsing(browseResult.getRecords(), request.getLimit());
-    browseResult = isBrowsingForward ? browseResult.next(nextValue) : browseResult.prev(nextValue);
     var records = isBrowsingForward ? browseResult.getRecords() : reverse(browseResult.getRecords());
-    return browseResult.records(trim(records, context, isBrowsingForward));
-  }
-
-  private String getNextValueForBrowsing(List<T> records, int limit) {
-    return records.size() <= limit ? null : getValueForBrowsing(records.get(limit - 1));
+    return new BrowseResult<T>()
+      .totalRecords(browseResult.getTotalRecords())
+      .prev(getPrevBrowsingValue(records, context, isBrowsingForward))
+      .next(getNextBrowsingValue(records, context, isBrowsingForward))
+      .records(trim(records, context, isBrowsingForward));
   }
 }

--- a/src/test/java/org/folio/search/controller/AuthorityBrowseIT.java
+++ b/src/test/java/org/folio/search/controller/AuthorityBrowseIT.java
@@ -184,7 +184,7 @@ class AuthorityBrowseIT extends BaseIntegrationTest {
 
       // browsing forward
       arguments(forwardQuery, "Brian K. Vaughan", 5, new AuthorityBrowseResult()
-        .totalRecords(14).prev(null).next("James Rollins")
+        .totalRecords(14).prev("Comic-Con").next("James Rollins")
         .items(List.of(
           authorityBrowseItem("Comic-Con", 7, "Conference Name", AUTHORIZED),
           authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED),
@@ -193,7 +193,7 @@ class AuthorityBrowseIT extends BaseIntegrationTest {
           authorityBrowseItem("James Rollins", 2, "Personal Name", REFERENCE)))),
 
       arguments(forwardQuery, "biology", 5, new AuthorityBrowseResult()
-        .totalRecords(14).prev(null).next("Disney")
+        .totalRecords(14).prev("Biomedical Symposium").next("Disney")
         .items(List.of(
           authorityBrowseItem("Biomedical Symposium", 8, "Conference Name", REFERENCE),
           authorityBrowseItem("Blumberg Green Beauty", 5, "Corporate Name", REFERENCE),
@@ -203,7 +203,7 @@ class AuthorityBrowseIT extends BaseIntegrationTest {
 
       // checks if collapsing works in forward direction
       arguments(forwardQuery, "F", 5, new AuthorityBrowseResult()
-        .totalRecords(14).prev(null).next("Novel")
+        .totalRecords(14).prev("Fantasy").next("Novel")
         .items(List.of(
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED),
@@ -216,7 +216,7 @@ class AuthorityBrowseIT extends BaseIntegrationTest {
         .items(emptyList())),
 
       arguments(forwardIncludingQuery, "Brian K. Vaughan", 5, new AuthorityBrowseResult()
-        .totalRecords(14).prev(null).next("Harry Potter")
+        .totalRecords(14).prev("Brian K. Vaughan").next("Harry Potter")
         .items(List.of(
           authorityBrowseItem("Brian K. Vaughan", 1, "Personal Name", AUTHORIZED),
           authorityBrowseItem("Comic-Con", 7, "Conference Name", AUTHORIZED),
@@ -225,7 +225,7 @@ class AuthorityBrowseIT extends BaseIntegrationTest {
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED)))),
 
       arguments(forwardIncludingQuery, "biology", 5, new AuthorityBrowseResult()
-        .totalRecords(14).prev(null).next("Disney")
+        .totalRecords(14).prev("Biomedical Symposium").next("Disney")
         .items(List.of(
           authorityBrowseItem("Biomedical Symposium", 8, "Conference Name", REFERENCE),
           authorityBrowseItem("Blumberg Green Beauty", 5, "Corporate Name", REFERENCE),
@@ -235,14 +235,14 @@ class AuthorityBrowseIT extends BaseIntegrationTest {
 
       // browsing backward
       arguments(backwardQuery, "Brian K. Vaughan", 5, new AuthorityBrowseResult()
-        .totalRecords(14).prev(null).next(null)
+        .totalRecords(14).prev(null).next("Blumberg Green Beauty")
         .items(List.of(
           authorityBrowseItem("Asia Pacific", 10, "Geographic Name", AUTHORIZED),
           authorityBrowseItem("Biomedical Symposium", 8, "Conference Name", REFERENCE),
           authorityBrowseItem("Blumberg Green Beauty", 5, "Corporate Name", REFERENCE)))),
 
       arguments(backwardQuery, "fun", 5, new AuthorityBrowseResult()
-        .totalRecords(14).prev("Blumberg Green Beauty").next(null)
+        .totalRecords(14).prev("Blumberg Green Beauty").next("Fantasy")
         .items(List.of(
           authorityBrowseItem("Blumberg Green Beauty", 5, "Corporate Name", REFERENCE),
           authorityBrowseItem("Brian K. Vaughan", 1, "Personal Name", AUTHORIZED),
@@ -251,7 +251,7 @@ class AuthorityBrowseIT extends BaseIntegrationTest {
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE)))),
 
       arguments(backwardQuery, "G", 5, new AuthorityBrowseResult()
-        .totalRecords(14).prev("Blumberg Green Beauty").next(null)
+        .totalRecords(14).prev("Blumberg Green Beauty").next("Fantasy")
         .items(List.of(
           authorityBrowseItem("Blumberg Green Beauty", 5, "Corporate Name", REFERENCE),
           authorityBrowseItem("Brian K. Vaughan", 1, "Personal Name", AUTHORIZED),
@@ -264,7 +264,7 @@ class AuthorityBrowseIT extends BaseIntegrationTest {
         .items(emptyList())),
 
       arguments(backwardIncludingQuery, "Brian K. Vaughan", 5, new AuthorityBrowseResult()
-        .totalRecords(14).prev(null).next(null)
+        .totalRecords(14).prev(null).next("Brian K. Vaughan")
         .items(List.of(
           authorityBrowseItem("Asia Pacific", 10, "Geographic Name", AUTHORIZED),
           authorityBrowseItem("Biomedical Symposium", 8, "Conference Name", REFERENCE),
@@ -272,7 +272,7 @@ class AuthorityBrowseIT extends BaseIntegrationTest {
           authorityBrowseItem("Brian K. Vaughan", 1, "Personal Name", AUTHORIZED)))),
 
       arguments(backwardIncludingQuery, "fun", 5, new AuthorityBrowseResult()
-        .totalRecords(14).prev("Blumberg Green Beauty").next(null)
+        .totalRecords(14).prev("Blumberg Green Beauty").next("Fantasy")
         .items(List.of(
           authorityBrowseItem("Blumberg Green Beauty", 5, "Corporate Name", REFERENCE),
           authorityBrowseItem("Brian K. Vaughan", 1, "Personal Name", AUTHORIZED),

--- a/src/test/java/org/folio/search/controller/CallNumberBrowseIT.java
+++ b/src/test/java/org/folio/search/controller/CallNumberBrowseIT.java
@@ -221,7 +221,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
 
       // browsing forward
       arguments(forwardQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(28).prev(null).next("DA 3880 K56 M27 41984").items(List.of(
+        .totalRecords(28).prev("DA 3700 B91 L79").next("DA 3880 K56 M27 41984").items(List.of(
           cnBrowseItem(instance("instance #36"), "DA 3700 B91 L79"),
           cnBrowseItem(instance("instance #09"), "DA 3700 C95 NO 18"),
           cnBrowseItem(instance("instance #41"), "DA 3870 B55 41868"),
@@ -230,7 +230,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
         ))),
 
       arguments(forwardQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(24).prev(null).next("DA 3900 C89 V1").items(List.of(
+        .totalRecords(24).prev("DA 3890 A1 I72 41885").next("DA 3900 C89 V1").items(List.of(
           cnBrowseItem(instance("instance #14"), "DA 3890 A1 I72 41885"),
           cnBrowseItem(instance("instance #22"), "DA 3890 A2 B76 42002"),
           cnBrowseItem(instance("instance #19"), "DA 3890 A2 F57 42011"),
@@ -240,7 +240,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
 
       // checks if collapsing works in forward direction
       arguments(forwardQuery, "F", 5, new CallNumberBrowseResult()
-        .totalRecords(13).prev(null).next("FC 17 B89").items(List.of(
+        .totalRecords(13).prev("F  PR1866.S63 V.1 C.1").next("FC 17 B89").items(List.of(
           cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1"),
           cnBrowseItem(instance("instance #27"), "F 43733 L370 41992"),
           cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
@@ -252,7 +252,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
         .totalRecords(0).prev(null).next(null).items(emptyList())),
 
       arguments(forwardIncludingQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(28).prev(null).next("DA 3870 H47 41975").items(List.of(
+        .totalRecords(28).prev("CE 210 K297 41858").next("DA 3870 H47 41975").items(List.of(
           cnBrowseItem(instance("instance #38"), "CE 210 K297 41858"),
           cnBrowseItem(instance("instance #36"), "DA 3700 B91 L79"),
           cnBrowseItem(instance("instance #09"), "DA 3700 C95 NO 18"),
@@ -261,7 +261,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
         ))),
 
       arguments(forwardIncludingQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(24).prev(null).next("DA 3900 C89 V1").items(List.of(
+        .totalRecords(24).prev("DA 3890 A1 I72 41885").next("DA 3900 C89 V1").items(List.of(
           cnBrowseItem(instance("instance #14"), "DA 3890 A1 I72 41885"),
           cnBrowseItem(instance("instance #22"), "DA 3890 A2 B76 42002"),
           cnBrowseItem(instance("instance #19"), "DA 3890 A2 F57 42011"),
@@ -271,7 +271,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
 
       // browsing backward
       arguments(backwardQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(8).prev("AC 11 A67 X 42000").next(null).items(List.of(
+        .totalRecords(8).prev("AC 11 A67 X 42000").next("CE 16 D86 X 41998").items(List.of(
           cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
           cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
           cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993"),
@@ -280,7 +280,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
         ))),
 
       arguments(backwardQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(24).prev("DA 3880 O6 L75").next(null).items(List.of(
+        .totalRecords(24).prev("DA 3880 O6 L75").next("DA 3880 O6 M96").items(List.of(
           cnBrowseItem(instance("instance #20"), "DA 3880 O6 L75"),
           cnBrowseItem(instance("instance #15"), "DA 3880 O6 L76"),
           cnBrowseItem(instance("instance #05"), "DA 3880 O6 M15"),
@@ -290,7 +290,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
 
       // check that collapsing works for browsing backward
       arguments(backwardQuery, "G", 5, new CallNumberBrowseResult()
-        .totalRecords(32).prev("F  PR1866.S63 V.1 C.1").next(null).items(List.of(
+        .totalRecords(32).prev("F  PR1866.S63 V.1 C.1").next("FC 17 B89").items(List.of(
           cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1"),
           cnBrowseItem(instance("instance #27"), "F 43733 L370 41992"),
           cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
@@ -299,7 +299,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
         ))),
 
       arguments(backwardQuery, "F 1", 5, new CallNumberBrowseResult()
-        .totalRecords(28).prev("E 12.11 I12 288 D").next(null).items(List.of(
+        .totalRecords(28).prev("E 12.11 I12 288 D").next("F  PR1866.S63 V.1 C.1").items(List.of(
           cnBrowseItem(instance("instance #35"), "E 12.11 I12 288 D"),
           cnBrowseItem(instance("instance #33"), "E 12.11 I2 298"),
           cnBrowseItem(instance("instance #27"), "E 211 A506"),
@@ -311,7 +311,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
         .totalRecords(0).prev(null).next(null).items(emptyList())),
 
       arguments(backwardIncludingQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(8).prev("AC 11 E8 NO 14 P S1487").next(null).items(List.of(
+        .totalRecords(8).prev("AC 11 E8 NO 14 P S1487").next("CE 210 K297 41858").items(List.of(
           cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
           cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993"),
           cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993"),
@@ -320,7 +320,7 @@ class CallNumberBrowseIT extends BaseIntegrationTest {
         ))),
 
       arguments(backwardIncludingQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(24).prev("DA 3880 O6 L75").next(null).items(List.of(
+        .totalRecords(24).prev("DA 3880 O6 L75").next("DA 3880 O6 M96").items(List.of(
           cnBrowseItem(instance("instance #20"), "DA 3880 O6 L75"),
           cnBrowseItem(instance("instance #15"), "DA 3880 O6 L76"),
           cnBrowseItem(instance("instance #05"), "DA 3880 O6 M15"),

--- a/src/test/java/org/folio/search/controller/SubjectBrowseIT.java
+++ b/src/test/java/org/folio/search/controller/SubjectBrowseIT.java
@@ -199,7 +199,7 @@ class SubjectBrowseIT extends BaseIntegrationTest {
 
       // browsing forward
       arguments(forwardQuery, "water", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev(null).next(null)
+        .totalRecords(22).prev("Water--Analysis").next(null)
         .items(List.of(
           subjectBrowseItem(1, "Water--Analysis"),
           subjectBrowseItem(1, "Water--Microbiology"),
@@ -207,7 +207,7 @@ class SubjectBrowseIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Water-supply")))),
 
       arguments(forwardQuery, "biology", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev(null).next("Fantasy")
+        .totalRecords(22).prev("Book").next("Fantasy")
         .items(List.of(
           subjectBrowseItem(1, "Book"),
           subjectBrowseItem(1, "Database design"),
@@ -217,7 +217,7 @@ class SubjectBrowseIT extends BaseIntegrationTest {
 
       // checks if collapsing works in forward direction
       arguments(forwardQuery, "F", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev(null).next("Religion")
+        .totalRecords(22).prev("Fantasy").next("Religion")
         .items(List.of(
           subjectBrowseItem(1, "Fantasy"),
           subjectBrowseItem(3, "History"),
@@ -228,7 +228,7 @@ class SubjectBrowseIT extends BaseIntegrationTest {
       arguments(forwardQuery, "Z", 10, subjectBrowseResult(22, emptyList())),
 
       arguments(forwardIncludingQuery, "water", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev(null).next(null)
+        .totalRecords(22).prev("Water").next(null)
         .items(List.of(
           subjectBrowseItem(1, "Water"),
           subjectBrowseItem(1, "Water--Analysis"),
@@ -237,7 +237,7 @@ class SubjectBrowseIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Water-supply")))),
 
       arguments(forwardIncludingQuery, "biology", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev(null).next("Fantasy")
+        .totalRecords(22).prev("Book").next("Fantasy")
         .items(List.of(
           subjectBrowseItem(1, "Book"),
           subjectBrowseItem(1, "Database design"),
@@ -247,7 +247,7 @@ class SubjectBrowseIT extends BaseIntegrationTest {
 
       // browsing backward
       arguments(backwardQuery, "water", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Science--Methodology").next(null)
+        .totalRecords(22).prev("Science--Methodology").next("United States")
         .items(List.of(
           subjectBrowseItem(1, "Science--Methodology"),
           subjectBrowseItem(1, "Science--Philosophy"),
@@ -256,7 +256,7 @@ class SubjectBrowseIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "United States")))),
 
       arguments(backwardQuery, "fun", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Book").next(null)
+        .totalRecords(22).prev("Book").next("Fantasy")
         .items(List.of(
           subjectBrowseItem(1, "Book"),
           subjectBrowseItem(1, "Database design"),
@@ -265,7 +265,7 @@ class SubjectBrowseIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Fantasy")))),
 
       arguments(backwardQuery, "G", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Book").next(null)
+        .totalRecords(22).prev("Book").next("Fantasy")
         .items(List.of(
           subjectBrowseItem(1, "Book"),
           subjectBrowseItem(1, "Database design"),
@@ -276,7 +276,7 @@ class SubjectBrowseIT extends BaseIntegrationTest {
       arguments(backwardQuery, "A", 10, subjectBrowseResult(22, emptyList())),
 
       arguments(backwardIncludingQuery, "water", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Science--Philosophy").next(null)
+        .totalRecords(22).prev("Science--Philosophy").next("Water")
         .items(List.of(
           subjectBrowseItem(1, "Science--Philosophy"),
           subjectBrowseItem(1, "Text"),
@@ -285,7 +285,7 @@ class SubjectBrowseIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Water")))),
 
       arguments(backwardIncludingQuery, "fun", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Book").next(null)
+        .totalRecords(22).prev("Book").next("Fantasy")
         .items(List.of(
           subjectBrowseItem(1, "Book"),
           subjectBrowseItem(1, "Database design"),

--- a/src/test/java/org/folio/search/service/browse/AuthorityBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/AuthorityBrowseServiceTest.java
@@ -77,7 +77,7 @@ class AuthorityBrowseServiceTest {
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, null, null, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, "s1", null, List.of(
       browseItem("s1"), browseItem("s2"), browseItem("s3"), browseItem("s4"), browseItem("s5"))));
   }
 
@@ -97,7 +97,7 @@ class AuthorityBrowseServiceTest {
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, null, null, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, "s1", null, List.of(
       browseItem("s1"), browseItem("s2"), browseItem("s3"), browseItem("s4"), browseItem("s5"))));
   }
 
@@ -115,7 +115,7 @@ class AuthorityBrowseServiceTest {
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(3, null, null, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(3, null, "s3", List.of(
       browseItem("s1"), browseItem("s2"), browseItem("s3"))));
   }
 
@@ -134,7 +134,7 @@ class AuthorityBrowseServiceTest {
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, null, "s4", List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, "s0", "s4", List.of(
       browseItem("s0"), browseItem("s1"), browseItem("s2"), browseItem("s3"), browseItem("s4"))));
   }
 
@@ -153,7 +153,7 @@ class AuthorityBrowseServiceTest {
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(10, null, null, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(10, "s0", null, List.of(
       browseItem("s0"), browseItem("s1"), browseItem("s2"), browseItem("s3"))));
   }
 
@@ -172,7 +172,7 @@ class AuthorityBrowseServiceTest {
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(6, null, "s5", List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(6, "s1", "s5", List.of(
       browseItem("s1"), browseItem("s2"), browseItem("s3"), browseItem("s4"), browseItem("s5"))));
   }
 
@@ -191,7 +191,7 @@ class AuthorityBrowseServiceTest {
 
     var browseSearchResult = authorityBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(3, "s2", null, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(3, "s2", "s4", List.of(
       browseItem("s2"), browseItem("s3"), browseItem("s4"))));
   }
 

--- a/src/test/java/org/folio/search/service/browse/SubjectBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/SubjectBrowseServiceTest.java
@@ -75,7 +75,7 @@ class SubjectBrowseServiceTest {
 
     var browseSearchResult = subjectBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(6, null, "s5", List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(6, "s1", "s5", List.of(
       subjectBrowseItem(1, "s1"), subjectBrowseItem(2, "s2"), subjectBrowseItem(3, "s3"),
       subjectBrowseItem(2, "s4"), subjectBrowseItem(1, "s5"))));
   }
@@ -114,7 +114,7 @@ class SubjectBrowseServiceTest {
 
     var browseSearchResult = subjectBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(4, "s1", null, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(4, "s1", "s3", List.of(
       subjectBrowseItem(1, "s1"), subjectBrowseItem(2, "s2"), subjectBrowseItem(3, "s3"))));
   }
 
@@ -137,7 +137,7 @@ class SubjectBrowseServiceTest {
 
     var browseSearchResult = subjectBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, null, "s4", List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, "s0", "s4", List.of(
       subjectBrowseItem(1, "s0"), subjectBrowseItem(2, "s1"), subjectBrowseItem(3, "s2"),
       subjectBrowseItem(2, "s3"), subjectBrowseItem(1, "s4"))));
   }
@@ -161,7 +161,7 @@ class SubjectBrowseServiceTest {
 
     var browseSearchResult = subjectBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, null, null, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(5, "s1", null, List.of(
       subjectBrowseItem(2, "s1"), subjectBrowseItem(3, "s2"), subjectBrowseItem(2, "s3"),
       subjectBrowseItem(1, "s4"), subjectBrowseItem(10, "s5"))));
   }
@@ -183,7 +183,7 @@ class SubjectBrowseServiceTest {
 
     var browseSearchResult = subjectBrowseService.browse(request);
 
-    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(4, "s2", null, List.of(
+    assertThat(browseSearchResult).isEqualTo(BrowseResult.of(4, "s2", "s4", List.of(
       subjectBrowseItem(14, "s2"), subjectBrowseItem(5, "s3"), subjectBrowseItem(10, "s4"))));
   }
 
@@ -203,7 +203,7 @@ class SubjectBrowseServiceTest {
 
     var actual = subjectBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(BrowseResult.of(2, null, null, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(2, "s1", null, List.of(
       subjectBrowseItem(1, "s1"), subjectBrowseItem(2, "s2"))));
   }
 


### PR DESCRIPTION
### Purpose
In current implementation - for forward the previous value is null, for backward - next value is null. It can be improved by adding this value from the result list, assuming that these queries can be reached after initial request by browsing around.

### Approach
- Previous and next values are calculated on the existing dataset and they are provides more comfortable way to browse the catalog
- Unit and integration test are updated with the new field values

