### PR TITLE
MSEARCH-344 Implement response fields per feature/endpoint

### DIFF
--- a/src/main/java/org/folio/search/model/metadata/PlainFieldDescription.java
+++ b/src/main/java/org/folio/search/model/metadata/PlainFieldDescription.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.folio.search.model.types.ResponseGroupType;
 import org.folio.search.model.types.SearchType;
 
 /**
@@ -43,7 +44,7 @@ public class PlainFieldDescription extends FieldDescription {
   /**
    * Specifies if fields should be returned as part of elasticsearch response or not.
    */
-  private boolean showInResponse;
+  private List<ResponseGroupType> showInResponse = Collections.emptyList();
 
   /**
    * Search term processor, which pre-processes incoming term for elasticsearch request.

--- a/src/main/java/org/folio/search/model/types/ResponseGroupType.java
+++ b/src/main/java/org/folio/search/model/types/ResponseGroupType.java
@@ -1,0 +1,28 @@
+package org.folio.search.model.types;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResponseGroupType {
+
+  /**
+   * General response group type to return field for search endpoints.
+   */
+  SEARCH("search"),
+
+  /**
+   * General response group type to return field for browse endpoints.
+   */
+  BROWSE("browse"),
+
+  /**
+   * Response group type for fields returning only for call-number browsing.
+   */
+  CN_BROWSE("call-number-browse");
+
+  @JsonValue
+  private final String value;
+}

--- a/src/main/java/org/folio/search/service/SearchService.java
+++ b/src/main/java/org/folio/search/service/SearchService.java
@@ -1,6 +1,7 @@
 package org.folio.search.service;
 
 import static org.apache.commons.lang3.BooleanUtils.isFalse;
+import static org.folio.search.model.types.ResponseGroupType.SEARCH;
 
 import lombok.RequiredArgsConstructor;
 import org.folio.search.cql.CqlSearchQueryConverter;
@@ -42,7 +43,7 @@ public class SearchService {
       .trackTotalHits(true);
 
     if (isFalse(request.getExpandAll())) {
-      var includes = searchFieldProvider.getSourceFields(resource).toArray(String[]::new);
+      var includes = searchFieldProvider.getSourceFields(resource, SEARCH);
       queryBuilder.fetchSource(includes, null);
     }
 

--- a/src/main/java/org/folio/search/service/browse/AuthorityBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/AuthorityBrowseService.java
@@ -1,6 +1,7 @@
 package org.folio.search.service.browse;
 
 import static java.util.Locale.ROOT;
+import static org.apache.commons.lang3.BooleanUtils.isFalse;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
@@ -8,10 +9,10 @@ import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.elasticsearch.search.sort.SortBuilders.fieldSort;
 import static org.elasticsearch.search.sort.SortOrder.ASC;
 import static org.elasticsearch.search.sort.SortOrder.DESC;
+import static org.folio.search.model.types.ResponseGroupType.BROWSE;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.BooleanUtils;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.folio.search.domain.dto.Authority;
@@ -69,8 +70,6 @@ public class AuthorityBrowseService extends AbstractBrowseServiceBySearchAfter<A
   }
 
   private String[] getIncludedSourceFields(BrowseRequest request) {
-    return BooleanUtils.isFalse(request.getExpandAll())
-      ? searchFieldProvider.getSourceFields(request.getResource()).toArray(String[]::new)
-      : null;
+    return isFalse(request.getExpandAll()) ? searchFieldProvider.getSourceFields(request.getResource(), BROWSE) : null;
   }
 }

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseQueryProvider.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseQueryProvider.java
@@ -11,6 +11,7 @@ import static org.elasticsearch.search.sort.ScriptSortBuilder.ScriptSortType.STR
 import static org.elasticsearch.search.sort.SortBuilders.scriptSort;
 import static org.elasticsearch.search.sort.SortOrder.ASC;
 import static org.elasticsearch.search.sort.SortOrder.DESC;
+import static org.folio.search.model.types.ResponseGroupType.CN_BROWSE;
 
 import lombok.RequiredArgsConstructor;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -55,7 +56,7 @@ public class CallNumberBrowseQueryProvider {
       .sort(scriptSort(script, STRING).order(isBrowsingForward ? ASC : DESC));
 
     if (isFalse(request.getExpandAll())) {
-      var includes = searchFieldProvider.getSourceFields(request.getResource()).toArray(String[]::new);
+      var includes = searchFieldProvider.getSourceFields(request.getResource(), CN_BROWSE);
       searchSource.fetchSource(includes, null);
     }
 

--- a/src/main/java/org/folio/search/service/metadata/SearchFieldProvider.java
+++ b/src/main/java/org/folio/search/service/metadata/SearchFieldProvider.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import org.folio.search.model.metadata.PlainFieldDescription;
 import org.folio.search.model.metadata.SearchFieldType;
+import org.folio.search.model.types.ResponseGroupType;
 
 /**
  * Provides access to the index field type, which are used as reference in resource model and it's description in
@@ -38,12 +39,13 @@ public interface SearchFieldProvider {
   Optional<PlainFieldDescription> getPlainFieldByPath(String resource, String path);
 
   /**
-   * Provides list of fields of source fields for resource.
+   * Provides list of fields of source fields for resource and response group type.
    *
    * @param resource resource type as {@link String}
+   * @param groupType - response group type as {@link ResponseGroupType} object
    * @return list of fields.
    */
-  List<String> getSourceFields(String resource);
+  String[] getSourceFields(String resource, ResponseGroupType groupType);
 
   /**
    * Checks if given language is supported.

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -7,7 +7,7 @@
   "fields": {
     "id": {
       "index": "keyword",
-      "showInResponse": true
+      "showInResponse": [ "search", "browse" ]
     },
     "personalNameTitle": {
       "type": "authority",
@@ -234,7 +234,7 @@
       "processor": "headingTypeProcessor",
       "searchTypes": [ "facet", "filter", "sort" ],
       "rawProcessing": true,
-      "showInResponse": true,
+      "showInResponse": [ "search", "browse" ],
       "sort": {
         "fieldName": "headingType",
         "type": "collection",
@@ -247,7 +247,7 @@
       "processor": "authRefTypeProcessor",
       "searchTypes": [ "filter", "sort" ],
       "rawProcessing": true,
-      "showInResponse": true,
+      "showInResponse": [ "search", "browse" ],
       "sort": {
         "fieldName": "authRefType",
         "type": "collection",
@@ -260,7 +260,7 @@
       "processor": "headingRefProcessor",
       "searchTypes": "sort",
       "rawProcessing": true,
-      "showInResponse": true,
+      "showInResponse": [ "search", "browse" ],
       "mappings": {
         "copy_to": [ "sort_headingRef" ]
       }

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -18,13 +18,13 @@
       "searchTypes": [ "facet", "filter" ],
       "index": "bool",
       "default": false,
-      "showInResponse": true
+      "showInResponse": [ "search", "call-number-browse" ]
     }
   },
   "fields": {
     "id": {
       "index": "keyword",
-      "showInResponse": true
+      "showInResponse": [ "search", "call-number-browse" ]
     },
     "hrid": {
       "index": "keyword"
@@ -37,7 +37,7 @@
       "searchTypes": "sort",
       "searchAliases": [ "title", "keyword" ],
       "index": "multilang",
-      "showInResponse": true
+      "showInResponse": [ "search", "call-number-browse" ]
     },
     "alternativeTitles": {
       "type": "object",
@@ -77,15 +77,15 @@
         "name": {
           "searchAliases": [ "contributors", "keyword" ],
           "index": "standard",
-          "showInResponse": true
+          "showInResponse": [ "search", "call-number-browse" ]
         },
         "primary": {
           "index": "bool",
-          "showInResponse": true
+          "showInResponse": [ "search", "call-number-browse" ]
         },
         "contributorNameTypeId": {
           "index": "source",
-          "showInResponse": true
+          "showInResponse": [ "search", "call-number-browse" ]
         }
       }
     },
@@ -151,11 +151,11 @@
         "publisher": {
           "searchAliases": [ "publisher" ],
           "index": "multilang",
-          "showInResponse": true
+          "showInResponse": [ "search", "call-number-browse" ]
         },
         "dateOfPublication": {
           "index": "source",
-          "showInResponse": true
+          "showInResponse": [ "search", "call-number-browse" ]
         }
       }
     },
@@ -217,7 +217,7 @@
       "searchTypes": [ "facet", "filter" ],
       "index": "bool",
       "default": false,
-      "showInResponse": true
+      "showInResponse": [ "search", "call-number-browse" ]
     },
     "items": {
       "type": "object",
@@ -276,21 +276,21 @@
           "properties": {
             "callNumber": {
               "index": "source",
-              "showInResponse": true
+              "showInResponse": [ "search", "call-number-browse" ]
             },
             "prefix": {
               "index": "source",
-              "showInResponse": true
+              "showInResponse": [ "search", "call-number-browse" ]
             },
             "suffix": {
               "index": "source",
-              "showInResponse": true
+              "showInResponse": [ "search", "call-number-browse" ]
             }
           }
         },
         "effectiveShelvingOrder": {
           "index": "source",
-          "showInResponse": true
+          "showInResponse": [ "search", "call-number-browse" ]
         },
         "tags": {
           "type": "object",

--- a/src/main/resources/model/instance_subject.json
+++ b/src/main/resources/model/instance_subject.json
@@ -6,7 +6,8 @@
   },
   "fields": {
     "subject": {
-      "index": "keyword_lowercase"
+      "index": "keyword_lowercase",
+      "showInResponse": [ "browse" ]
     }
   }
 }

--- a/src/test/java/org/folio/search/service/SearchServiceTest.java
+++ b/src/test/java/org/folio/search/service/SearchServiceTest.java
@@ -15,7 +15,6 @@ import static org.folio.search.utils.TestUtils.searchServiceRequest;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
-import java.util.List;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;

--- a/src/test/java/org/folio/search/service/SearchServiceTest.java
+++ b/src/test/java/org/folio/search/service/SearchServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
+import static org.folio.search.model.types.ResponseGroupType.SEARCH;
 import static org.folio.search.utils.TestConstants.RESOURCE_ID;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
@@ -12,7 +13,6 @@ import static org.folio.search.utils.TestUtils.searchResult;
 import static org.folio.search.utils.TestUtils.searchServiceRequest;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.folio.search.cql.CqlSearchQueryConverter;
@@ -51,7 +51,7 @@ class SearchServiceTest {
       .trackTotalHits(true).fetchSource(array("field1", "field2"), null);
     var expectedSearchResult = searchResult(TestResource.of(RESOURCE_ID));
 
-    when(searchFieldProvider.getSourceFields(RESOURCE_NAME)).thenReturn(List.of("field1", "field2"));
+    when(searchFieldProvider.getSourceFields(RESOURCE_NAME, SEARCH)).thenReturn(new String[] {"field1", "field2"});
     when(cqlSearchQueryConverter.convert(SEARCH_QUERY, RESOURCE_NAME)).thenReturn(searchSourceBuilder);
     when(searchRepository.search(searchRequest, expectedSourceBuilder)).thenReturn(searchResponse);
     when(documentConverter.convertToSearchResult(searchResponse, TestResource.class)).thenReturn(expectedSearchResult);
@@ -62,8 +62,7 @@ class SearchServiceTest {
 
   @Test
   void search_negative_sumOfOffsetAndLimitExceeds10000() {
-    var searchRequest = CqlSearchRequest
-      .of(TestResource.class, TENANT_ID, SEARCH_QUERY, 500, 9600, false);
+    var searchRequest = CqlSearchRequest.of(TestResource.class, TENANT_ID, SEARCH_QUERY, 500, 9600, false);
     assertThatThrownBy(() -> searchService.search(searchRequest))
       .isInstanceOf(RequestValidationException.class)
       .hasMessage("The sum of limit and offset should not exceed 10000.");

--- a/src/test/java/org/folio/search/service/browse/AuthorityBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/AuthorityBrowseServiceTest.java
@@ -8,6 +8,7 @@ import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 import static org.elasticsearch.search.sort.SortBuilders.fieldSort;
 import static org.elasticsearch.search.sort.SortOrder.ASC;
 import static org.elasticsearch.search.sort.SortOrder.DESC;
+import static org.folio.search.model.types.ResponseGroupType.BROWSE;
 import static org.folio.search.utils.SearchUtils.AUTHORITY_RESOURCE;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.authorityBrowseItem;
@@ -91,7 +92,7 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(context);
     when(searchRepository.search(request, expectedSearchSource)).thenReturn(searchResponse);
-    when(searchFieldProvider.getSourceFields(AUTHORITY_RESOURCE)).thenReturn(List.of("id", "headingRef"));
+    when(searchFieldProvider.getSourceFields(AUTHORITY_RESOURCE, BROWSE)).thenReturn(new String[]{"id", "headingRef"});
     when(documentConverter.convertToSearchResult(searchResponse, Authority.class))
       .thenReturn(searchResult(authorities("s1", "s2", "s3", "s4", "s5")));
 

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseQueryProviderTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseQueryProviderTest.java
@@ -12,6 +12,7 @@ import static org.elasticsearch.search.sort.ScriptSortBuilder.ScriptSortType.STR
 import static org.elasticsearch.search.sort.SortBuilders.scriptSort;
 import static org.elasticsearch.search.sort.SortOrder.ASC;
 import static org.elasticsearch.search.sort.SortOrder.DESC;
+import static org.folio.search.model.types.ResponseGroupType.CN_BROWSE;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.mockito.Mockito.verify;
@@ -51,7 +52,7 @@ class CallNumberBrowseQueryProviderTest {
   @Test
   void get_positive_forward() {
     when(callNumberTermConverter.convert(ANCHOR)).thenReturn(ANCHOR_AS_NUMBER);
-    when(searchFieldProvider.getSourceFields(RESOURCE_NAME)).thenReturn(List.of("id", "title"));
+    when(searchFieldProvider.getSourceFields(RESOURCE_NAME, CN_BROWSE)).thenReturn(new String[] {"id", "title"});
     var context = BrowseContext.builder().anchor(ANCHOR).succeedingLimit(5).build();
 
     var actual = queryProvider.get(request(false), context, true);
@@ -63,7 +64,7 @@ class CallNumberBrowseQueryProviderTest {
   @Test
   void get_positive_forwardQueryWithFilters() {
     when(callNumberTermConverter.convert(ANCHOR)).thenReturn(ANCHOR_AS_NUMBER);
-    when(searchFieldProvider.getSourceFields(RESOURCE_NAME)).thenReturn(List.of("id", "title"));
+    when(searchFieldProvider.getSourceFields(RESOURCE_NAME, CN_BROWSE)).thenReturn(new String[] {"id", "title"});
     var filterQuery = termQuery("effectiveLocationId", "location#1");
     var context = BrowseContext.builder().anchor(ANCHOR).succeedingLimit(5)
       .filters(List.of(filterQuery)).build();
@@ -105,7 +106,7 @@ class CallNumberBrowseQueryProviderTest {
   @Test
   void get_positive_backward() {
     when(callNumberTermConverter.convert(ANCHOR)).thenReturn(ANCHOR_AS_NUMBER);
-    when(searchFieldProvider.getSourceFields(RESOURCE_NAME)).thenReturn(List.of("id", "title"));
+    when(searchFieldProvider.getSourceFields(RESOURCE_NAME, CN_BROWSE)).thenReturn(new String[] {"id", "title"});
     var context = BrowseContext.builder().anchor(ANCHOR).precedingLimit(5).build();
 
     var actual = queryProvider.get(request(false), context, false);

--- a/src/test/java/org/folio/search/service/metadata/LocalSearchFieldProviderTest.java
+++ b/src/test/java/org/folio/search/service/metadata/LocalSearchFieldProviderTest.java
@@ -1,8 +1,10 @@
 package org.folio.search.service.metadata;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.model.types.ResponseGroupType.SEARCH;
 import static org.folio.search.model.types.SearchType.FACET;
 import static org.folio.search.model.types.SearchType.FILTER;
 import static org.folio.search.utils.JsonUtils.jsonObject;
@@ -28,6 +30,7 @@ import org.folio.search.model.metadata.PostProcessResourceDescriptionConverter;
 import org.folio.search.model.metadata.ResourceDescription;
 import org.folio.search.model.metadata.SearchFieldDescriptor;
 import org.folio.search.model.metadata.SearchFieldType;
+import org.folio.search.model.types.ResponseGroupType;
 import org.folio.search.model.types.SearchType;
 import org.folio.search.utils.TestUtils;
 import org.folio.search.utils.types.UnitTest;
@@ -85,15 +88,15 @@ class LocalSearchFieldProviderTest {
 
   @Test
   void getSourceFields_positive() {
-    var actual = getSearchFieldProvider().getSourceFields(RESOURCE_NAME);
+    var actual = getSearchFieldProvider().getSourceFields(RESOURCE_NAME, SEARCH);
     assertThat(actual).containsExactlyInAnyOrder("id", "plain_title1", "title2.sub1",
       "title2.sub3.plain_sub5", "source");
   }
 
   @Test
   void getSourceFields_positive_nonExistingResource() {
-    var actual = getSearchFieldProvider().getSourceFields("unknown-resource");
-    assertThat(actual).isEmpty();
+    var actual = getSearchFieldProvider().getSourceFields("unknown-resource", SEARCH);
+    assertThat(actual).isNull();
   }
 
   @Test
@@ -132,7 +135,7 @@ class LocalSearchFieldProviderTest {
   void getPlainFieldByPath_positive() {
     when(metadataResourceProvider.getResourceDescription(RESOURCE_NAME)).thenReturn(Optional.of(resourceDescription()));
     var actual = getSearchFieldProvider().getPlainFieldByPath(RESOURCE_NAME, "id");
-    assertThat(actual).isPresent().get().isEqualTo(plainField("keyword", true));
+    assertThat(actual).isPresent().get().isEqualTo(plainField("keyword", List.of(SEARCH)));
   }
 
   @DisplayName("getPlainFieldByPath_parameterized")
@@ -223,18 +226,18 @@ class LocalSearchFieldProviderTest {
 
   private ResourceDescription resourceDescription() {
     return resourceDescription(mapOf(
-        "id", plainField("keyword", true),
+        "id", plainField("keyword", List.of(SEARCH)),
         "allInstance", multilangField("cql.all", "cql.allInstance"),
         "allItems", multilangField("cql.all", "cql.allItems"),
         "allHoldings", multilangField("cql.all", "cql.allHoldings"),
-        "title1", plainField("multilang", true, TITLE_SEARCH_TYPE),
+        "title1", plainField("multilang", List.of(SEARCH), TITLE_SEARCH_TYPE),
         "title2", objectField(mapOf(
-          "sub1", plainField("keyword", true, TITLE_SEARCH_TYPE),
-          "sub2", plainField("multilang", false, TITLE_SEARCH_TYPE),
+          "sub1", plainField("keyword", List.of(SEARCH), TITLE_SEARCH_TYPE),
+          "sub2", plainField("multilang", emptyList(), TITLE_SEARCH_TYPE),
           "sub3", objectField(mapOf(
-            "sub4", plainField("keyword", false, TITLE_SEARCH_TYPE),
-            "sub5", plainField("multilang", true))))),
-        "source", plainField("keyword", true),
+            "sub4", plainField("keyword", emptyList(), TITLE_SEARCH_TYPE),
+            "sub5", plainField("multilang", List.of(SEARCH)))))),
+        "source", plainField("keyword", List.of(SEARCH)),
         "oldFieldName", plainField(List.of("newFieldName"), FACET, FILTER)
       ),
       mapOf(
@@ -267,9 +270,9 @@ class LocalSearchFieldProviderTest {
 
   private static Stream<Arguments> getPlainFieldsByPathDataProvider() {
     return Stream.of(
-      arguments("id", plainField("keyword", true)),
-      arguments("title2.sub1", plainField("keyword", true, TITLE_SEARCH_TYPE)),
-      arguments("title2.sub3.sub4", plainField("keyword", false, TITLE_SEARCH_TYPE)),
+      arguments("id", plainField("keyword", List.of(SEARCH))),
+      arguments("title2.sub1", plainField("keyword", List.of(SEARCH), TITLE_SEARCH_TYPE)),
+      arguments("title2.sub3.sub4", plainField("keyword", emptyList(), TITLE_SEARCH_TYPE)),
       arguments("title2.sub3", null),
       arguments("title4", null),
       arguments("title1.subfield", null),
@@ -278,11 +281,12 @@ class LocalSearchFieldProviderTest {
     );
   }
 
-  private static PlainFieldDescription plainField(String index, boolean showInResponse, String... searchAliases) {
+  private static PlainFieldDescription plainField(
+    String index, List<ResponseGroupType> responseGroupTypes, String... searchAliases) {
     var fieldDescription = new PlainFieldDescription();
     fieldDescription.setIndex(index);
     fieldDescription.setSearchAliases(List.of(searchAliases));
-    fieldDescription.setShowInResponse(showInResponse);
+    fieldDescription.setShowInResponse(responseGroupTypes);
     return fieldDescription;
   }
 


### PR DESCRIPTION
### Purpose
Returning required fields per feature/endpoint could allow in future customize response body to minify its size

### Approach
- Replace boolean value for `showInResponse` with array of predefined response groups
- Update the related documentation and tests

