### PR TITLE
MSEARCH-319 Implement search across fields using operator 'and'

### DIFF
--- a/src/main/java/org/folio/search/cql/builders/AllTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/AllTermQueryBuilder.java
@@ -2,6 +2,7 @@ package org.folio.search.cql.builders;
 
 import static org.elasticsearch.index.query.MultiMatchQueryBuilder.Type.CROSS_FIELDS;
 import static org.elasticsearch.index.query.Operator.AND;
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
 
@@ -14,6 +15,20 @@ public class AllTermQueryBuilder extends FulltextQueryBuilder {
 
   @Override
   public QueryBuilder getQuery(Object term, String resource, String... fields) {
+    if (term instanceof String) {
+      var stringTerm = (String) term;
+      var terms = stringTerm.split("\\s+");
+      if (terms.length == 1) {
+        return multiMatchQuery(terms[0], fields);
+      }
+
+      var boolQuery = boolQuery();
+      for (var singleTerm : terms) {
+        boolQuery.must(multiMatchQuery(singleTerm, fields));
+      }
+      return boolQuery;
+    }
+
     return multiMatchQuery(term, fields).operator(AND).type(CROSS_FIELDS);
   }
 

--- a/src/main/java/org/folio/search/model/metadata/PlainFieldDescription.java
+++ b/src/main/java/org/folio/search/model/metadata/PlainFieldDescription.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.folio.search.model.types.ResponseGroupType;
@@ -22,8 +22,12 @@ public class PlainFieldDescription extends FieldDescription {
 
   public static final String MULTILANG_FIELD_TYPE = "multilang";
   public static final String STANDARD_FIELD_TYPE = "standard";
-  public static final Set<String> FULLTEXT_FIELD_TYPES = Set.of(MULTILANG_FIELD_TYPE, STANDARD_FIELD_TYPE);
   public static final String PLAIN_FULLTEXT_FIELD_TYPE = "keyword_lowercase";
+
+  public static final Map<String, String> FULLTEXT_FIELD_TYPES = Map.of(
+    MULTILANG_FIELD_TYPE, PLAIN_FULLTEXT_FIELD_TYPE,
+    STANDARD_FIELD_TYPE, PLAIN_FULLTEXT_FIELD_TYPE,
+    "whitespace", "keyword_trimmed");
 
   /**
    * List of search types, that is used to identify search options for given field.
@@ -93,7 +97,7 @@ public class PlainFieldDescription extends FieldDescription {
    */
   @JsonProperty
   public boolean hasFulltextIndex() {
-    return FULLTEXT_FIELD_TYPES.contains(index) && indexPlainValue;
+    return FULLTEXT_FIELD_TYPES.containsKey(index) && indexPlainValue;
   }
 
   /**

--- a/src/main/java/org/folio/search/service/es/SearchMappingsHelper.java
+++ b/src/main/java/org/folio/search/service/es/SearchMappingsHelper.java
@@ -3,7 +3,7 @@ package org.folio.search.service.es;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toMap;
-import static org.folio.search.model.metadata.PlainFieldDescription.PLAIN_FULLTEXT_FIELD_TYPE;
+import static org.folio.search.model.metadata.PlainFieldDescription.FULLTEXT_FIELD_TYPES;
 import static org.folio.search.utils.SearchUtils.MULTILANG_SOURCE_SUBFIELD;
 import static org.folio.search.utils.SearchUtils.PLAIN_FULLTEXT_PREFIX;
 
@@ -110,7 +110,7 @@ public class SearchMappingsHelper {
       }
 
       var fulltextEsMappings = new LinkedHashMap<String, JsonNode>(2, 1.0f);
-      var plainFieldMappings = getSearchFieldTypeMappings(PLAIN_FULLTEXT_FIELD_TYPE);
+      var plainFieldMappings = getSearchFieldTypeMappings(FULLTEXT_FIELD_TYPES.get(indexType));
       fulltextEsMappings.put(name, mappings);
       fulltextEsMappings.put(PLAIN_FULLTEXT_PREFIX + name, withCustomMappings(plainFieldMappings, customMappings));
       return fulltextEsMappings;

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -4,7 +4,6 @@ import static java.util.Locale.ROOT;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toMap;
 import static org.folio.search.configuration.properties.FolioEnvironment.getFolioEnvName;
-import static org.folio.search.model.metadata.PlainFieldDescription.STANDARD_FIELD_TYPE;
 import static org.folio.search.utils.CollectionUtils.mergeSafelyToSet;
 
 import com.google.common.base.CaseFormat;
@@ -49,8 +48,6 @@ public class SearchUtils {
   public static final String SUBJECT_BROWSING_FIELD = "subject";
   public static final String AUTHORITY_BROWSING_FIELD = "headingRef";
   public static final String SUBJECT_AGGREGATION_NAME = "subjects";
-  public static final String ITEM_SHELF_KEY_FIELD_NAME =
-    CALL_NUMBER_BROWSING_FIELD.substring(INSTANCE_ITEM_FIELD_NAME.length() + 1);
 
   public static final String CQL_META_FIELD_PREFIX = "cql.";
   public static final String MULTILANG_SOURCE_SUBFIELD = "src";
@@ -218,7 +215,7 @@ public class SearchUtils {
     if (description.isMultilang()) {
       return getMultilangValue(fieldName, fieldValue, languages);
     }
-    if (STANDARD_FIELD_TYPE.equals(description.getIndex())) {
+    if (description.hasFulltextIndex()) {
       return getStandardFulltextValue(fieldName, fieldValue, description.isIndexPlainValue());
     }
     return Collections.singletonMap(fieldName, fieldValue);

--- a/src/main/resources/elasticsearch/index-field-types.json
+++ b/src/main/resources/elasticsearch/index-field-types.json
@@ -26,6 +26,18 @@
       "normalizer": "keyword_lowercase"
     }
   },
+  "keyword_trimmed": {
+    "mapping": {
+      "type": "keyword",
+      "normalizer": "keyword_trimmed"
+    }
+  },
+  "whitespace": {
+    "mapping": {
+      "type": "text",
+      "analyzer": "whitespace"
+    }
+  },
   "date": {
     "mapping": {
       "type": "date",

--- a/src/main/resources/elasticsearch/index/instance.json
+++ b/src/main/resources/elasticsearch/index/instance.json
@@ -15,11 +15,15 @@
     },
     "normalizer": {
       "keyword_lowercase": {
-        "filter": [ "lowercase" ],
+        "filter": [ "lowercase", "trim" ],
         "type": "custom"
       },
       "keyword_uppercase": {
-        "filter": [ "uppercase" ],
+        "filter": [ "uppercase", "trim" ],
+        "type": "custom"
+      },
+      "keyword_trimmed": {
+        "filter": [ "trim" ],
         "type": "custom"
       }
     },

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -219,11 +219,14 @@
       }
     },
     "notes": {
-      "noteTypeId": {
-        "index": "source"
-      },
-      "value": {
-        "index": "source"
+      "type": "object",
+      "properties": {
+        "noteTypeId": {
+          "index": "source"
+        },
+        "value": {
+          "index": "source"
+        }
       }
     }
   },
@@ -273,7 +276,7 @@
   },
   "mappingsSource": { },
   "indexMappings": {
-    "sort_headingRef" : {
+    "sort_headingRef": {
       "type": "keyword",
       "normalizer": "keyword_lowercase"
     }

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -64,7 +64,7 @@
       "properties": {
         "value": {
           "searchAliases": [ "keyword" ],
-          "index": "keyword"
+          "index": "whitespace"
         },
         "identifierTypeId": {
           "index": "source"

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -168,6 +168,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
 
       arguments("keyword = *", ""),
       arguments("keyword all {value}", "semantic web primer"),
+      arguments("keyword all {value}", "semantic Antoniou ocm0012345 047144250X"),
       arguments("subjects all {value}", "semantic"),
 
       arguments("tags.tagList all {value}", "book"),

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseQueryProviderTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseQueryProviderTest.java
@@ -180,6 +180,7 @@ class CallNumberBrowseQueryProviderTest {
   private static SearchQueryConfigurationProperties getSearchQueryConfigurationProperties() {
     var config = new SearchQueryConfigurationProperties();
     config.setRangeQueryLimitMultiplier(3d);
+    config.setCallNumberBrowseOptimizationEnabled(false);
     return config;
   }
 }


### PR DESCRIPTION
### Purpose
Issue found during Bugfest Lotus test. The keyword index, search for title, contributor, or identifier data and intended to work separately. If you combine title and contributor data, the search works. If you add one identifier that is stored in the found instance record, then the search fails (e.g. `wolves matthew 9781609383657`).

### Approach
- Elasticsearch multi-match with type = `cross_fields` groups fields by it's analyzer and full match must be found in this group. Replacing cross fields with boolean query resolves this issue.

### Learning
- https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-multi-match-query.html#cross-field-analysis
