### PR TITLE
MSEARCH-370 Add new reindexSupported field to resource description

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -28,6 +28,7 @@ the [full-text queries](https://www.elastic.co/guide/en/elasticsearch/reference/
 | searchFields         | Contains a list of generated fields for the resource events (for example, It can be contain ISBN normalized values or generating subset of field values).                                                                                                                                       |
 | indexMappings        | Object with additional index mappings for resource (It can be helpful for `copy_to` functionality of Elasticsearch                                                                                                                                                                              |
 | mappingSource        | It's used to include or exclude some field from storing those values in `_source` object in Elasticsearch. Mainly, it's used to reduce the size per index. See also: [_source field](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html#include-exclude) |
+| reindexSupported     | Indicates if the resource could be reindexed                                                                                                                                                                                                                                                    |
 
 #### Supported field description types
 

--- a/src/main/java/org/folio/search/model/metadata/ResourceDescription.java
+++ b/src/main/java/org/folio/search/model/metadata/ResourceDescription.java
@@ -28,6 +28,11 @@ public class ResourceDescription {
   private String parent;
 
   /**
+   * Indicates if the resource could be reindexed.
+   */
+  private boolean reindexSupported = false;
+
+  /**
    * Related java class for event body.
    */
   private Class<?> eventBodyJavaClass;

--- a/src/main/java/org/folio/search/service/IndexService.java
+++ b/src/main/java/org/folio/search/service/IndexService.java
@@ -126,9 +126,9 @@ public class IndexService {
   private List<String> getResourceNamesToReindex(ReindexRequest reindexRequest) {
     var resourceName = getReindexRequestResourceName(reindexRequest);
     var resourceDescription = resourceDescriptionService.get(resourceName);
-    if (resourceDescription == null ||
-      resourceDescription.getParent() != null ||
-      !resourceDescription.isReindexSupported()) {
+    if (resourceDescription == null
+      || resourceDescription.getParent() != null
+      || !resourceDescription.isReindexSupported()) {
       throw new RequestValidationException(
         "Reindex request contains invalid resource name", RESOURCE_NAME_PARAMETER, resourceName);
     }

--- a/src/main/java/org/folio/search/service/IndexService.java
+++ b/src/main/java/org/folio/search/service/IndexService.java
@@ -126,7 +126,9 @@ public class IndexService {
   private List<String> getResourceNamesToReindex(ReindexRequest reindexRequest) {
     var resourceName = getReindexRequestResourceName(reindexRequest);
     var resourceDescription = resourceDescriptionService.get(resourceName);
-    if (resourceDescription == null || resourceDescription.getParent() != null) {
+    if (resourceDescription == null ||
+      resourceDescription.getParent() != null ||
+      !resourceDescription.isReindexSupported()) {
       throw new RequestValidationException(
         "Reindex request contains invalid resource name", RESOURCE_NAME_PARAMETER, resourceName);
     }

--- a/src/main/java/org/folio/search/service/SearchTenantService.java
+++ b/src/main/java/org/folio/search/service/SearchTenantService.java
@@ -64,7 +64,7 @@ public class SearchTenantService {
       .filter(parameter -> parameter.getKey().equals(REINDEX_PARAM_NAME) && parseBoolean(parameter.getValue()))
       .findFirst()
       .ifPresent(parameter -> resourceNames.forEach(resource -> {
-        if (resourceDescriptionService.get(resource).getParent() == null) {
+        if (resourceDescriptionService.get(resource).isReindexSupported()) {
           indexService.reindexInventory(context.getTenantId(), new ReindexRequest().resourceName(resource));
         }
       }));

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -1,6 +1,7 @@
 {
   "name": "authority",
   "eventBodyJavaClass": "org.folio.search.domain.dto.Authority",
+  "reindexSupported": true,
   "indexingConfiguration": {
     "eventPreProcessor": "authorityEventPreProcessor"
   },

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -1,6 +1,7 @@
 {
   "name": "instance",
   "eventBodyJavaClass": "org.folio.search.domain.dto.Instance",
+  "reindexSupported": true,
   "languageSourcePaths": [ "$.languages" ],
   "indexingConfiguration": {
     "eventPreProcessor": "instanceEventPreProcessor"

--- a/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
+++ b/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
@@ -73,7 +73,7 @@ class SearchTenantServiceTest {
   }
 
   @Test
-  void shouldRunReindexOnTenantParamPresent() {
+  void shouldRunReindexOnTenantParamPresentForResourcesThatSupportsReindex() {
     var resourceDescription = secondaryResourceDescription("secondary", RESOURCE_NAME);
     when(context.getTenantId()).thenReturn(TENANT_ID);
     when(resourceDescriptionService.getResourceNames()).thenReturn(List.of(RESOURCE_NAME, "secondary"));
@@ -84,6 +84,7 @@ class SearchTenantServiceTest {
     searchTenantService.initializeTenant(attributes);
 
     verify(indexService).reindexInventory(TENANT_ID, new ReindexRequest().resourceName(RESOURCE_NAME));
+    verify(indexService, never()).reindexInventory(TENANT_ID, new ReindexRequest().resourceName("secondary"));
   }
 
   @Test

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -265,13 +265,6 @@ public class TestUtils {
     return resourceDescription(RESOURCE_NAME, fields);
   }
 
-  public static ResourceDescription resourceDescription(String name, Map<String, FieldDescription> fields) {
-    var resourceDescription = new ResourceDescription();
-    resourceDescription.setName(name);
-    resourceDescription.setFields(fields);
-    return resourceDescription;
-  }
-
   public static ResourceDescription resourceDescription(
     Map<String, FieldDescription> fields, List<String> languageSourcePaths) {
     var resourceDescription = resourceDescription(RESOURCE_NAME, fields);
@@ -282,6 +275,15 @@ public class TestUtils {
   public static ResourceDescription secondaryResourceDescription(String name, String parent) {
     var resourceDescription = resourceDescription(name, emptyMap());
     resourceDescription.setParent(parent);
+    resourceDescription.setReindexSupported(false);
+    return resourceDescription;
+  }
+
+  public static ResourceDescription resourceDescription(String name, Map<String, FieldDescription> fields) {
+    var resourceDescription = new ResourceDescription();
+    resourceDescription.setName(name);
+    resourceDescription.setFields(fields);
+    resourceDescription.setReindexSupported(true);
     return resourceDescription;
   }
 

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -272,18 +272,18 @@ public class TestUtils {
     return resourceDescription;
   }
 
-  public static ResourceDescription secondaryResourceDescription(String name, String parent) {
-    var resourceDescription = resourceDescription(name, emptyMap());
-    resourceDescription.setParent(parent);
-    resourceDescription.setReindexSupported(false);
-    return resourceDescription;
-  }
-
   public static ResourceDescription resourceDescription(String name, Map<String, FieldDescription> fields) {
     var resourceDescription = new ResourceDescription();
     resourceDescription.setName(name);
     resourceDescription.setFields(fields);
     resourceDescription.setReindexSupported(true);
+    return resourceDescription;
+  }
+
+  public static ResourceDescription secondaryResourceDescription(String name, String parent) {
+    var resourceDescription = resourceDescription(name, emptyMap());
+    resourceDescription.setParent(parent);
+    resourceDescription.setReindexSupported(false);
     return resourceDescription;
   }
 


### PR DESCRIPTION
### Purpose
Fix tenant initialization error when `runReindex=true` in `tenantParameters`

### Approach
Add new reindexSupported field to resource description that indicate that resource could be reindexed