### PR TITLE
MSEARCH-371 Index contributors on reindex request

### DIFF
--- a/src/main/java/org/folio/search/configuration/KafkaConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/KafkaConfiguration.java
@@ -68,12 +68,12 @@ public class KafkaConfiguration {
   /**
    * Creates and configures {@link ProducerFactory} as Spring bean.
    *
-   * <p>Key type - {@link String}, value - {@link Object}.</p>
+   * <p>Key type - {@link String}, value - {@link ResourceEvent}.</p>
    *
    * @return typed {@link ProducerFactory} object as Spring bean.
    */
   @Bean
-  public ProducerFactory<String, Object> producerFactory() {
+  public ProducerFactory<String, ResourceEvent> producerFactory() {
     Map<String, Object> configProps = new HashMap<>(kafkaProperties.buildProducerProperties());
     configProps.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     configProps.put(VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
@@ -83,12 +83,12 @@ public class KafkaConfiguration {
   /**
    * Creates and configures {@link KafkaTemplate} as Spring bean.
    *
-   * <p>Key type - {@link String}, value - {@link Object}.</p>
+   * <p>Key type - {@link String}, value - {@link ResourceEvent}.</p>
    *
    * @return typed {@link KafkaTemplate} object as Spring bean.
    */
   @Bean
-  public KafkaTemplate<String, Object> kafkaTemplate(ProducerFactory<String, Object> producerFactory) {
+  public KafkaTemplate<String, ResourceEvent> kafkaTemplate(ProducerFactory<String, ResourceEvent> producerFactory) {
     return new KafkaTemplate<>(producerFactory);
   }
 }

--- a/src/main/java/org/folio/search/integration/KafkaMessageListener.java
+++ b/src/main/java/org/folio/search/integration/KafkaMessageListener.java
@@ -1,46 +1,28 @@
 package org.folio.search.integration;
 
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
-import static org.apache.commons.codec.digest.DigestUtils.sha1Hex;
-import static org.apache.commons.collections4.MapUtils.getObject;
 import static org.apache.commons.collections4.MapUtils.getString;
 import static org.apache.commons.lang3.RegExUtils.replaceAll;
-import static org.apache.commons.lang3.StringUtils.toRootLowerCase;
 import static org.folio.search.configuration.RetryTemplateConfiguration.KAFKA_RETRY_TEMPLATE_NAME;
 import static org.folio.search.domain.dto.ResourceEventType.CREATE;
-import static org.folio.search.domain.dto.ResourceEventType.DELETE;
 import static org.folio.search.domain.dto.ResourceEventType.REINDEX;
-import static org.folio.search.utils.CollectionUtils.subtract;
-import static org.folio.search.utils.KafkaUtils.getTenantTopicName;
 import static org.folio.search.utils.SearchConverterUtils.getEventPayload;
-import static org.folio.search.utils.SearchConverterUtils.getNewAsMap;
-import static org.folio.search.utils.SearchConverterUtils.getOldAsMap;
 import static org.folio.search.utils.SearchConverterUtils.getResourceEventId;
 import static org.folio.search.utils.SearchUtils.AUTHORITY_RESOURCE;
 import static org.folio.search.utils.SearchUtils.CONTRIBUTOR_RESOURCE;
 import static org.folio.search.utils.SearchUtils.ID_FIELD;
-import static org.folio.search.utils.SearchUtils.INSTANCE_CONTRIBUTORS_FIELD_NAME;
 import static org.folio.search.utils.SearchUtils.INSTANCE_ID_FIELD;
 import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.folio.search.domain.dto.Contributor;
 import org.folio.search.domain.dto.ResourceEvent;
-import org.folio.search.domain.dto.ResourceEventType;
-import org.folio.search.model.event.ContributorEvent;
 import org.folio.search.service.KafkaAdminService;
 import org.folio.search.service.ResourceService;
-import org.folio.search.utils.JsonConverter;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 /**
@@ -50,12 +32,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class KafkaMessageListener {
-
-  private static final String INSTANCE_CONTRIBUTOR_TOPIC_NAME = "search.instance-contributor";
-
-  private final JsonConverter jsonConverter;
   private final ResourceService resourceService;
-  private final KafkaTemplate<String, Object> kafkaTemplate;
   private final FolioMessageBatchProcessor folioMessageBatchProcessor;
 
   /**
@@ -72,7 +49,6 @@ public class KafkaMessageListener {
   public void handleEvents(List<ConsumerRecord<String, ResourceEvent>> consumerRecords) {
     log.info("Processing instance ids from kafka events [number of events: {}]", consumerRecords.size());
     var batch = getInstanceResourceEvents(consumerRecords);
-    batch.forEach(this::sendContributorEventsToKafka);
     folioMessageBatchProcessor.consumeBatchWithFallback(batch, KAFKA_RETRY_TEMPLATE_NAME,
       resourceService::indexResourcesById, KafkaMessageListener::logFailedEvent);
   }
@@ -158,43 +134,4 @@ public class KafkaMessageListener {
       event.getType().getValue(), event.getType(), event.getTenant(), event.getId(), e);
   }
 
-  private static String getContributorId(String tenantId, Contributor contributor) {
-    return sha1Hex(tenantId + "|" + //NOSONAR
-      contributor.getContributorNameTypeId() + "|" + toRootLowerCase(contributor.getName()));
-  }
-
-  private void sendContributorEventsToKafka(ResourceEvent event) {
-    var type = new TypeReference<List<Contributor>>() { };
-    var oldContributors = getContributors(getOldAsMap(event), type);
-    var newContributors = getContributors(getNewAsMap(event), type);
-
-    sendContributorEventsToKafka(event, subtract(newContributors, oldContributors), CREATE);
-    sendContributorEventsToKafka(event, subtract(oldContributors, newContributors), DELETE);
-  }
-
-  private void sendContributorEventsToKafka(ResourceEvent evt, Set<Contributor> contributors, ResourceEventType type) {
-    var tenantId = evt.getTenant();
-    var topicName = getTenantTopicName(INSTANCE_CONTRIBUTOR_TOPIC_NAME, tenantId);
-    var instanceId = getResourceEventId(evt);
-    contributors.stream()
-      .map(contributor -> prepareResourceEvent(contributor, instanceId, type, tenantId))
-      .forEach(resourceEvent -> kafkaTemplate.send(topicName, resourceEvent.getId(), resourceEvent));
-  }
-
-  private List<Contributor> getContributors(Map<String, Object> objectMap, TypeReference<List<Contributor>> type) {
-    return jsonConverter.convert(getObject(objectMap, INSTANCE_CONTRIBUTORS_FIELD_NAME, emptyList()), type);
-  }
-
-  private ResourceEvent prepareResourceEvent(Contributor contributor, String instanceId, ResourceEventType type,
-                                             String tenantId) {
-    var contributorEvent = ContributorEvent.builder()
-      .id(getContributorId(tenantId, contributor))
-      .instanceId(instanceId)
-      .name(contributor.getName())
-      .nameTypeId(contributor.getContributorNameTypeId())
-      .typeId(contributor.getContributorTypeId())
-      .build();
-    var eventBody = new ResourceEvent().type(type).tenant(tenantId);
-    return type == CREATE ? eventBody._new(contributorEvent) : eventBody.old(contributorEvent);
-  }
 }

--- a/src/main/java/org/folio/search/integration/KafkaMessageProducer.java
+++ b/src/main/java/org/folio/search/integration/KafkaMessageProducer.java
@@ -1,0 +1,95 @@
+package org.folio.search.integration;
+
+import static java.util.Collections.emptyList;
+import static org.apache.commons.codec.digest.DigestUtils.sha1Hex;
+import static org.apache.commons.collections4.MapUtils.getObject;
+import static org.apache.commons.lang3.StringUtils.toRootLowerCase;
+import static org.folio.search.domain.dto.ResourceEventType.CREATE;
+import static org.folio.search.domain.dto.ResourceEventType.DELETE;
+import static org.folio.search.utils.CollectionUtils.subtract;
+import static org.folio.search.utils.KafkaUtils.getTenantTopicName;
+import static org.folio.search.utils.SearchConverterUtils.getNewAsMap;
+import static org.folio.search.utils.SearchConverterUtils.getOldAsMap;
+import static org.folio.search.utils.SearchConverterUtils.getResourceEventId;
+import static org.folio.search.utils.SearchUtils.INSTANCE_CONTRIBUTORS_FIELD_NAME;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.folio.search.domain.dto.Contributor;
+import org.folio.search.domain.dto.ResourceEvent;
+import org.folio.search.domain.dto.ResourceEventType;
+import org.folio.search.model.event.ContributorEvent;
+import org.folio.search.utils.JsonConverter;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaMessageProducer {
+
+  private static final String INSTANCE_CONTRIBUTOR_TOPIC_NAME = "search.instance-contributor";
+  private final JsonConverter jsonConverter;
+  private final KafkaTemplate<String, ResourceEvent> kafkaTemplate;
+
+  public void sendContributorEvents(List<ResourceEvent> resourceEvents) {
+    if (resourceEvents != null && !resourceEvents.isEmpty()) {
+      resourceEvents.stream()
+        .map(this::getContributorEvents)
+        .flatMap(List::stream)
+        .forEach(kafkaTemplate::send);
+    }
+  }
+
+  private List<ProducerRecord<String, ResourceEvent>> getContributorEvents(ResourceEvent event) {
+    var type = new TypeReference<List<Contributor>>() { };
+    var oldContributors = getContributors(getOldAsMap(event), type);
+    var newContributors = getContributors(getNewAsMap(event), type);
+
+    return Stream.of(
+        prepareContributorEvents(event, subtract(newContributors, oldContributors), CREATE),
+        prepareContributorEvents(event, subtract(oldContributors, newContributors), DELETE))
+      .flatMap(List::stream)
+      .collect(Collectors.toList());
+  }
+
+  private List<Contributor> getContributors(Map<String, Object> objectMap, TypeReference<List<Contributor>> type) {
+    return jsonConverter.convert(getObject(objectMap, INSTANCE_CONTRIBUTORS_FIELD_NAME, emptyList()), type);
+  }
+
+  private List<ProducerRecord<String, ResourceEvent>> prepareContributorEvents(ResourceEvent evt,
+                                                                               Set<Contributor> contributors,
+                                                                               ResourceEventType type) {
+    var tenantId = evt.getTenant();
+    var topicName = getTenantTopicName(INSTANCE_CONTRIBUTOR_TOPIC_NAME, tenantId);
+    var instanceId = getResourceEventId(evt);
+    return contributors.stream()
+      .map(contributor -> prepareResourceEvent(contributor, instanceId, type, tenantId))
+      .map(resourceEvent -> new ProducerRecord<>(topicName, resourceEvent.getId(), resourceEvent))
+      .collect(Collectors.toList());
+  }
+
+  private ResourceEvent prepareResourceEvent(Contributor contributor, String instanceId, ResourceEventType type,
+                                             String tenantId) {
+    var id = getContributorId(tenantId, contributor);
+    var contributorEvent = ContributorEvent.builder()
+      .id(id)
+      .instanceId(instanceId)
+      .name(contributor.getName())
+      .nameTypeId(contributor.getContributorNameTypeId())
+      .typeId(contributor.getContributorTypeId())
+      .build();
+    var eventBody = new ResourceEvent().id(id).type(type).tenant(tenantId);
+    return type == CREATE ? eventBody._new(contributorEvent) : eventBody.old(contributorEvent);
+  }
+
+  private String getContributorId(String tenantId, Contributor contributor) {
+    return sha1Hex(tenantId + "|" + //NOSONAR
+      contributor.getContributorNameTypeId() + "|" + toRootLowerCase(contributor.getName()));
+  }
+}

--- a/src/main/java/org/folio/search/integration/KafkaMessageProducer.java
+++ b/src/main/java/org/folio/search/integration/KafkaMessageProducer.java
@@ -37,7 +37,7 @@ public class KafkaMessageProducer {
   private final JsonConverter jsonConverter;
   private final KafkaTemplate<String, ResourceEvent> kafkaTemplate;
 
-  public void sendContributorEvents(List<ResourceEvent> resourceEvents) {
+  public void prepareAndSendContributorEvents(List<ResourceEvent> resourceEvents) {
     if (resourceEvents != null && !resourceEvents.isEmpty()) {
       resourceEvents.stream()
         .map(this::getContributorEvents)

--- a/src/main/java/org/folio/search/service/ResourceService.java
+++ b/src/main/java/org/folio/search/service/ResourceService.java
@@ -88,10 +88,10 @@ public class ResourceService {
 
     var groupedByOperation = eventsToIndex.stream().collect(groupingBy(ResourceService::getEventIndexType));
     var fetchedInstances = resourceFetchService.fetchInstancesByIds(groupedByOperation.get(INDEX));
-    messageProducer.sendContributorEvents(fetchedInstances);
+    messageProducer.prepareAndSendContributorEvents(fetchedInstances);
     var indexDocuments = multiTenantSearchDocumentConverter.convert(fetchedInstances);
     var removeDocuments = multiTenantSearchDocumentConverter.convert(groupedByOperation.get(DELETE));
-    messageProducer.sendContributorEvents(groupedByOperation.get(DELETE));
+    messageProducer.prepareAndSendContributorEvents(groupedByOperation.get(DELETE));
     var bulkIndexResponse = indexSearchDocuments(mergeMaps(indexDocuments, removeDocuments));
     log.info("Records indexed to elasticsearch [indexRequests: {}, removeRequests: {}{}]",
       getNumberOfRequests(indexDocuments), getNumberOfRequests(removeDocuments), getErrorMessage(bulkIndexResponse));

--- a/src/main/resources/elasticsearch/index/contributor.json
+++ b/src/main/resources/elasticsearch/index/contributor.json
@@ -5,8 +5,8 @@
     "refresh_interval": "1s",
     "codec": "best_compression",
     "mapping.total_fields.limit": 1000,
-    "sort.field": "name",
-    "sort.order": "asc"
+    "sort.field": [ "name", "contributorNameTypeId" ],
+    "sort.order": [ "asc", "asc" ]
   },
   "analysis": {
     "normalizer": {

--- a/src/main/resources/model/contributor.json
+++ b/src/main/resources/model/contributor.json
@@ -1,5 +1,6 @@
 {
   "name": "contributor",
+  "parent": "instance",
   "eventBodyJavaClass": "org.folio.search.domain.dto.Contributor",
   "indexingConfiguration": {
     "resourceRepository": "instanceContributorsRepository"

--- a/src/test/java/org/folio/search/controller/IndexingIT.java
+++ b/src/test/java/org/folio/search/controller/IndexingIT.java
@@ -181,6 +181,24 @@ class IndexingIT extends BaseIntegrationTest {
       .andExpect(jsonPath("$.errors[0].parameters[0].value", is("instance_subject")));
   }
 
+  @Test
+  void runReindex_positive_contributor() throws Exception {
+    var request = post(ApiEndpoints.reindexPath())
+      .content(asJsonString(new ReindexRequest().resourceName("contributor")))
+      .headers(defaultHeaders())
+      .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
+      .contentType(MediaType.APPLICATION_JSON);
+
+    mockMvc.perform(request)
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.total_records", is(1)))
+      .andExpect(jsonPath("$.errors[0].message", is("Reindex request contains invalid resource name")))
+      .andExpect(jsonPath("$.errors[0].type", is("RequestValidationException")))
+      .andExpect(jsonPath("$.errors[0].code", is("validation_error")))
+      .andExpect(jsonPath("$.errors[0].parameters[0].key", is("resourceName")))
+      .andExpect(jsonPath("$.errors[0].parameters[0].value", is("contributor")));
+  }
+
   private void createInstances() {
     var instances = INSTANCE_IDS.stream()
       .map(id -> new Instance().id(id).subjects(List.of("subject-" + sha1Hex(id))))

--- a/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
+++ b/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
@@ -85,7 +85,7 @@ class KafkaMessageListenerIT {
   private static final String INSTANCE_ID = randomId();
   private static final String KAFKA_LISTENER_IT_ENV = "kafka-listener-it";
 
-  @Autowired private KafkaTemplate<String, Object> kafkaTemplate;
+  @Autowired private KafkaTemplate<String, ResourceEvent> kafkaTemplate;
   @Autowired private FolioKafkaProperties kafkaProperties;
   @MockBean private ResourceService resourceService;
 

--- a/src/test/java/org/folio/search/service/ResourceServiceTest.java
+++ b/src/test/java/org/folio/search/service/ResourceServiceTest.java
@@ -136,7 +136,7 @@ class ResourceServiceTest {
     when(searchDocumentConverter.convert(List.of(resourceEvent))).thenReturn(mapOf(RESOURCE_NAME, expectedDocuments));
     when(searchDocumentConverter.convert(null)).thenReturn(emptyMap());
     when(primaryResourceRepository.indexResources(expectedDocuments)).thenReturn(expectedResponse);
-    doNothing().when(kafkaMessageProducer).sendContributorEvents(anyList());
+    doNothing().when(kafkaMessageProducer).prepareAndSendContributorEvents(anyList());
 
     var actual = indexService.indexResourcesById(resourceEvents);
     assertThat(actual).isEqualTo(expectedResponse);
@@ -156,7 +156,7 @@ class ResourceServiceTest {
     when(indexRepository.indexExists(INDEX_NAME)).thenReturn(true);
     when(primaryResourceRepository.indexResources(List.of(searchBody))).thenReturn(expectedResponse);
     when(resourceDescriptionService.find(RESOURCE_NAME)).thenReturn(of(resourceDescription(RESOURCE_NAME)));
-    doNothing().when(kafkaMessageProducer).sendContributorEvents(anyList());
+    doNothing().when(kafkaMessageProducer).prepareAndSendContributorEvents(anyList());
 
     var response = indexService.indexResourcesById(List.of(resourceEvent));
     assertThat(response).isEqualTo(expectedResponse);
@@ -171,7 +171,7 @@ class ResourceServiceTest {
     when(searchDocumentConverter.convert(emptyList())).thenReturn(emptyMap());
     when(searchDocumentConverter.convert(resourceEvents)).thenReturn(mapOf(RESOURCE_NAME, expectedDocuments));
     when(indexRepository.indexExists(INDEX_NAME)).thenReturn(true);
-    doNothing().when(kafkaMessageProducer).sendContributorEvents(anyList());
+    doNothing().when(kafkaMessageProducer).prepareAndSendContributorEvents(anyList());
 
     var expectedResponse = getSuccessIndexOperationResponse();
     when(primaryResourceRepository.indexResources(expectedDocuments)).thenReturn(expectedResponse);
@@ -192,7 +192,7 @@ class ResourceServiceTest {
     when(searchDocumentConverter.convert(List.of(resourceEvent))).thenReturn(mapOf(RESOURCE_NAME, expectedDocuments));
     when(searchDocumentConverter.convert(null)).thenReturn(emptyMap());
     when(primaryResourceRepository.indexResources(expectedDocuments)).thenReturn(expectedResponse);
-    doNothing().when(kafkaMessageProducer).sendContributorEvents(anyList());
+    doNothing().when(kafkaMessageProducer).prepareAndSendContributorEvents(anyList());
 
     var actual = indexService.indexResourcesById(resourceEvents);
     assertThat(actual).isEqualTo(expectedResponse);
@@ -219,7 +219,7 @@ class ResourceServiceTest {
     when(searchDocumentConverter.convert(null)).thenReturn(emptyMap());
     when(searchDocumentConverter.convert(emptyList())).thenReturn(emptyMap());
     when(primaryResourceRepository.indexResources(null)).thenReturn(getSuccessIndexOperationResponse());
-    doNothing().when(kafkaMessageProducer).sendContributorEvents(anyList());
+    doNothing().when(kafkaMessageProducer).prepareAndSendContributorEvents(anyList());
 
     var actual = indexService.indexResourcesById(eventIds);
 

--- a/src/test/java/org/folio/search/service/ResourceServiceTest.java
+++ b/src/test/java/org/folio/search/service/ResourceServiceTest.java
@@ -19,12 +19,15 @@ import static org.folio.search.utils.TestUtils.resourceDescription;
 import static org.folio.search.utils.TestUtils.resourceEvent;
 import static org.folio.search.utils.TestUtils.searchDocumentBody;
 import static org.folio.search.utils.TestUtils.searchDocumentBodyToDelete;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.folio.search.integration.KafkaMessageProducer;
 import org.folio.search.integration.ResourceFetchService;
 import org.folio.search.model.metadata.ResourceDescription;
 import org.folio.search.model.metadata.ResourceIndexingConfiguration;
@@ -53,6 +56,7 @@ class ResourceServiceTest {
   @Mock private ResourceDescriptionService resourceDescriptionService;
   @Mock private Map<String, ResourceRepository> resourceRepositoryBeans;
   @Mock private MultiTenantSearchDocumentConverter searchDocumentConverter;
+  @Mock private KafkaMessageProducer kafkaMessageProducer;
 
   @Test
   void indexResources_positive() {
@@ -132,6 +136,7 @@ class ResourceServiceTest {
     when(searchDocumentConverter.convert(List.of(resourceEvent))).thenReturn(mapOf(RESOURCE_NAME, expectedDocuments));
     when(searchDocumentConverter.convert(null)).thenReturn(emptyMap());
     when(primaryResourceRepository.indexResources(expectedDocuments)).thenReturn(expectedResponse);
+    doNothing().when(kafkaMessageProducer).sendContributorEvents(anyList());
 
     var actual = indexService.indexResourcesById(resourceEvents);
     assertThat(actual).isEqualTo(expectedResponse);
@@ -151,6 +156,7 @@ class ResourceServiceTest {
     when(indexRepository.indexExists(INDEX_NAME)).thenReturn(true);
     when(primaryResourceRepository.indexResources(List.of(searchBody))).thenReturn(expectedResponse);
     when(resourceDescriptionService.find(RESOURCE_NAME)).thenReturn(of(resourceDescription(RESOURCE_NAME)));
+    doNothing().when(kafkaMessageProducer).sendContributorEvents(anyList());
 
     var response = indexService.indexResourcesById(List.of(resourceEvent));
     assertThat(response).isEqualTo(expectedResponse);
@@ -165,6 +171,7 @@ class ResourceServiceTest {
     when(searchDocumentConverter.convert(emptyList())).thenReturn(emptyMap());
     when(searchDocumentConverter.convert(resourceEvents)).thenReturn(mapOf(RESOURCE_NAME, expectedDocuments));
     when(indexRepository.indexExists(INDEX_NAME)).thenReturn(true);
+    doNothing().when(kafkaMessageProducer).sendContributorEvents(anyList());
 
     var expectedResponse = getSuccessIndexOperationResponse();
     when(primaryResourceRepository.indexResources(expectedDocuments)).thenReturn(expectedResponse);
@@ -185,6 +192,7 @@ class ResourceServiceTest {
     when(searchDocumentConverter.convert(List.of(resourceEvent))).thenReturn(mapOf(RESOURCE_NAME, expectedDocuments));
     when(searchDocumentConverter.convert(null)).thenReturn(emptyMap());
     when(primaryResourceRepository.indexResources(expectedDocuments)).thenReturn(expectedResponse);
+    doNothing().when(kafkaMessageProducer).sendContributorEvents(anyList());
 
     var actual = indexService.indexResourcesById(resourceEvents);
     assertThat(actual).isEqualTo(expectedResponse);
@@ -211,6 +219,7 @@ class ResourceServiceTest {
     when(searchDocumentConverter.convert(null)).thenReturn(emptyMap());
     when(searchDocumentConverter.convert(emptyList())).thenReturn(emptyMap());
     when(primaryResourceRepository.indexResources(null)).thenReturn(getSuccessIndexOperationResponse());
+    doNothing().when(kafkaMessageProducer).sendContributorEvents(anyList());
 
     var actual = indexService.indexResourcesById(eventIds);
 

--- a/src/test/java/org/folio/search/support/api/InventoryApi.java
+++ b/src/test/java/org/folio/search/support/api/InventoryApi.java
@@ -30,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.ResourceEvent;
 import org.springframework.kafka.core.KafkaTemplate;
 
 @RequiredArgsConstructor
@@ -40,7 +41,7 @@ public class InventoryApi {
   private static final Map<String, Map<String, ItemEvent>> ITEM_STORE = new LinkedHashMap<>();
   private static final String ID_FIELD = "id";
 
-  private final KafkaTemplate<String, Object> kafkaTemplate;
+  private final KafkaTemplate<String, ResourceEvent> kafkaTemplate;
 
   public void createInstance(String tenantId, Instance instance) {
     createInstance(tenantId, toMap(instance));

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -32,6 +32,7 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.search.domain.dto.Authority;
 import org.folio.search.domain.dto.FeatureConfig;
 import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.ResourceEvent;
 import org.folio.search.domain.dto.TenantConfiguredFeature;
 import org.folio.search.support.api.InventoryApi;
 import org.folio.search.support.extension.EnableElasticSearch;
@@ -65,13 +66,13 @@ public abstract class BaseIntegrationTest {
 
   protected static MockMvc mockMvc;
   protected static InventoryApi inventoryApi;
-  protected static KafkaTemplate<String, Object> kafkaTemplate;
+  protected static KafkaTemplate<String, ResourceEvent> kafkaTemplate;
   protected static OkapiConfiguration okapi;
 
   @BeforeAll
   static void setUpDefaultTenant(
     @Autowired MockMvc mockMvc,
-    @Autowired KafkaTemplate<String, Object> kafkaTemplate) {
+    @Autowired KafkaTemplate<String, ResourceEvent> kafkaTemplate) {
     setEnvProperty("folio-test");
     BaseIntegrationTest.mockMvc = mockMvc;
     BaseIntegrationTest.kafkaTemplate = kafkaTemplate;


### PR DESCRIPTION
### Purpose
Fix problem when contributors are not indexed on reindex request

### Approach
Move logic of contributor-events producing from Kafka listener to resource service

### Learning
This happened due to contributor is not an independent entity, it's a child of an instance record. When instance records are reindexed then Kafka listener received events that contain only instance id and no data. After these events received a resource service fetch instance from /inventory-view/instances endpoint and only after that index instances and all related entities.
