### PR TITLE
MSEARCH-374 Fix duplicate contributors while browsing

### DIFF
--- a/src/main/java/org/folio/search/service/browse/ContributorBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/ContributorBrowseService.java
@@ -35,7 +35,9 @@ public class ContributorBrowseService extends
     var boolQuery = boolQuery().filter(FILTER_QUERY)
       .must(termQuery(request.getTargetField(), context.getAnchor()));
     context.getFilters().forEach(boolQuery::filter);
-    return searchSource().query(termQuery(request.getTargetField(), context.getAnchor())).from(0).size(1);
+    return searchSource().query(termQuery(request.getTargetField(), context.getAnchor()))
+      .size(context.getLimit(context.isBrowsingForward()))
+      .from(0);
   }
 
   @Override
@@ -43,9 +45,8 @@ public class ContributorBrowseService extends
     var boolQuery = boolQuery().filter(FILTER_QUERY);
     ctx.getFilters().forEach(boolQuery::filter);
     return searchSource().query(boolQuery)
-      .searchAfter(new Object[] {ctx.getAnchor().toLowerCase(ROOT), ctx.getAnchor()})
+      .searchAfter(new Object[] {ctx.getAnchor().toLowerCase(ROOT)})
       .sort(fieldSort(req.getTargetField()).order(isBrowsingForward ? ASC : DESC))
-      .sort(fieldSort("contributorNameTypeId").order(isBrowsingForward ? ASC : DESC))
       .size(ctx.getLimit(isBrowsingForward) + 1)
       .from(0);
   }

--- a/src/test/java/org/folio/search/controller/ContributorBrowseIT.java
+++ b/src/test/java/org/folio/search/controller/ContributorBrowseIT.java
@@ -21,6 +21,7 @@ import static org.folio.search.utils.TestUtils.randomId;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -64,13 +65,21 @@ class ContributorBrowseIT extends BaseIntegrationTest {
   @BeforeAll
   static void prepare(@Autowired RestHighLevelClient restHighLevelClient) {
     setUpTenant(INSTANCES);
+
+    // this is needed to test browsing by contributors when there are contributors with zero linked instances
+    var instanceToUpdate = INSTANCES[0];
+    var newContributors = new ArrayList<>(instanceToUpdate.getContributors());
+    newContributors.remove(2);
+    instanceToUpdate.setContributors(newContributors);
+    inventoryApi.updateInstance(TENANT_ID, instanceToUpdate);
+
     await().atMost(ONE_MINUTE).pollInterval(TWO_HUNDRED_MILLISECONDS).untilAsserted(() -> {
       var aggregation = AggregationBuilders.count("contributorTypeId").field("contributorTypeId");
       var searchRequest = new SearchRequest().source(
           searchSource().query(matchAllQuery()).trackTotalHits(true).from(0).size(100).aggregation(aggregation))
         .indices(getIndexName(SearchUtils.CONTRIBUTOR_RESOURCE, TENANT_ID)).routing(TENANT_ID);
       var searchResponse = restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
-      assertThat(((ParsedValueCount) searchResponse.getAggregations().asList().get(0)).getValue()).isEqualTo(14);
+      assertThat(((ParsedValueCount) searchResponse.getAggregations().asList().get(0)).getValue()).isEqualTo(13);
     });
   }
 
@@ -88,15 +97,15 @@ class ContributorBrowseIT extends BaseIntegrationTest {
     var backwardIncludingQuery = "name <= {value}";
 
     return Stream.of(arguments(aroundQuery, "John", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Bon Jovi").next("Klaus Meine").items(
-          List.of(contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
+        new InstanceContributorBrowseResult().totalRecords(9).prev("Bon Jovi").next("Klaus Meine").items(
+          List.of(contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], TYPE_IDS[0]),
             contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
             contributorBrowseItem(0, true, "John"),
             contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
             contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null)))),
 
       arguments(aroundQuery, "Lenon", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Klaus Meine").next(null).items(
+        new InstanceContributorBrowseResult().totalRecords(9).prev("Klaus Meine").next(null).items(
           List.of(contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
             contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
             contributorBrowseItem(0, true, "Lenon"),
@@ -104,17 +113,24 @@ class ContributorBrowseIT extends BaseIntegrationTest {
             contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
 
       arguments(aroundIncludingQuery, "Meine", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Klaus Meine").next(null).items(
+        new InstanceContributorBrowseResult().totalRecords(9).prev("Klaus Meine").next(null).items(
           List.of(contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
             contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
             contributorBrowseItem(0, true, "Meine"),
             contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
             contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
 
+      arguments(aroundIncludingQuery, "Klaus Meine", 5,
+        new InstanceContributorBrowseResult().totalRecords(9).prev("George Harrison").next("Paul McCartney").items(
+          List.of(contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
+            contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
+            contributorBrowseItem(1, true,"Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
+            contributorBrowseItem(2, true,"Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
+            contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2])))),
+
       arguments(aroundIncludingQuery, "Zak", 25,
-        new InstanceContributorBrowseResult().totalRecords(10).prev(null).next(null).items(
+        new InstanceContributorBrowseResult().totalRecords(9).prev(null).next(null).items(
           List.of(contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], TYPE_IDS[0]),
             contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], TYPE_IDS[0]),
             contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
             contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
@@ -126,72 +142,72 @@ class ContributorBrowseIT extends BaseIntegrationTest {
             contributorBrowseItem(0, true, "Zak")))),
 
       arguments(aroundIncludingQuery, "PMC", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Klaus Meine").next(null).items(
-          List.of(contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
+        new InstanceContributorBrowseResult().totalRecords(9).prev("Klaus Meine").next(null).items(
+          List.of(contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
             contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
             contributorBrowseItem(0, true, "PMC"),
             contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
 
       arguments(aroundIncludingQuery, "a", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev(null).next("Anthony Kiedis").items(
+        new InstanceContributorBrowseResult().totalRecords(9).prev(null).next("Bon Jovi").items(
           List.of(contributorBrowseItem(0, true, "a"),
             contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], TYPE_IDS[0])))),
+            contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], TYPE_IDS[0])))),
 
       arguments(aroundIncludingQuery, "z", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Paul McCartney").next(null).items(
+        new InstanceContributorBrowseResult().totalRecords(9).prev("Paul McCartney").next(null).items(
           List.of(contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
             contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
             contributorBrowseItem(0, true, "z")))),
 
       // browsing forward
       arguments(forwardQuery, "ringo", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Ringo Starr").next(null)
+        new InstanceContributorBrowseResult().totalRecords(9).prev("Ringo Starr").next(null)
           .items(List.of(contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
 
       arguments(forwardQuery, "anthony", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Anthony Kiedis").next("George Harrison").items(
+        new InstanceContributorBrowseResult().totalRecords(9).prev("Anthony Kiedis").next("John Lennon").items(
           List.of(contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], TYPE_IDS[0]),
             contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], TYPE_IDS[0]),
             contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2])))),
+            contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
+            contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0])))),
 
-      arguments(forwardQuery, "Z", 10, new InstanceContributorBrowseResult().totalRecords(10).items(emptyList())),
+      arguments(forwardQuery, "Z", 10, new InstanceContributorBrowseResult().totalRecords(9).items(emptyList())),
 
       arguments(forwardIncludingQuery, "Ringo Starr", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Ringo Starr").next(null)
+        new InstanceContributorBrowseResult().totalRecords(9).prev("Ringo Starr").next(null)
           .items(List.of(contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
 
       arguments(forwardIncludingQuery, "anthony", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Anthony Kiedis").next("George Harrison").items(
+        new InstanceContributorBrowseResult().totalRecords(9).prev("Anthony Kiedis").next("John Lennon").items(
           List.of(contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], TYPE_IDS[0]),
             contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], TYPE_IDS[0]),
             contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2])))),
+            contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
+            contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0])))),
 
       // browsing backward
       arguments(backwardQuery, "Ringo Starr", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("John Lennon").next("Ringo Starr").items(
-          List.of(contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
-            contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
-            contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
-            contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
-
-      arguments(backwardQuery, "R", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("George Harrison").next("Paul McCartney").items(
+        new InstanceContributorBrowseResult().totalRecords(9).prev("George Harrison").next("Paul McCartney").items(
           List.of(contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
             contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
             contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
             contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
             contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2])))),
 
-      arguments(backwardQuery, "A", 10, new InstanceContributorBrowseResult().totalRecords(10).items(emptyList())),
+      arguments(backwardQuery, "R", 5,
+        new InstanceContributorBrowseResult().totalRecords(9).prev("George Harrison").next("Paul McCartney").items(
+          List.of(contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
+            contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
+            contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
+            contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
+            contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2])))),
+
+      arguments(backwardQuery, "A", 10, new InstanceContributorBrowseResult().totalRecords(9).items(emptyList())),
 
       arguments(backwardIncludingQuery, "ringo", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("George Harrison").next("Paul McCartney").items(
+        new InstanceContributorBrowseResult().totalRecords(9).prev("George Harrison").next("Paul McCartney").items(
           List.of(contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
             contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
             contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
@@ -279,8 +295,8 @@ class ContributorBrowseIT extends BaseIntegrationTest {
         + NAME_TYPE_IDS[0]).param("limit", "5");
 
     var actual = parseResponse(doGet(request), InstanceContributorBrowseResult.class);
-    var expected = new InstanceContributorBrowseResult().totalRecords(4).prev(null).next(null).items(
-      List.of(contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], TYPE_IDS[0]),
+    var expected = new InstanceContributorBrowseResult().totalRecords(3).prev(null).next(null).items(
+      List.of(
         contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
         contributorBrowseItem(0, true, "John"),
         contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),


### PR DESCRIPTION
### Purpose
Fix duplicate contributors while browsing

### Approach
* update anchorQuery to load all matched contributors
* update searchQuery to not sort by nameTypeId and now relying on index sort