### PR TITLE
MSEARCH-383 Change contributor events producing to ignore contributorTypeText

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,9 +505,9 @@ if it is defined but doesn't match.
 
 ### Contributors search options
 
-| Option              | Type | Example                         | Description                                     |
-|:--------------------|:----:|:--------------------------------|:------------------------------------------------|
-| `contributorTypeId` | term | `contributorTypeId == "123456"` | Matches contributors with `123456` name type id |
+| Option                  | Type | Example                             | Description                                     |
+|:------------------------|:----:|:------------------------------------|:------------------------------------------------|
+| `contributorNameTypeId` | term | `contributorNameTypeId == "123456"` | Matches contributors with `123456` name type id |
 
 
 ### Search by all field values
@@ -639,9 +639,9 @@ GET /instances/facets?query=title all book&facet=source:5,discoverySuppress:2
 
 ### Contributors facets
 
-| Option              | Type | Description                            |
-|:--------------------|:----:|:---------------------------------------|
-| `contributorTypeId` | term | Requests a contributor name type facet |
+| Option                  | Type | Description                            |
+|:------------------------|:----:|:---------------------------------------|
+| `contributorNameTypeId` | term | Requests a contributor name type facet |
 
 ## Sorting results
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - kafka
       - postgres
     environment:
+      ELASTICSEARCH_URL: http://opensearch:9200
       DB_HOST: postgres
       JAVA_OPTIONS: -Xmx120m -Xms120m
       JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,address=*:5010,server=y,suspend=n
@@ -63,7 +64,7 @@ services:
     ports:
       - "5601:5601"
     environment:
-      OPENSEARCH_HOSTS: '["http://elasticsearch:9200"]'
+      OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
     networks:
       - mod-search-local
     depends_on:
@@ -97,6 +98,22 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
       KAFKA_MESSAGE_MAX_BYTES: 1000000
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
+
+  kafka-ui:
+    container_name: kafka-ui-quick-marc
+    image: provectuslabs/kafka-ui:latest
+    ports:
+      - "8080:8080"
+    depends_on:
+      - zookeeper
+      - kafka
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+      KAFKA_CLUSTERS_0_JMXPORT: 9997
+    networks:
+      - mod-search-local
 
   postgres:
     container_name: postgres

--- a/docker/.env
+++ b/docker/.env
@@ -1,1 +1,4 @@
 COMPOSE_PROJECT_NAME=folio-mod-search
+DEBUG_PORT=5010
+OKAPI_URL=http://api-mock:8080
+APP_PORT:8081

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,13 +5,13 @@ services:
     container_name: mod-search
     image: dev.folio/mod-search
     build:
-      context: ..
-      dockerfile: ../Dockerfile
+      context: ..\
+      dockerfile: Dockerfile
     networks:
       - mod-search-local
     ports:
-      - "8081:8081"
-      - "5010:5010"
+      - "${APP_PORT}:8081"
+      - "${DEBUG_PORT}:${DEBUG_PORT}"
     depends_on:
       - api-mock
       - opensearch
@@ -21,8 +21,8 @@ services:
       ELASTICSEARCH_URL: http://opensearch:9200
       DB_HOST: postgres
       JAVA_OPTIONS: -Xmx120m -Xms120m
-      JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,address=*:5010,server=y,suspend=n
-      okapi.url: http://api-mock:8080
+      JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:${DEBUG_PORT}
+      okapi.url: ${OKAPI_URL}
 
   api-mock:
     image: wiremock/wiremock:2.32.0
@@ -41,7 +41,7 @@ services:
     image: dev.folio/opensearch:1.3.2
     build:
       context: elasticsearch
-      dockerfile: elasticsearch/Dockerfile
+      dockerfile: Dockerfile
     networks:
       - mod-search-local
     ports:
@@ -60,7 +60,7 @@ services:
     image: dev.folio/opensearch-dashboards:1.3.2
     build:
       context: dashboards
-      dockerfile: dashboards/Dockerfile
+      dockerfile: Dockerfile
     ports:
       - "5601:5601"
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     container_name: mod-search
     image: dev.folio/mod-search
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: ../Dockerfile
     networks:
       - mod-search-local
     ports:
@@ -40,8 +40,8 @@ services:
     container_name: opensearch
     image: dev.folio/opensearch:1.3.2
     build:
-      context: docker/elasticsearch
-      dockerfile: Dockerfile
+      context: elasticsearch
+      dockerfile: elasticsearch/Dockerfile
     networks:
       - mod-search-local
     ports:
@@ -59,8 +59,8 @@ services:
     container_name: opensearch-dashboards
     image: dev.folio/opensearch-dashboards:1.3.2
     build:
-      context: docker/dashboards
-      dockerfile: Dockerfile
+      context: dashboards
+      dockerfile: dashboards/Dockerfile
     ports:
       - "5601:5601"
     environment:
@@ -81,7 +81,6 @@ services:
   kafka:
     container_name: kafka
     image: wurstmeister/kafka:2.13-2.8.1
-#    hostname: kafka
     networks:
       - mod-search-local
     depends_on:

--- a/src/main/java/org/folio/search/integration/KafkaMessageProducer.java
+++ b/src/main/java/org/folio/search/integration/KafkaMessageProducer.java
@@ -54,8 +54,8 @@ public class KafkaMessageProducer {
     var newContributors = getContributorEvents(getNewAsMap(event), instanceId, tenantId);
 
     return Stream.of(
-        prepareContributorEvents(subtract(newContributors, oldContributors), CREATE, event.getTenant()),
-        prepareContributorEvents(subtract(oldContributors, newContributors), DELETE, event.getTenant()))
+        prepareContributorEvents(subtract(newContributors, oldContributors), CREATE, tenantId),
+        prepareContributorEvents(subtract(oldContributors, newContributors), DELETE, tenantId))
       .flatMap(List::stream)
       .collect(Collectors.toList());
   }

--- a/src/test/java/org/folio/search/integration/KafkaMessageProducerTest.java
+++ b/src/test/java/org/folio/search/integration/KafkaMessageProducerTest.java
@@ -1,0 +1,97 @@
+package org.folio.search.integration;
+
+import static java.util.Collections.singletonList;
+import static org.folio.search.domain.dto.ResourceEventType.UPDATE;
+import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
+import static org.folio.search.utils.TestUtils.mapOf;
+import static org.folio.search.utils.TestUtils.randomId;
+import static org.folio.search.utils.TestUtils.resourceEvent;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.folio.search.domain.dto.ResourceEvent;
+import org.folio.search.utils.JsonConverter;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaMessageProducerTest {
+
+  @InjectMocks
+  private KafkaMessageProducer producer;
+  @Spy
+  private JsonConverter jsonConverter = new JsonConverter(new ObjectMapper());
+  @Mock
+  private KafkaTemplate<String, ResourceEvent> kafkaTemplate;
+
+  @Test
+  void shouldSendTwoContributorEvents_whenContributorChanged() {
+    var instanceId = randomId();
+    var typeId = randomId();
+    var oldContributorObject = contributorObject(typeId, "Vader, Dart");
+    var newContributorObject = contributorObject(typeId, "Skywalker, Luke");
+    var resourceEvent = resourceEvent(instanceId, INSTANCE_RESOURCE, UPDATE,
+      instanceObject(instanceId, newContributorObject),
+      instanceObject(instanceId, oldContributorObject)
+    );
+    producer.prepareAndSendContributorEvents(singletonList(resourceEvent));
+
+    verify(kafkaTemplate, times(2)).send(ArgumentMatchers.<ProducerRecord<String, ResourceEvent>>any());
+  }
+
+  @Test
+  void shouldSendNoContributorEvents_whenContributorNotChanged() {
+    var instanceId = randomId();
+    var typeId = randomId();
+    var name = "Vader, Dart";
+    var oldContributorObject = contributorObject(typeId, name);
+    var newContributorObject = contributorObject(typeId, name);
+    var resourceEvent = resourceEvent(instanceId, INSTANCE_RESOURCE, UPDATE,
+      instanceObject(instanceId, newContributorObject),
+      instanceObject(instanceId, oldContributorObject)
+    );
+    producer.prepareAndSendContributorEvents(singletonList(resourceEvent));
+
+    verify(kafkaTemplate, never()).send(ArgumentMatchers.<ProducerRecord<String, ResourceEvent>>any());
+  }
+
+  @Test
+  void shouldSendNoContributorEvents_whenChangedOnlyContributorTypeText() {
+    var instanceId = randomId();
+    var typeId = randomId();
+    var name = "Vader, Dart";
+    var oldContributorObject = contributorObject(typeId, name);
+    var newContributorObject = contributorObject(typeId, name);
+    newContributorObject.put("contributorTypeText", "text");
+    var resourceEvent = resourceEvent(instanceId, INSTANCE_RESOURCE, UPDATE,
+      instanceObject(instanceId, newContributorObject),
+      instanceObject(instanceId, oldContributorObject)
+    );
+    producer.prepareAndSendContributorEvents(singletonList(resourceEvent));
+
+    verify(kafkaTemplate, never()).send(ArgumentMatchers.<ProducerRecord<String, ResourceEvent>>any());
+  }
+
+  @NotNull
+  private Map<String, String> instanceObject(String id, Map<String, String> contributorObject) {
+    return mapOf("id", id, "contributors", List.of(contributorObject));
+  }
+
+  @NotNull
+  private Map<String, String> contributorObject(String typeId, String name) {
+    return mapOf("contributorNameTypeId", typeId, "name", name);
+  }
+}

--- a/src/test/java/org/folio/search/integration/KafkaMessageProducerTest.java
+++ b/src/test/java/org/folio/search/integration/KafkaMessageProducerTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerRecord;


### PR DESCRIPTION
### Purpose
Fix bug when existed contributor is not returned at Browse contributors result list when user filled field `contributorTypeText`.

### Approach
Ignore `contributorTypeText` when forming contributor events. If taking this field into an account then system formes one update and one delete event, and contributor is removed from index.