### PR TITLE
MSEARCH-388 Add filters to anchor-query for contributor browse

### DIFF
--- a/src/main/java/org/folio/search/service/browse/ContributorBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/ContributorBrowseService.java
@@ -31,7 +31,7 @@ public class ContributorBrowseService extends
     var boolQuery = boolQuery()
       .must(termQuery(request.getTargetField(), context.getAnchor()));
     context.getFilters().forEach(boolQuery::filter);
-    return searchSource().query(termQuery(request.getTargetField(), context.getAnchor()))
+    return searchSource().query(boolQuery)
       .size(context.getLimit(context.isBrowsingForward()))
       .from(0);
   }

--- a/src/test/java/org/folio/search/controller/ContributorBrowseIT.java
+++ b/src/test/java/org/folio/search/controller/ContributorBrowseIT.java
@@ -292,7 +292,7 @@ class ContributorBrowseIT extends BaseIntegrationTest {
   @Test
   void browseByContributor_withNameTypeFilter() {
     var request = get(instanceContributorBrowsePath()).param("query",
-      "(" + prepareQuery("name >= {value} or name < {value}", '"' + "John" + '"') + ") and contributorNameTypeId=="
+      "(" + prepareQuery("name >= {value} or name < {value}", '"' + "John Lennon" + '"') + ") and contributorNameTypeId=="
         + NAME_TYPE_IDS[0]).param("limit", "5");
 
     var actual = parseResponse(doGet(request), InstanceContributorBrowseResult.class);
@@ -300,7 +300,7 @@ class ContributorBrowseIT extends BaseIntegrationTest {
       List.of(
         contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], TYPE_IDS[0]),
         contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
-        contributorBrowseItem(0, true, "John"),
+        contributorBrowseItem(0, true, "John Lennon"),
         contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
         contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2])));
 

--- a/src/test/java/org/folio/search/controller/ContributorBrowseIT.java
+++ b/src/test/java/org/folio/search/controller/ContributorBrowseIT.java
@@ -292,8 +292,8 @@ class ContributorBrowseIT extends BaseIntegrationTest {
   @Test
   void browseByContributor_withNameTypeFilter() {
     var request = get(instanceContributorBrowsePath()).param("query",
-      "(" + prepareQuery("name >= {value} or name < {value}", '"' + "John Lennon" + '"') + ") and contributorNameTypeId=="
-        + NAME_TYPE_IDS[0]).param("limit", "5");
+      "(" + prepareQuery("name >= {value} or name < {value}", '"' + "John Lennon" + '"') + ") "
+        + "and contributorNameTypeId==" + NAME_TYPE_IDS[0]).param("limit", "5");
 
     var actual = parseResponse(doGet(request), InstanceContributorBrowseResult.class);
     var expected = new InstanceContributorBrowseResult().totalRecords(4).prev(null).next(null).items(


### PR DESCRIPTION
## Purpose
Fix the bug when the "Name type" filter doesn't account for the search query on anchor result.

## Approach
Add filters from browse request to anchor-query for contributor browse

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed

