### PR TITLE
MSEARCH-387 Not found when trying to retrieve resource job ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ CQL operators could have modifiers that change search behaviour
 
 | Operator | Modifier | Usage                            | Description                      |
 |:---------|:---------|:---------------------------------|:---------------------------------|
-| `==`     | `string` | `title ==\string "semantic web"` | Exact match for full text fields | 
+| `==`     | `string` | `title ==\string "semantic web"` | Exact match for full text fields |
 
 ## Search Options
 
@@ -686,7 +686,7 @@ Send a POST request to create a Job
 ```
 It is possible to check job status by jobs Id.
 
-`GET /search/authorities/jobs/{jobId}`
+`GET /search/resources/jobs/{jobId}`
 
 **Response**
 ```json
@@ -703,7 +703,7 @@ It is possible to check job status by jobs Id.
 
 When the job is COMPLETED, it is possible to retrieve ids by job id
 
-`GET /search/resources/jobs/ids/{jobId}`
+`GET /search/resources/jobs/{jobId}/ids`
 
 After retrieving ids, job should change status to "DEPRECATED". If there are no completed job with prepared ids, client can't receive ids by query.
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -74,7 +74,7 @@
       "handlers": [
         {
           "methods": [ "GET" ],
-          "pathPattern": "/search/resources/jobs/ids/{jobId}",
+          "pathPattern": "/search/resources/jobs/{jobId}/ids",
           "permissionsRequired": [ "search.resources.ids.collection.get" ]
         },
         {

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -167,7 +167,7 @@ paths:
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
 
-  /resources/ids/{jobId}:
+  /resources/jobs/{jobId}/ids:
     get:
       operationId: getResourceIds
       description: Get a list of resource ids by job id

--- a/src/test/java/org/folio/search/support/base/ApiEndpoints.java
+++ b/src/test/java/org/folio/search/support/base/ApiEndpoints.java
@@ -62,7 +62,7 @@ public class ApiEndpoints {
   }
 
   public static String resourcesIds(String query) {
-    return String.format("/search/resources/ids/%s", query);
+    return String.format("/search/resources/jobs/%s/ids", query);
   }
 
   public static String resourcesIdsJob() {


### PR DESCRIPTION
## Approach
Use the same endpoint `/search/resources/jobs/{jobId}/ids` in moduleDescriptor and OpenApi

### Learning
https://issues.folio.org/browse/MSEARCH-387
