### PR TITLE
MSEARCH-392 Stream ids job, relation doesn't exist while using multi tenant

### DIFF
--- a/src/main/java/org/folio/search/service/ResourceIdService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdService.java
@@ -92,29 +92,29 @@ public class ResourceIdService {
   @Async
   @Transactional
   public void streamResourceIdsForJob(ResourceIdsJobEntity job, String tenantId) {
-      var tableName = job.getTemporaryTableName();
-      try {
-        var entityType = job.getEntityType();
-        String resource = entityType.getResource();
-        String sourceIdPath = entityType.getSourceIdPath();
-        var request = CqlResourceIdsRequest.of(resource, tenantId, job.getQuery(), sourceIdPath);
+    var tableName = job.getTemporaryTableName();
+    try {
+      var entityType = job.getEntityType();
+      String resource = entityType.getResource();
+      String sourceIdPath = entityType.getSourceIdPath();
+      var request = CqlResourceIdsRequest.of(resource, tenantId, job.getQuery(), sourceIdPath);
 
-        idsTemporaryRepository.createTableForIds(tableName);
-        streamResourceIds(request, idsList -> idsTemporaryRepository.insertIds(idsList, tableName));
-        job.setStatus(StreamJobStatus.COMPLETED);
-      } catch (Exception e) {
-        log.warn("Failed to process resource ids job with id = {}", job.getId());
-        idsTemporaryRepository.dropTableForIds(tableName);
-        job.setStatus(StreamJobStatus.ERROR);
-      } finally {
-        jobRepository.save(job);
-      }
+      idsTemporaryRepository.createTableForIds(tableName);
+      streamResourceIds(request, idsList -> idsTemporaryRepository.insertIds(idsList, tableName));
+      job.setStatus(StreamJobStatus.COMPLETED);
+    } catch (Exception e) {
+      log.warn("Failed to process resource ids job with id = {}", job.getId());
+      idsTemporaryRepository.dropTableForIds(tableName);
+      job.setStatus(StreamJobStatus.ERROR);
+    } finally {
+      jobRepository.save(job);
+    }
   }
 
   /**
-   * Starts async streaming job in scope of tenant
+   * Starts async streaming job in scope of tenant.
    *
-   * @param job      Async job as {@link ResourceIdsJobEntity} object
+   * @param job      Job as {@link ResourceIdsJobEntity} object
    * @param tenantId tenant id as {@link String} object
    */
   @Transactional

--- a/src/main/java/org/folio/search/service/ResourceIdService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdService.java
@@ -84,12 +84,11 @@ public class ResourceIdService {
   }
 
   /**
-   * Starts async job to prepare a list of ids by cql in new DB's table.
+   * Starts job to prepare a list of ids by cql in new DB's table.
    *
    * @param job      Async job as {@link ResourceIdsJobEntity} object
    * @param tenantId tenant id as {@link String} object
    */
-  @Async
   @Transactional
   public void streamResourceIdsForJob(ResourceIdsJobEntity job, String tenantId) {
     var tableName = job.getTemporaryTableName();
@@ -112,12 +111,12 @@ public class ResourceIdService {
   }
 
   /**
-   * Starts async streaming job in scope of tenant.
+   * Starts async streaming ids job in scope of current tenant.
    *
    * @param job      Job as {@link ResourceIdsJobEntity} object
    * @param tenantId tenant id as {@link String} object
    */
-  @Transactional
+  @Async
   public void startAsyncStreamingIdsJob(ResourceIdsJobEntity job, String tenantId) {
     tenantScopedExecutionService.executeTenantScoped(tenantId, () -> {
       streamResourceIdsForJob(job, tenantId);

--- a/src/main/java/org/folio/search/service/ResourceIdService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdService.java
@@ -119,7 +119,7 @@ public class ResourceIdService {
   @Async
   public void startAsyncStreamingIdsJob(ResourceIdsJobEntity job, String tenantId) {
     tenantScopedExecutionService.executeTenantScoped(tenantId, () -> {
-      streamResourceIdsForJob(job, tenantId);
+      streamResourceIdsForJob(job, tenantId); //NOSONAR
       return job;
     });
   }

--- a/src/main/java/org/folio/search/service/ResourceIdService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdService.java
@@ -25,7 +25,6 @@ import org.folio.search.model.types.StreamJobStatus;
 import org.folio.search.repository.ResourceIdsJobRepository;
 import org.folio.search.repository.ResourceIdsTemporaryRepository;
 import org.folio.search.repository.SearchRepository;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -108,20 +107,6 @@ public class ResourceIdService {
     } finally {
       jobRepository.save(job);
     }
-  }
-
-  /**
-   * Starts async streaming ids job in scope of current tenant.
-   *
-   * @param job      Job as {@link ResourceIdsJobEntity} object
-   * @param tenantId tenant id as {@link String} object
-   */
-  @Async
-  public void startAsyncStreamingIdsJob(ResourceIdsJobEntity job, String tenantId) {
-    tenantScopedExecutionService.executeTenantScoped(tenantId, () -> {
-      streamResourceIdsForJob(job, tenantId); //NOSONAR
-      return job;
-    });
   }
 
   /**

--- a/src/main/java/org/folio/search/service/ResourceIdService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdService.java
@@ -39,7 +39,6 @@ public class ResourceIdService {
   private final CqlSearchQueryConverter queryConverter;
   private final ResourceIdsJobRepository jobRepository;
   private final ResourceIdsTemporaryRepository idsTemporaryRepository;
-  private final TenantScopedExecutionService tenantScopedExecutionService;
 
   /**
    * Returns resource ids for passed cql query in text type.

--- a/src/main/java/org/folio/search/service/ResourceIdsJobService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdsJobService.java
@@ -26,7 +26,6 @@ public class ResourceIdsJobService {
     return resourceIdsJobMapper.convert(jobRepository.getById(id));
   }
 
-  @Transactional
   public ResourceIdsJob createStreamJob(ResourceIdsJob job, String tenantId) {
     var tableName = RandomStringUtils
       .random(32, 0, 0, true, false, null, new SecureRandom())
@@ -37,7 +36,7 @@ public class ResourceIdsJobService {
     entity.setTemporaryTableName(tableName);
 
     var savedJob = jobRepository.save(entity);
-    resourceIdService.startAsyncStreamingIdsJob(entity, tenantId);
+    resourceIdService.startAsyncStreamingIdsJob(savedJob, tenantId);
     return resourceIdsJobMapper.convert(savedJob);
   }
 }

--- a/src/main/java/org/folio/search/service/ResourceIdsJobService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdsJobService.java
@@ -7,8 +7,10 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.search.converter.ResourceIdsJobMapper;
 import org.folio.search.domain.dto.ResourceIdsJob;
+import org.folio.search.model.streamids.ResourceIdsJobEntity;
 import org.folio.search.model.types.StreamJobStatus;
 import org.folio.search.repository.ResourceIdsJobRepository;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,17 +28,26 @@ public class ResourceIdsJobService {
     return resourceIdsJobMapper.convert(jobRepository.getById(id));
   }
 
+  @Async
+  public void startAsyncStreamingIdsJob(ResourceIdsJobEntity job, String tenantId) {
+    resourceIdService.streamResourceIdsForJob(job, tenantId);
+  }
+
+  @Transactional
   public ResourceIdsJob createStreamJob(ResourceIdsJob job, String tenantId) {
-    var tableName = RandomStringUtils
-      .random(32, 0, 0, true, false, null, new SecureRandom())
-      .toLowerCase();
     var entity = resourceIdsJobMapper.convert(job);
     entity.setCreatedDate(new Date());
     entity.setStatus(StreamJobStatus.IN_PROGRESS);
-    entity.setTemporaryTableName(tableName);
+    entity.setTemporaryTableName(generateTemporaryTableName());
 
     var savedJob = jobRepository.save(entity);
-    resourceIdService.startAsyncStreamingIdsJob(savedJob, tenantId);
+    startAsyncStreamingIdsJob(savedJob, tenantId);
     return resourceIdsJobMapper.convert(savedJob);
+  }
+
+  private String generateTemporaryTableName() {
+    return RandomStringUtils
+      .random(32, 0, 0, true, false, null, new SecureRandom())
+      .toLowerCase();
   }
 }

--- a/src/main/java/org/folio/search/service/ResourceIdsJobService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdsJobService.java
@@ -37,7 +37,7 @@ public class ResourceIdsJobService {
     entity.setTemporaryTableName(tableName);
 
     var savedJob = jobRepository.save(entity);
-    resourceIdService.startAsyncStreamingIdsJob(savedJob, tenantId);
+    resourceIdService.startAsyncStreamingIdsJob(entity, tenantId);
     return resourceIdsJobMapper.convert(savedJob);
   }
 }

--- a/src/main/java/org/folio/search/service/ResourceIdsJobService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdsJobService.java
@@ -10,7 +10,6 @@ import org.folio.search.domain.dto.ResourceIdsJob;
 import org.folio.search.model.types.StreamJobStatus;
 import org.folio.search.repository.ResourceIdsJobRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Log4j2
 @Service
@@ -22,12 +21,10 @@ public class ResourceIdsJobService {
   private final ResourceIdsJobMapper resourceIdsJobMapper;
   private final ResourceIdService resourceIdService;
 
-  @Transactional(readOnly = true)
   public ResourceIdsJob getJobById(String id) {
     return resourceIdsJobMapper.convert(jobRepository.getById(id));
   }
 
-  @Transactional
   public ResourceIdsJob createStreamJob(ResourceIdsJob job, String tenantId) {
     var entity = resourceIdsJobMapper.convert(job);
     entity.setCreatedDate(new Date());

--- a/src/main/java/org/folio/search/service/ResourceIdsJobService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdsJobService.java
@@ -7,10 +7,8 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.search.converter.ResourceIdsJobMapper;
 import org.folio.search.domain.dto.ResourceIdsJob;
-import org.folio.search.model.streamids.ResourceIdsJobEntity;
 import org.folio.search.model.types.StreamJobStatus;
 import org.folio.search.repository.ResourceIdsJobRepository;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ResourceIdsJobService {
 
+  private final TenantScopedExecutionService tenantExecutionService;
   private final ResourceIdsJobRepository jobRepository;
   private final ResourceIdsJobMapper resourceIdsJobMapper;
   private final ResourceIdService resourceIdService;
@@ -28,20 +27,17 @@ public class ResourceIdsJobService {
     return resourceIdsJobMapper.convert(jobRepository.getById(id));
   }
 
-  @Async
-  public void startAsyncStreamingIdsJob(ResourceIdsJobEntity job, String tenantId) {
-    resourceIdService.streamResourceIdsForJob(job, tenantId);
-  }
-
   @Transactional
   public ResourceIdsJob createStreamJob(ResourceIdsJob job, String tenantId) {
     var entity = resourceIdsJobMapper.convert(job);
     entity.setCreatedDate(new Date());
     entity.setStatus(StreamJobStatus.IN_PROGRESS);
     entity.setTemporaryTableName(generateTemporaryTableName());
-
     var savedJob = jobRepository.save(entity);
-    startAsyncStreamingIdsJob(savedJob, tenantId);
+
+    Runnable asyncJob = () -> resourceIdService.streamResourceIdsForJob(savedJob, tenantId);
+    tenantExecutionService.executeAsyncTenantScoped(tenantId, asyncJob);
+
     return resourceIdsJobMapper.convert(savedJob);
   }
 

--- a/src/main/java/org/folio/search/service/ResourceIdsJobService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdsJobService.java
@@ -35,8 +35,9 @@ public class ResourceIdsJobService {
     entity.setCreatedDate(new Date());
     entity.setStatus(StreamJobStatus.IN_PROGRESS);
     entity.setTemporaryTableName(tableName);
-    var result = jobRepository.save(entity);
-    resourceIdService.streamResourceIdsForJob(entity, tenantId);
-    return resourceIdsJobMapper.convert(result);
+
+    var savedJob = jobRepository.save(entity);
+    resourceIdService.startAsyncStreamingIdsJob(savedJob, tenantId);
+    return resourceIdsJobMapper.convert(savedJob);
   }
 }

--- a/src/main/java/org/folio/search/service/ResourceIdsStreamHelper.java
+++ b/src/main/java/org/folio/search/service/ResourceIdsStreamHelper.java
@@ -52,7 +52,9 @@ public class ResourceIdsStreamHelper {
   public ResponseEntity<Void> streamResourceIdsFromDb(String jobId) {
     try {
       resourceIdService.streamIdsFromDatabaseAsJson(jobId, prepareHttpResponse().getOutputStream());
-      return ResponseEntity.ok().build();
+      return ResponseEntity.ok()
+        .header("Content-Type", APPLICATION_JSON_VALUE)
+        .build();
     } catch (IOException e) {
       throw new SearchServiceException("Failed to get output stream from response", e);
     }

--- a/src/main/java/org/folio/search/service/ResourceIdsStreamHelper.java
+++ b/src/main/java/org/folio/search/service/ResourceIdsStreamHelper.java
@@ -51,10 +51,10 @@ public class ResourceIdsStreamHelper {
    */
   public ResponseEntity<Void> streamResourceIdsFromDb(String jobId) {
     try {
-      resourceIdService.streamIdsFromDatabaseAsJson(jobId, prepareHttpResponse().getOutputStream());
-      return ResponseEntity.ok()
-        .header("Content-Type", APPLICATION_JSON_VALUE)
-        .build();
+      var httpServletResponse = prepareHttpResponse();
+      httpServletResponse.setContentType(APPLICATION_JSON_VALUE);
+      resourceIdService.streamIdsFromDatabaseAsJson(jobId, httpServletResponse.getOutputStream());
+      return ResponseEntity.ok().build();
     } catch (IOException e) {
       throw new SearchServiceException("Failed to get output stream from response", e);
     }

--- a/src/main/java/org/folio/search/service/TenantScopedExecutionService.java
+++ b/src/main/java/org/folio/search/service/TenantScopedExecutionService.java
@@ -9,6 +9,7 @@ import lombok.SneakyThrows;
 import org.folio.search.model.context.FolioExecutionContextBuilder;
 import org.folio.search.service.systemuser.SystemUserService;
 import org.folio.spring.FolioExecutionContext;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -31,6 +32,22 @@ public class TenantScopedExecutionService {
     try {
       beginFolioExecutionContext(folioExecutionContext(tenantId));
       return job.call();
+    } finally {
+      endFolioExecutionContext();
+    }
+  }
+
+  /**
+   * Executes given job in scope of tenant asynchronously.
+   *
+   * @param tenantId - The tenant name.
+   * @param job      - Job to be executed in tenant scope.
+   */
+  @Async
+  public void executeAsyncTenantScoped(String tenantId, Runnable job) {
+    try {
+      beginFolioExecutionContext(folioExecutionContext(tenantId));
+      job.run();
     } finally {
       endFolioExecutionContext();
     }

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -258,7 +258,7 @@ public abstract class BaseIntegrationTest {
 
   @SneakyThrows
   protected static void setUpTenant(List<TestData> testDataList, String tenant) {
-    enableTenant(TENANT_ID);
+    enableTenant(tenant);
     for (TestData testData : testDataList) {
       var type = testData.getType();
       var testRecords = testData.getTestRecords();


### PR DESCRIPTION
## Purpose
The errors like this appears when additional tenant was added:
`ERROR: relation "resource_ids_job" does not exist. (at ResourceIdService:110)`

It looks like the repository can't find the correct schema because the async job is running in transaction 

## Approach
- Starting async job execution in scope of current tenant
- Separate @Async and @Transaction annotations (They can't used together)
- Add Content-Type for response. Without this header karate can't display the body response [KARATE issue](https://github.com/karatelabs/karate/issues/1024#issuecomment-1195374833)

### Learning
https://issues.folio.org/browse/MSEARCH-392