### PR TITLE
MSEARCH-415: Option for Elasticsearch integration test

### DIFF
--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -1,0 +1,17 @@
+name: elasticsearch
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+        cache: 'maven'
+    - run: export SEARCH_ENGINE_DOCKERFILE="docker/elasticsearch/Dockerfile"; mvn clean install
+

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ These languages will be added on tenant init and applied to index. Example usage
 
 ### Configuring Elasticsearch
 
-#### Configuring on-premise OpenSearch instance
+#### Configuring on-premise Elasticsearch instance
 
 It is required to install some required plugins for your search engine instance, here is the list:
 * analysis-icu

--- a/docker/opensearch/Dockerfile
+++ b/docker/opensearch/Dockerfile
@@ -1,15 +1,13 @@
-FROM elasticsearch:8.3.3
+FROM opensearchproject/opensearch:1.3.2
 
 # Switch from /dev/random to /dev/urandom, otherwise the plugin installer needs many minutes to get
 # random numbers to verify the signature of the downloaded plugins.
 # https://github.com/elastic/elasticsearch/pull/84766
 # https://stackoverflow.com/questions/137212/how-to-deal-with-a-slow-securerandom-generator
 # https://security.stackexchange.com/questions/3936/is-a-rand-from-dev-urandom-secure-for-a-login-key
-USER root
-RUN sed -i 's!^securerandom\.source=.*!securerandom.source=file:/dev/./urandom!' /usr/share/elasticsearch/jdk/conf/security/java.security
-USER elasticsearch
+RUN sed -i 's!^securerandom\.source=.*!securerandom.source=file:/dev/./urandom!' /usr/share/opensearch/jdk/conf/security/java.security
 
-RUN elasticsearch-plugin install --batch \
+RUN opensearch-plugin install --batch \
   analysis-icu \
   analysis-kuromoji \
   analysis-smartcn \

--- a/src/main/resources/swagger.api/schemas/holding.json
+++ b/src/main/resources/swagger.api/schemas/holding.json
@@ -82,5 +82,6 @@
     "metadata": {
       "$ref": "metadata.json"
     }
-  }
+  },
+  "required": ["electronicAccess", "notes"]
 }

--- a/src/main/resources/swagger.api/schemas/instance.json
+++ b/src/main/resources/swagger.api/schemas/instance.json
@@ -194,6 +194,7 @@
         "$ref": "holding.json"
       }
     }
-  }
+  },
+  "required": ["electronicAccess", "notes", "items", "holdings"]
 }
 

--- a/src/main/resources/swagger.api/schemas/item.json
+++ b/src/main/resources/swagger.api/schemas/item.json
@@ -117,5 +117,6 @@
     "metadata": {
       "$ref": "metadata.json"
     }
-  }
+  },
+  "required": ["notes"]
 }

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -105,7 +105,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
     var response = doSearchByInstances(prepareQuery("id=={value}", getSemanticWebId()))
       .andExpect(jsonPath("totalRecords", is(1)))
       // make sure that no unexpected properties are present
-      .andExpect(jsonPath("instances[0].length()", is(8)));
+      .andExpect(jsonPath("instances[0].length()", is(11)));
 
     var actual = parseResponse(response, new TypeReference<ResultList<Instance>>() { }).getResult().get(0);
     assertThat(actual.getId(), is(expected.getId()));
@@ -123,6 +123,9 @@ class SearchInstanceIT extends BaseIntegrationTest {
         .effectiveCallNumberComponents(callNumber("prefix-90000", "suffix-90000"))
         .effectiveShelvingOrder("TK 45105.88815 A58 42004 FT MEADE")
     )));
+    assertThat(actual.getHoldings(), is(List.of()));
+    assertThat(actual.getElectronicAccess(), is(List.of()));
+    assertThat(actual.getNotes(), is(List.of()));
   }
 
   @Test

--- a/src/test/java/org/folio/search/integration/ResourceFetchServiceTest.java
+++ b/src/test/java/org/folio/search/integration/ResourceFetchServiceTest.java
@@ -61,10 +61,14 @@ class ResourceFetchServiceTest {
     var actual = resourceFetchService.fetchInstancesByIds(events);
 
     assertThat(actual).isEqualTo(List.of(
-      resourceEvent(instanceId1, INSTANCE_RESOURCE, mapOf("id", instanceId1, "title", "inst1", "isBoundWith", null)),
+      resourceEvent(instanceId1, INSTANCE_RESOURCE,
+        mapOf("id", instanceId1, "title", "inst1", "isBoundWith", null,
+            "holdings", List.of(), "items", List.of(), "electronicAccess", List.of(), "notes", List.of())),
       resourceEvent(instanceId2, INSTANCE_RESOURCE, UPDATE,
         mapOf("id", instanceId2, "title", "inst2",
-          "holdings", List.of(mapOf("id", "holdingId")), "items", List.of(mapOf("id", "itemId")), "isBoundWith", true),
+          "holdings", List.of(mapOf("id", "holdingId", "electronicAccess", List.of(), "notes", List.of())),
+          "items", List.of(mapOf("id", "itemId", "notes", List.of())),
+          "isBoundWith", true, "electronicAccess", List.of(), "notes", List.of()),
         mapOf("id", instanceId2, "title", "old"))
     ));
   }
@@ -81,9 +85,9 @@ class ResourceFetchServiceTest {
       .thenReturn(asSinglePage(List.of(instanceView)));
 
     var actual = resourceFetchService.fetchInstancesByIds(events);
-    assertThat(actual).isEqualTo(List.of(
-      resourceEvent(instanceId1, INSTANCE_RESOURCE, mapOf("id", instanceId1, "title", "inst1", "isBoundWith", null))
-    ));
+    assertThat(actual).isEqualTo(List.of(resourceEvent(instanceId1, INSTANCE_RESOURCE,
+        mapOf("id", instanceId1, "title", "inst1", "isBoundWith", null,
+            "holdings", List.of(), "items", List.of(), "electronicAccess", List.of(), "notes", List.of()))));
   }
 
   @Test
@@ -100,7 +104,9 @@ class ResourceFetchServiceTest {
 
     var actual = resourceFetchService.fetchInstancesByIds(List.of(resourceEvent));
     assertThat(actual).isEqualTo(List.of(
-      resourceEvent(invalidId, INSTANCE_RESOURCE, mapOf("id", invalidId, "title", "inst1", "isBoundWith", null))
+      resourceEvent(invalidId, INSTANCE_RESOURCE,
+          mapOf("id", invalidId, "title", "inst1", "isBoundWith", null,
+              "holdings", List.of(), "items", List.of(), "electronicAccess", List.of(), "notes", List.of()))
     ));
   }
 


### PR DESCRIPTION
In #cc-elasticsearch-opensearch-discussion Slack channel people asked whether mod-search can still run with an Elasticsearch server.

Provide an option to switch the search engine from OpenSearch to Elasticsearch when running the integration test phase of the build.

Implementation details:

OpenSearch and Elasticsearch consider an undefined property, a null property and an empty list property the same. Elasticsearch 8.1 changed the empty list to a null value in same cases. This is a compatible change. To make the integration tests work the swagger schema files for instance, holding and item have been changed to always provide an empty list to compensate for the change; this is why some array fields have been made required. The changes in the schema files need changes in ResourceFetchServiceTest.java.

There was no null/empty list change in OpenSearch yet, only in Elasticsearch.