### PR TITLE
MSEARCH-418: Support interface instance-storage 9.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,10 @@
 * MSEARCH-350 Change Holdings ids stream API to use jobs
 * MSEARCH-382 500 Error When searching by incorrect date
 * MSEARCH-385 Update module documentation
-* MSEARCH-390 Stream ids job freeze IN_PROGRESS if query is invalid
+* MSEARCH-390 Stream ids job freeze IN\_PROGRESS if query is invalid
 * MSEARCH-392 Stream ids job, relation doesn't exist while using multi tenant
 * MSEARCH-396 Supports users interface versions 15.3 16.0
+* MSEARCH-418 Supports also instance-storage interface version 9.0
 
 ## 1.7.4 2022-08-17
 * MSEARCH-401 Avoid using shelving order in call-number browsing

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -194,7 +194,7 @@
   "requires": [
     {
       "id": "instance-storage",
-      "version": "7.5 8.0"
+      "version": "7.5 8.0 9.0"
     },
     {
       "id": "login",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

mod-search uses only instance-storage, not the other two.

mod-search is not affected because the incompatible change is in the DELETE all APIs only that is not used by mod-search.

Only the okapiInterfaces need to be bumped in "requires" section of ModuleDescriptor-template.json