### PR TITLE
MSEARCH-415: Option for Elasticsearch integration test

### DIFF
--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -1,0 +1,17 @@
+name: elasticsearch
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+        cache: 'maven'
+    - run: export SEARCH_ENGINE_DOCKERFILE="docker/elasticsearch/Dockerfile"; mvn clean install
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-search
 
-Copyright (C) 2020-2021 The Open Library Foundation
+Copyright (C) 2020-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
@@ -65,12 +65,24 @@ This module provides a search functionality for instance and authorities via RES
 [The Contextual Query Language](https://www.loc.gov/standards/sru/cql/) as a formal language to query
 records using filters, boolean conditions, etc.
 
+mod-search has switched from Elasticsearch to OpenSearch for integration tests, however,
+many variables still have Elasticsearch in their name for backwards compatibility.
+
 ## Compiling
 
 ```shell
 mvn install
 ```
 See that it says "BUILD SUCCESS" near the end.
+
+By default the integration tests run against an OpenSearch server.
+To run them against an Elasticsearch server use
+
+```shell
+SEARCH_ENGINE_DOCKERFILE="docker/elasticsearch/Dockerfile" mvn install
+```
+
+or run [GitHub Action elasticsearch.yml](.github/workflows/elasticsearch.yml).
 
 ## Running it
 
@@ -144,16 +156,16 @@ These languages will be added on tenant init and applied to index. Example usage
 
 #### Configuring on-premise Elasticsearch instance
 
-It is required to install some required plugins for your ES instance, here is the list:
+It is required to install some required plugins for your search engine instance, here is the list:
 * analysis-icu
 * analysis-kuromoji
 * analysis-smartcn
 * analysis-nori
 * analysis-phonetic
 
-You can find sample Dockerfile in `docker/elasticsearch/Dockerfile` or install plugins manually:
+You can find sample Dockerfile in [docker/opensearch/Dockerfile] or install plugins manually:
 ```shell
-${ES_HOME}/bin/elasticsearch-plugin install --batch \
+${ES_HOME}/bin/opensearch-plugin install --batch \
   analysis-icu \
   analysis-kuromoji \
   analysis-smartcn \
@@ -161,9 +173,9 @@ ${ES_HOME}/bin/elasticsearch-plugin install --batch \
   analysis-phonetic
 ```
 
-See also [Install Elasticsearch with Docker](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docker.html).
+See also [Install OpenSearch/Docker Image](https://opensearch.org/docs/latest/opensearch/install/docker/).
 
-There is an alternative ES image from Bitnami - [bitnami/elasticsearch](https://hub.docker.com/r/bitnami/elasticsearch),
+There is an alternative Elasticsearch image from Bitnami - [bitnami/elasticsearch](https://hub.docker.com/r/bitnami/elasticsearch),
 that does not require extending dockerfile but has an env variable `ELASTICSEARCH_PLUGINS` to specify plugins to install.
 
 For production installations it is strongly recommended enabling security for instance and set-up user/password. The user
@@ -173,14 +185,15 @@ must have at least following permissions:
 
 #### Recommended production set-up
 
-The data nodes Elasticsearch configuration completely depends on the data.
+The data nodes OpenSearch configuration completely depends on the data.
 If there are 7 mln of instances the configuration with 2 nodes with 8Gb RAM and 500 Gb disk (AWS m5.large) works well.
 The nodes were both master and data node. We performed performance tests for this configuration, and it showed good results.
 We would recommend to performing additional performance testing (try to reindex and search with different configurations)
 with different type of nodes, and see what configuration is sufficient for what data volume.
 
-Also, for fault tolerance Elasticsearch requires dedicated master nodes (not to have quorum problem which is called split brain)
-with less powerful configuration (see [High availability](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-ha.html)).
+Also, for fault tolerance OpenSearch requires dedicated master nodes (not to have quorum problem which is called split brain)
+with less powerful configuration (see [High availability](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-ha.html)
+and [Cross-cluster replication](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/replication.html)).
 
 ### Environment variables
 
@@ -235,12 +248,13 @@ documentation [Spring Boot Externalized Configuration](https://docs.spring.io/sp
 
 ### Configuring connection to elasticsearch
 
-In order to configure connection to elasticsearch you have to provide following env variables:
-* `ELASTICSEARCH_URL` - URL to elasticsearch master node (e.g. http(s)://elasticsearch:9200);
-* `ELASTICSEARCH_USERNAME` - username of the user to connect to elasticsearch;
+In order to configure connection to OpenSearch or Elasticsearch you have to provide following env variables:
+* `ELASTICSEARCH_URL` - URL to OpenSearch or Elasticsearch master node (e.g. http(s)://elasticsearch:9200);
+* `ELASTICSEARCH_USERNAME` - username of the user to connect to OpenSearch or Elasticsearch;
 * `ELASTICSEARCH_PASSWORD` - password for the user (see
-  [official guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-security.html)
-  for more details about ES security).
+  [OpenSearch Security configuration](https://opensearch.org/docs/latest/security-plugin/configuration/index/) or
+  [Secure the Elastic Stack](https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-cluster.html)
+  for details).
 
 ### Tenant attributes
 
@@ -254,7 +268,7 @@ It is possible to define specific tenant parameters during module's initializati
 
 ### Recreating Elasticsearch index
 
-Sometimes we need to recreate Elasticsearch index, for example when a breaking change introduced to ES index
+Sometimes we need to recreate OpenSearch or Elasticsearch index, for example when a breaking change introduced to index
 structure (mapping). It can be fixed by running reindex request:
 
 ```http

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:8.0.1
+FROM elasticsearch:7.17.5
 
 # Switch from /dev/random to /dev/urandom, otherwise the plugin installer needs many minutes to get
 # random numbers to verify the signature of the downloaded plugins.

--- a/docker/opensearch/Dockerfile
+++ b/docker/opensearch/Dockerfile
@@ -1,15 +1,13 @@
-FROM elasticsearch:8.0.1
+FROM opensearchproject/opensearch:1.3.2
 
 # Switch from /dev/random to /dev/urandom, otherwise the plugin installer needs many minutes to get
 # random numbers to verify the signature of the downloaded plugins.
 # https://github.com/elastic/elasticsearch/pull/84766
 # https://stackoverflow.com/questions/137212/how-to-deal-with-a-slow-securerandom-generator
 # https://security.stackexchange.com/questions/3936/is-a-rand-from-dev-urandom-secure-for-a-login-key
-USER root
-RUN sed -i 's!^securerandom\.source=.*!securerandom.source=file:/dev/./urandom!' /usr/share/elasticsearch/jdk/conf/security/java.security
-USER elasticsearch
+RUN sed -i 's!^securerandom\.source=.*!securerandom.source=file:/dev/./urandom!' /usr/share/opensearch/jdk/conf/security/java.security
 
-RUN elasticsearch-plugin install --batch \
+RUN opensearch-plugin install --batch \
   analysis-icu \
   analysis-kuromoji \
   analysis-smartcn \


### PR DESCRIPTION
In #cc-elasticsearch-opensearch-discussion Slack channel people asked whether mod-search can still run with an Elasticsearch server.

Provide an option to switch the search engine from OpenSearch to Elasticsearch when running the integration test phase of the build.

Note that this pull request uses Elasticsearch 7.18.5 container because the current 8.3.3 container has a change:
Since version 8.1 Elasticsearch no longer generates an empty array but an undefined property making many
unit tests fail. Upgrading Elasticseach from LTS version 7.18.5 to 8.3.3 will be handled in a separate issue and PR.

This obsoletes PR #289 that tried to combine the option and the upgrade from 7.18.5 to 8.3.3.