### PR TITLE
MSEARCH-414 Browse call-numbers. Search failed when record have enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ CQL operators could have modifiers that change search behaviour
 
 | Operator | Modifier | Usage                            | Description                      |
 |:---------|:---------|:---------------------------------|:---------------------------------|
-| `==`     | `string` | `title ==\string "semantic web"` | Exact match for full text fields |
+| `==`     | `string` | `title ==/string "semantic web"` | Exact match for full text fields |
 
 ### Search API
 
@@ -509,7 +509,6 @@ does not produce any values, so the following search options will return an empt
 | `itemNormalizedCallNumbers`        |   term    | `itemNormalizedCallNumbers="cn434"`                          | Matches instances that have item with given call number and might not be formatted correctly                        |
 | `itemTags`                         |   term    | `itemTags="important"`                                       | Matches instances that have item with given tag                                                                     |
 | `item.electronicAccess`            | full-text | `item.electronicAccess any "resource"`                       | An alias for all `electronicAccess` fields - `uri`, `linkText`, `materialsSpecification`, `publicNote`              |
-| `callNumber`                       |   term    | `callNumber="A 12"`                                          | An alias for search by `item.effectiveShelvingOrder` field                                                          |
 | `item.effectiveShelvingOrder`      |   term    | `item.effectiveShelvingOrder="A 12"`                         | Matches instances that have item with given `effectiveShelvingOrder` value                                          |
 | `item.electronicAccess.uri`        |   term    | `item.electronicAccess.uri="http://folio.org*"`              | Search by electronic access URI                                                                                     |
 | `item.electronicAccess.linkText`   | full-text | `item.electronicAccess.linkText="Folio website"`             | Search by electronic access link text                                                                               |

--- a/doc/browsing.md
+++ b/doc/browsing.md
@@ -20,13 +20,27 @@ _where the `callNumber` is the name of field for browsing, `F` is the anchor val
 
 [Call Number Browse API](https://s3.amazonaws.com/foliodocs/api/mod-search/s/mod-search.html#operation/browseInstancesByCallNumber)
 
+#### Shelving Order Browsing
+
+In some cases we need to browse items by shelving order directly.\
+If browsing by call-number will browse with little precision to find approximate records that the user wants to see.
+Shelving order browsing using for cases where we know exact record to browse.
+(For example if we have previous record and want to browse in backward direction)
+
+| Direction          | Query                            |
+|:-------------------|:---------------------------------|
+| forward            | `itemEffectiveShelvingOrder > F` |
+| backward           | `itemEffectiveShelvingOrder < F` |
+
+_where the `itemEffectiveShelvingOrder` is the name of field for browsing, `F` is the item shelving order value_
+
 #### Approach
 
-_Numeric representation of `items.effectiveShelvingOrder` is used to narrow down the number of results in response. It
+_Numeric representation of `item.effectiveShelvingOrder` is used to narrow down the number of results in response. It
 increases the response time significantly because by default there is no other way to sort instances in the index by
 effective shelving key. This can be explained by the structure of the instance record. For Elasticsearch it contains all
 fields from the instance and corresponding items\holding as inner arrays. This results in fields
-like `items.effectiveShelvingOrder` to store multiple values. For correct browsing one of the values must be chosen
+like `item.effectiveShelvingOrder` to store multiple values. For correct browsing one of the values must be chosen
 every time depending on the user input. Script-based sorting solves this problem because the right value from the array
 can be chosen by the binary search algorithm from the core `Collections` class. Sorting of items before indexing
 operation reduces the overall complexity of script sorting._

--- a/src/main/java/org/folio/search/controller/BrowseController.java
+++ b/src/main/java/org/folio/search/controller/BrowseController.java
@@ -8,6 +8,7 @@ import static org.folio.search.utils.SearchUtils.CONTRIBUTOR_BROWSING_FIELD;
 import static org.folio.search.utils.SearchUtils.CONTRIBUTOR_RESOURCE;
 import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
 import static org.folio.search.utils.SearchUtils.INSTANCE_SUBJECT_RESOURCE;
+import static org.folio.search.utils.SearchUtils.SHELVING_ORDER_BROWSING_FIELD;
 import static org.folio.search.utils.SearchUtils.SUBJECT_BROWSING_FIELD;
 
 import lombok.RequiredArgsConstructor;
@@ -58,7 +59,8 @@ public class BrowseController implements BrowseApi {
                                                                             Boolean highlightMatch,
                                                                             Integer precedingRecordsCount) {
     var browseRequest = getBrowseRequestBuilder(query, tenant, limit, expandAll, highlightMatch, precedingRecordsCount)
-      .resource(INSTANCE_RESOURCE).targetField(CALL_NUMBER_BROWSING_FIELD).build();
+      .resource(INSTANCE_RESOURCE).targetField(SHELVING_ORDER_BROWSING_FIELD).subField(CALL_NUMBER_BROWSING_FIELD)
+      .build();
 
     var instanceByCallNumber = callNumberBrowseService.browse(browseRequest);
     return ResponseEntity.ok(new CallNumberBrowseResult()

--- a/src/main/java/org/folio/search/model/service/BrowseRequest.java
+++ b/src/main/java/org/folio/search/model/service/BrowseRequest.java
@@ -36,6 +36,11 @@ public class BrowseRequest implements ResourceRequest {
   private final String targetField;
 
   /**
+   * Sub-field for browsing.
+   */
+  private final String subField;
+
+  /**
    * Whether to return only basic properties or entire instance.
    */
   private final Boolean expandAll;

--- a/src/main/java/org/folio/search/service/browse/BrowseContextProvider.java
+++ b/src/main/java/org/folio/search/service/browse/BrowseContextProvider.java
@@ -8,7 +8,6 @@ import static org.hibernate.internal.util.collections.CollectionHelper.isNotEmpt
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
-
 import lombok.RequiredArgsConstructor;
 import org.folio.search.cql.CqlSearchQueryConverter;
 import org.folio.search.exception.RequestValidationException;

--- a/src/main/java/org/folio/search/service/browse/BrowseContextProvider.java
+++ b/src/main/java/org/folio/search/service/browse/BrowseContextProvider.java
@@ -8,6 +8,7 @@ import static org.hibernate.internal.util.collections.CollectionHelper.isNotEmpt
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
+
 import lombok.RequiredArgsConstructor;
 import org.folio.search.cql.CqlSearchQueryConverter;
 import org.folio.search.exception.RequestValidationException;
@@ -115,8 +116,12 @@ public class BrowseContextProvider {
 
   static boolean isValidRangeQuery(String targetField, String subField, QueryBuilder q) {
     if (q instanceof RangeQueryBuilder) {
-      var query = (RangeQueryBuilder) q;
-      return targetField.equals(query.fieldName()) || subField.equals(query.fieldName());
+      var fieldName = ((RangeQueryBuilder) q).fieldName();
+      var isTargetValid = targetField.equals(fieldName);
+      if (!isTargetValid && subField != null) {
+        return subField.equals(fieldName);
+      }
+      return isTargetValid;
     }
     return false;
   }

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -67,7 +67,7 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
 
   @Override
   protected String getValueForBrowsing(CallNumberBrowseItem browseItem) {
-    return browseItem.getFullCallNumber();
+    return browseItem.getShelfKey();
   }
 
   private static void highlightMatchingCallNumber(BrowseContext ctx,

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -48,7 +48,7 @@ public class SearchUtils {
   public static final String INSTANCE_HOLDING_FIELD_NAME = "holdings";
   public static final String INSTANCE_CONTRIBUTORS_FIELD_NAME = "contributors";
   public static final String IS_BOUND_WITH_FIELD_NAME = "isBoundWith";
-  public static final String CALL_NUMBER_BROWSING_FIELD = "itemEffectiveShelvingOrder";
+  public static final String CALL_NUMBER_BROWSING_FIELD = "callNumber";
   public static final String SUBJECT_BROWSING_FIELD = "subject";
   public static final String CONTRIBUTOR_BROWSING_FIELD = "name";
   public static final String AUTHORITY_BROWSING_FIELD = "headingRef";

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -49,6 +49,7 @@ public class SearchUtils {
   public static final String INSTANCE_CONTRIBUTORS_FIELD_NAME = "contributors";
   public static final String IS_BOUND_WITH_FIELD_NAME = "isBoundWith";
   public static final String CALL_NUMBER_BROWSING_FIELD = "callNumber";
+  public static final String SHELVING_ORDER_BROWSING_FIELD = "itemEffectiveShelvingOrder";
   public static final String SUBJECT_BROWSING_FIELD = "subject";
   public static final String CONTRIBUTOR_BROWSING_FIELD = "name";
   public static final String AUTHORITY_BROWSING_FIELD = "headingRef";

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -610,8 +610,7 @@
     "itemEffectiveShelvingOrder": {
       "type": "search",
       "index": "keyword",
-      "searchAliases": [ "callNumber", "items.effectiveShelvingOrder" ],
-      "searchTermProcessor": "effectiveShelvingOrderTermProcessor",
+      "searchAliases": [ "items.effectiveShelvingOrder" ],
       "processor": "itemEffectiveShelvingOrderProcessor"
     },
     "allInstances": {

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -610,7 +610,7 @@
     "itemEffectiveShelvingOrder": {
       "type": "search",
       "index": "keyword",
-      "searchAliases": [ "callNumber", "items.effectiveShelvingOrder" ],
+      "searchAliases": [ "items.effectiveShelvingOrder" ],
       "processor": "itemEffectiveShelvingOrderProcessor"
     },
     "allInstances": {

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -610,7 +610,7 @@
     "itemEffectiveShelvingOrder": {
       "type": "search",
       "index": "keyword",
-      "searchAliases": [ "items.effectiveShelvingOrder" ],
+      "searchAliases": [ "callNumber", "items.effectiveShelvingOrder" ],
       "processor": "itemEffectiveShelvingOrderProcessor"
     },
     "allInstances": {

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
@@ -70,7 +70,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       .param("precedingRecordsCount", "4");
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
-      .totalRecords(37).prev(null).next("CE 16 B6713 X 41993").items(List.of(
+      .totalRecords(37).prev(null).next("CE 216 B6713 X 541993").items(List.of(
         cnBrowseItem(instance("instance #31"), "AB 14 C72 NO 220"),
         cnBrowseItem(instance("instance #25"), "AC 11 A4 VOL 235"),
         cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
@@ -89,7 +89,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
 
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
-      .totalRecords(37).prev("AC 11 A67 X 42000").next("CE 16 D86 X 41998").items(List.of(
+      .totalRecords(37).prev("AC 211 A67 X 542000").next("CE 216 D86 X 541998").items(List.of(
         cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
         cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
         cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993"),
@@ -109,7 +109,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
 
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
-      .totalRecords(57).prev("DA 3870 B55 41868").next("DA 3880 O6 D5").items(List.of(
+      .totalRecords(57).prev("DA 43870 B55 541868").next("DA 43880 O6 D5").items(List.of(
         cnBrowseItem(instance("instance #41"), "DA 3870 B55 41868"),
         cnBrowseItem(instance("instance #07"), "DA 3870 H47 41975"),
         cnBrowseItem(instance("instance #11"), "DA 3880 K56 M27 41984"),
@@ -135,7 +135,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
     return Stream.of(
       arguments(aroundQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(36).prev("CE 16 B6724 41993").next("DA 3700 C95 NO 18").items(List.of(
+        .totalRecords(36).prev("CE 216 B6724 541993").next("DA 43700 C95 NO 218").items(List.of(
           cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993"),
           cnBrowseItem(instance("instance #04"), "CE 16 D86 X 41998"),
           cnBrowseItem(0, "CE 210 K297 41858", true),
@@ -144,7 +144,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(aroundQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(50).prev("DA 3880 O6 M81").next("DA 3890 A2 B76 42002").items(List.of(
+        .totalRecords(50).prev("DA 43880 O6 M81").next("DA 43890 A2 B76 542002").items(List.of(
           cnBrowseItem(instance("instance #13"), "DA 3880 O6 M81"),
           cnBrowseItem(instance("instance #02"), "DA 3880 O6 M96"),
           cnBrowseItem(0, "DA 3890 A1", true),
@@ -153,7 +153,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(aroundIncludingQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(36).prev("CE 16 B6724 41993").next("DA 3700 C95 NO 18").items(List.of(
+        .totalRecords(36).prev("CE 216 B6724 541993").next("DA 43700 C95 NO 218").items(List.of(
           cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993"),
           cnBrowseItem(instance("instance #04"), "CE 16 D86 X 41998"),
           cnBrowseItem(instance("instance #38"), "CE 210 K297 41858", true),
@@ -162,7 +162,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(aroundIncludingQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(50).prev("DA 3880 O6 M81").next("DA 3890 A2 B76 42002").items(List.of(
+        .totalRecords(50).prev("DA 43880 O6 M81").next("DA 43890 A2 B76 542002").items(List.of(
           cnBrowseItem(instance("instance #13"), "DA 3880 O6 M81"),
           cnBrowseItem(instance("instance #02"), "DA 3880 O6 M96"),
           cnBrowseItem(0, "DA 3890 A1", true),
@@ -172,7 +172,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // checks order of closely placed call-numbers
       arguments(aroundIncludingQuery, secondAnchorCallNumber, 25, new CallNumberBrowseResult()
-        .totalRecords(50).prev("DA 3870 H47 41975").next("E 211 N52 VOL 14").items(List.of(
+        .totalRecords(50).prev("DA 43870 H47 541975").next("E 3211 N52 VOL 214").items(List.of(
           cnBrowseItem(instance("instance #07"), "DA 3870 H47 41975"),
           cnBrowseItem(instance("instance #11"), "DA 3880 K56 M27 41984"),
           cnBrowseItem(instance("instance #32"), "DA 3880 O5 C3 V3"),
@@ -202,7 +202,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // checks if collapsing by the same result works correctly
       arguments(aroundIncludingQuery, "FC", 5, new CallNumberBrowseResult()
-        .totalRecords(39).prev("FA 42010 3546 256").next("G 45831 S2").items(List.of(
+        .totalRecords(39).prev("FA 542010 43546 3256").next("G 545831 S2").items(List.of(
           cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
           cnBrowseItem(instance("instance #42"), "FA 46252 3977 12 237"),
           cnBrowseItem(0, "FC", true),
@@ -212,7 +212,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // checks if collapsing by the same result works correctly
       arguments(aroundIncludingQuery, "fc", 5, new CallNumberBrowseResult()
-        .totalRecords(39).prev("FA 42010 3546 256").next("G 45831 S2").items(List.of(
+        .totalRecords(39).prev("FA 542010 43546 3256").next("G 545831 S2").items(List.of(
           cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
           cnBrowseItem(instance("instance #42"), "FA 46252 3977 12 237"),
           cnBrowseItem(0, "fc", true),
@@ -222,7 +222,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // browsing forward
       arguments(forwardQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(28).prev("DA 3700 B91 L79").next("DA 3880 K56 M27 41984").items(List.of(
+        .totalRecords(28).prev("DA 43700 B91 L79").next("DA 43880 K56 M27 541984").items(List.of(
           cnBrowseItem(instance("instance #36"), "DA 3700 B91 L79"),
           cnBrowseItem(instance("instance #09"), "DA 3700 C95 NO 18"),
           cnBrowseItem(instance("instance #41"), "DA 3870 B55 41868"),
@@ -231,7 +231,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(forwardQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(24).prev("DA 3890 A1 I72 41885").next("DA 3900 C89 V1").items(List.of(
+        .totalRecords(24).prev("DA 43890 A1 I72 541885").next("DA 43900 C89 V1").items(List.of(
           cnBrowseItem(instance("instance #14"), "DA 3890 A1 I72 41885"),
           cnBrowseItem(instance("instance #22"), "DA 3890 A2 B76 42002"),
           cnBrowseItem(instance("instance #19"), "DA 3890 A2 F57 42011"),
@@ -241,7 +241,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // checks if collapsing works in forward direction
       arguments(forwardQuery, "F", 5, new CallNumberBrowseResult()
-        .totalRecords(13).prev("F  PR1866.S63 V.1 C.1").next("FC 17 B89").items(List.of(
+        .totalRecords(13).prev("F  PR1866.S63 V.1 C.1").next("FC 217 B89").items(List.of(
           cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1"),
           cnBrowseItem(instance("instance #27"), "F 43733 L370 41992"),
           cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
@@ -253,7 +253,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         .totalRecords(0).prev(null).next(null).items(emptyList())),
 
       arguments(forwardIncludingQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(28).prev("CE 210 K297 41858").next("DA 3870 H47 41975").items(List.of(
+        .totalRecords(28).prev("CE 3210 K297 541858").next("DA 43870 H47 541975").items(List.of(
           cnBrowseItem(instance("instance #38"), "CE 210 K297 41858"),
           cnBrowseItem(instance("instance #36"), "DA 3700 B91 L79"),
           cnBrowseItem(instance("instance #09"), "DA 3700 C95 NO 18"),
@@ -262,7 +262,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(forwardIncludingQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(24).prev("DA 3890 A1 I72 41885").next("DA 3900 C89 V1").items(List.of(
+        .totalRecords(24).prev("DA 43890 A1 I72 541885").next("DA 43900 C89 V1").items(List.of(
           cnBrowseItem(instance("instance #14"), "DA 3890 A1 I72 41885"),
           cnBrowseItem(instance("instance #22"), "DA 3890 A2 B76 42002"),
           cnBrowseItem(instance("instance #19"), "DA 3890 A2 F57 42011"),
@@ -272,7 +272,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // browsing backward
       arguments(backwardQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(8).prev("AC 11 A67 X 42000").next("CE 16 D86 X 41998").items(List.of(
+        .totalRecords(8).prev("AC 211 A67 X 542000").next("CE 216 D86 X 541998").items(List.of(
           cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
           cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
           cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993"),
@@ -281,7 +281,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(backwardQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(26).prev("DA 3880 O6 L75").next("DA 3880 O6 M96").items(List.of(
+        .totalRecords(26).prev("DA 43880 O6 L75").next("DA 43880 O6 M96").items(List.of(
           cnBrowseItem(instance("instance #20"), "DA 3880 O6 L75"),
           cnBrowseItem(instance("instance #15"), "DA 3880 O6 L76"),
           cnBrowseItem(instance("instance #05"), "DA 3880 O6 M15"),
@@ -291,7 +291,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // check that collapsing works for browsing backward
       arguments(backwardQuery, "G", 5, new CallNumberBrowseResult()
-        .totalRecords(32).prev("F  PR1866.S63 V.1 C.1").next("FC 17 B89").items(List.of(
+        .totalRecords(32).prev("F  PR1866.S63 V.1 C.1").next("FC 217 B89").items(List.of(
           cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1"),
           cnBrowseItem(instance("instance #27"), "F 43733 L370 41992"),
           cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
@@ -300,7 +300,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(backwardQuery, "F 1", 5, new CallNumberBrowseResult()
-        .totalRecords(28).prev("E 12.11 I12 288 D").next("F  PR1866.S63 V.1 C.1").items(List.of(
+        .totalRecords(28).prev("E 212.11 I12 3288 D").next("F  PR1866.S63 V.1 C.1").items(List.of(
           cnBrowseItem(instance("instance #35"), "E 12.11 I12 288 D"),
           cnBrowseItem(instance("instance #33"), "E 12.11 I2 298"),
           cnBrowseItem(instance("instance #27"), "E 211 A506"),
@@ -312,7 +312,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         .totalRecords(0).prev(null).next(null).items(emptyList())),
 
       arguments(backwardIncludingQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(8).prev("AC 11 E8 NO 14 P S1487").next("CE 210 K297 41858").items(List.of(
+        .totalRecords(8).prev("AC 211 E8 NO 214 P S1487").next("CE 3210 K297 541858").items(List.of(
           cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
           cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993"),
           cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993"),
@@ -321,7 +321,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(backwardIncludingQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(26).prev("DA 3880 O6 L75").next("DA 3880 O6 M96").items(List.of(
+        .totalRecords(26).prev("DA 43880 O6 L75").next("DA 43880 O6 M96").items(List.of(
           cnBrowseItem(instance("instance #20"), "DA 3880 O6 L75"),
           cnBrowseItem(instance("instance #15"), "DA 3880 O6 L76"),
           cnBrowseItem(instance("instance #05"), "DA 3880 O6 M15"),

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
@@ -125,13 +125,15 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
   private static Stream<Arguments> callNumberBrowsingDataProvider() {
     var aroundQuery = "callNumber > {value} or callNumber < {value}";
     var aroundIncludingQuery = "callNumber >= {value} or callNumber < {value}";
-    var forwardQuery = "callNumber > {value}";
-    var forwardIncludingQuery = "callNumber >= {value}";
-    var backwardQuery = "callNumber < {value}";
-    var backwardIncludingQuery = "callNumber <= {value}";
+    var forwardQuery = "itemEffectiveShelvingOrder > {value}";
+    var forwardIncludingQuery = "itemEffectiveShelvingOrder >= {value}";
+    var backwardQuery = "itemEffectiveShelvingOrder < {value}";
+    var backwardIncludingQuery = "itemEffectiveShelvingOrder <= {value}";
 
     var firstAnchorCallNumber = "CE 210 K297 41858";
     var secondAnchorCallNumber = "DA 3890 A1";
+    var firstAnchorShelfKey = getShelfKeyFromCallNumber(firstAnchorCallNumber);
+    var secondAnchorShelfKey = getShelfKeyFromCallNumber(secondAnchorCallNumber);
 
     return Stream.of(
       arguments(aroundQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
@@ -221,7 +223,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       // browsing forward
-      arguments(forwardQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
+      arguments(forwardQuery, firstAnchorShelfKey, 5, new CallNumberBrowseResult()
         .totalRecords(28).prev("DA 43700 B91 L79").next("DA 43880 K56 M27 541984").items(List.of(
           cnBrowseItem(instance("instance #36"), "DA 3700 B91 L79"),
           cnBrowseItem(instance("instance #09"), "DA 3700 C95 NO 18"),
@@ -230,7 +232,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
           cnBrowseItem(instance("instance #11"), "DA 3880 K56 M27 41984")
         ))),
 
-      arguments(forwardQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
+      arguments(forwardQuery, secondAnchorShelfKey, 5, new CallNumberBrowseResult()
         .totalRecords(24).prev("DA 43890 A1 I72 541885").next("DA 43900 C89 V1").items(List.of(
           cnBrowseItem(instance("instance #14"), "DA 3890 A1 I72 41885"),
           cnBrowseItem(instance("instance #22"), "DA 3890 A2 B76 42002"),
@@ -252,7 +254,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       arguments(forwardQuery, "Z", 10, new CallNumberBrowseResult()
         .totalRecords(0).prev(null).next(null).items(emptyList())),
 
-      arguments(forwardIncludingQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
+      arguments(forwardIncludingQuery, firstAnchorShelfKey, 5, new CallNumberBrowseResult()
         .totalRecords(28).prev("CE 3210 K297 541858").next("DA 43870 H47 541975").items(List.of(
           cnBrowseItem(instance("instance #38"), "CE 210 K297 41858"),
           cnBrowseItem(instance("instance #36"), "DA 3700 B91 L79"),
@@ -261,7 +263,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
           cnBrowseItem(instance("instance #07"), "DA 3870 H47 41975")
         ))),
 
-      arguments(forwardIncludingQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
+      arguments(forwardIncludingQuery, secondAnchorShelfKey, 5, new CallNumberBrowseResult()
         .totalRecords(24).prev("DA 43890 A1 I72 541885").next("DA 43900 C89 V1").items(List.of(
           cnBrowseItem(instance("instance #14"), "DA 3890 A1 I72 41885"),
           cnBrowseItem(instance("instance #22"), "DA 3890 A2 B76 42002"),
@@ -271,7 +273,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       // browsing backward
-      arguments(backwardQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
+      arguments(backwardQuery, firstAnchorShelfKey, 5, new CallNumberBrowseResult()
         .totalRecords(8).prev("AC 211 A67 X 542000").next("CE 216 D86 X 541998").items(List.of(
           cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
           cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
@@ -280,7 +282,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
           cnBrowseItem(instance("instance #04"), "CE 16 D86 X 41998")
         ))),
 
-      arguments(backwardQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
+      arguments(backwardQuery, secondAnchorShelfKey, 5, new CallNumberBrowseResult()
         .totalRecords(26).prev("DA 43880 O6 L75").next("DA 43880 O6 M96").items(List.of(
           cnBrowseItem(instance("instance #20"), "DA 3880 O6 L75"),
           cnBrowseItem(instance("instance #15"), "DA 3880 O6 L76"),
@@ -299,7 +301,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
           cnBrowseItem(2, "FC 17 B89")
         ))),
 
-      arguments(backwardQuery, "F 1", 5, new CallNumberBrowseResult()
+      arguments(backwardQuery, "F 11", 5, new CallNumberBrowseResult()
         .totalRecords(28).prev("E 212.11 I12 3288 D").next("F  PR1866.S63 V.1 C.1").items(List.of(
           cnBrowseItem(instance("instance #35"), "E 12.11 I12 288 D"),
           cnBrowseItem(instance("instance #33"), "E 12.11 I2 298"),
@@ -311,7 +313,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       arguments(backwardQuery, "A", 10, new CallNumberBrowseResult()
         .totalRecords(0).prev(null).next(null).items(emptyList())),
 
-      arguments(backwardIncludingQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
+      arguments(backwardIncludingQuery, firstAnchorShelfKey, 5, new CallNumberBrowseResult()
         .totalRecords(8).prev("AC 211 E8 NO 214 P S1487").next("CE 3210 K297 541858").items(List.of(
           cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
           cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993"),
@@ -320,7 +322,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
           cnBrowseItem(instance("instance #38"), "CE 210 K297 41858")
         ))),
 
-      arguments(backwardIncludingQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
+      arguments(backwardIncludingQuery, secondAnchorShelfKey, 5, new CallNumberBrowseResult()
         .totalRecords(26).prev("DA 43880 O6 L75").next("DA 43880 O6 M96").items(List.of(
           cnBrowseItem(instance("instance #20"), "DA 3880 O6 L75"),
           cnBrowseItem(instance("instance #15"), "DA 3880 O6 L76"),

--- a/src/test/java/org/folio/search/controller/BrowseControllerTest.java
+++ b/src/test/java/org/folio/search/controller/BrowseControllerTest.java
@@ -8,6 +8,7 @@ import static org.folio.search.utils.SearchUtils.AUTHORITY_RESOURCE;
 import static org.folio.search.utils.SearchUtils.CALL_NUMBER_BROWSING_FIELD;
 import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
 import static org.folio.search.utils.SearchUtils.INSTANCE_SUBJECT_RESOURCE;
+import static org.folio.search.utils.SearchUtils.SHELVING_ORDER_BROWSING_FIELD;
 import static org.folio.search.utils.TestConstants.RESOURCE_ID;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.authorityBrowseItem;
@@ -72,7 +73,8 @@ class BrowseControllerTest {
   @Test
   void browseInstancesByCallNumber_positive_allFields() throws Exception {
     var query = "callNumber > B";
-    var request = BrowseRequest.of(INSTANCE_RESOURCE, TENANT_ID, query, 20, CALL_NUMBER_BROWSING_FIELD, true, true, 5);
+    var request = BrowseRequest.of(INSTANCE_RESOURCE, TENANT_ID,
+      query, 20, SHELVING_ORDER_BROWSING_FIELD, CALL_NUMBER_BROWSING_FIELD, true, true, 5);
     when(callNumberBrowseService.browse(request)).thenReturn(BrowseResult.empty());
 
     var requestBuilder = get(instanceCallNumberBrowsePath())
@@ -93,7 +95,7 @@ class BrowseControllerTest {
   @Test
   void browseInstancesBySubject_positive() throws Exception {
     var query = "subject > water";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT_RESOURCE, TENANT_ID, query, 25, "subject", null, true, 12);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT_RESOURCE, TENANT_ID, query, 25, "subject", null, null, true, 12);
     var browseResult = BrowseResult.of(1, List.of(subjectBrowseItem(10, "water treatment")));
     when(subjectBrowseService.browse(request)).thenReturn(browseResult);
     var requestBuilder = get(instanceSubjectBrowsePath())
@@ -112,7 +114,7 @@ class BrowseControllerTest {
   @Test
   void browseAuthoritiesBySubject_positive() throws Exception {
     var query = "headingRef > mark";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 25, "headingRef", false, true, 12);
+    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 25, "headingRef", null, false, true, 12);
     var authority = new Authority().id(RESOURCE_ID).headingRef("mark twain");
     var browseResult = BrowseResult.of(1, List.of(authorityBrowseItem("mark twain", authority)));
     when(authorityBrowseService.browse(request)).thenReturn(browseResult);
@@ -185,6 +187,6 @@ class BrowseControllerTest {
 
   public static BrowseRequest browseRequest(String query, int limit) {
     return BrowseRequest.of(INSTANCE_RESOURCE, TENANT_ID, query, limit,
-      CALL_NUMBER_BROWSING_FIELD, false, true, limit / 2);
+      SHELVING_ORDER_BROWSING_FIELD, CALL_NUMBER_BROWSING_FIELD, false, true, limit / 2);
   }
 }

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -329,6 +329,9 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("item.electronicAccess.linkText all {value}", "links available"),
       arguments("item.electronicAccess.publicNote all {value}", "table of contents"),
 
+      arguments("item.effectiveShelvingOrder ==/string \"{value}\"", "TK 45105.88815 A58 42004 FT MEADE"),
+      arguments("itemEffectiveShelvingOrder ==/string \"{value}\"", "TK 45105.88815 A58 42004 FT MEADE"),
+
       // Search by item fields (Backward compatibility)
       arguments("items.hrid = {value}", "item000000000014"),
       arguments("items.hrid = {value}", "item*"),

--- a/src/test/java/org/folio/search/service/browse/AuthorityBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/AuthorityBrowseServiceTest.java
@@ -73,7 +73,7 @@ class AuthorityBrowseServiceTest {
   @Test
   void browse_positive_forward() {
     var query = "headingRef > s0";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, true, false, 5);
+    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, null, true, false, 5);
     var esQuery = rangeQuery(TARGET_FIELD).gt("s0");
     var context = BrowseContext.builder().succeedingQuery(esQuery).succeedingLimit(5).anchor("s0").build();
 
@@ -91,14 +91,14 @@ class AuthorityBrowseServiceTest {
   @Test
   void browse_positive_forward_expandAllIsFalse() {
     var query = "headingRef > s0";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, false, false, 5);
+    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, null, false, false, 5);
     var esQuery = rangeQuery(TARGET_FIELD).gt("s0");
     var context = BrowseContext.builder().succeedingQuery(esQuery).succeedingLimit(5).anchor("s0").build();
-    var expectedSearchSource = searchSource("s0", 6, ASC).fetchSource(new String[] {"id", "headingRef"}, null);
+    var expectedSearchSource = searchSource("s0", 6, ASC).fetchSource(new String[]{"id", "headingRef"}, null);
 
     when(browseContextProvider.get(request)).thenReturn(context);
     when(searchRepository.search(request, expectedSearchSource)).thenReturn(searchResponse);
-    when(searchFieldProvider.getSourceFields(AUTHORITY_RESOURCE, BROWSE)).thenReturn(new String[] {"id", "headingRef"});
+    when(searchFieldProvider.getSourceFields(AUTHORITY_RESOURCE, BROWSE)).thenReturn(new String[]{"id", "headingRef"});
     when(documentConverter.convertToSearchResult(searchResponse, Authority.class))
       .thenReturn(searchResult(authorities("s1", "s2", "s3", "s4", "s5")));
 
@@ -111,7 +111,7 @@ class AuthorityBrowseServiceTest {
   @Test
   void browse_positive_backward() {
     var query = "headingRef < s4";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 3, TARGET_FIELD, true, false, 3);
+    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 3, TARGET_FIELD, null, true, false, 3);
     var esQuery = rangeQuery(TARGET_FIELD).lt("s4");
     var context = BrowseContext.builder().precedingQuery(esQuery).precedingLimit(3).anchor("s4").build();
 
@@ -130,7 +130,8 @@ class AuthorityBrowseServiceTest {
   @ValueSource(booleans = {true, false})
   void browse_positive_forwardIncluding(boolean highlightMatch) {
     var query = "headingRef >= s0";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, true, highlightMatch, 5);
+    var request =
+      BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, null, true, highlightMatch, 5);
     var esQuery = rangeQuery(TARGET_FIELD).gte("s0");
     var context = BrowseContext.builder().succeedingQuery(esQuery).succeedingLimit(5).anchor("s0").build();
 
@@ -149,7 +150,8 @@ class AuthorityBrowseServiceTest {
   @ValueSource(booleans = {true, false})
   void browse_positive_forwardIncluding_searchResultLowerThanLimit(boolean highlightMatch) {
     var query = "headingRef >= s0";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 10, TARGET_FIELD, true, highlightMatch, 5);
+    var request =
+      BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 10, TARGET_FIELD, null, true, highlightMatch, 5);
     var esQuery = rangeQuery(TARGET_FIELD).gte("s0");
     var context = BrowseContext.builder().succeedingQuery(esQuery).succeedingLimit(10).anchor("s0").build();
 
@@ -168,7 +170,8 @@ class AuthorityBrowseServiceTest {
   @ValueSource(booleans = {true, false})
   void browse_positive_forwardIncludingAnchorNotFound(boolean highlightMatch) {
     var query = "headingRef >= s0";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, true, highlightMatch, 5);
+    var request =
+      BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, null, true, highlightMatch, 5);
     var esQuery = rangeQuery(TARGET_FIELD).gte("s0");
     var context = BrowseContext.builder().succeedingQuery(esQuery).succeedingLimit(5).anchor("s0").build();
 
@@ -187,7 +190,8 @@ class AuthorityBrowseServiceTest {
   @ValueSource(booleans = {true, false})
   void browse_positive_backwardIncluding(boolean highlightMatch) {
     var query = "headingRef <= s4";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 3, TARGET_FIELD, true, highlightMatch, 3);
+    var request =
+      BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 3, TARGET_FIELD, null, true, highlightMatch, 3);
     var esQuery = rangeQuery(TARGET_FIELD).lte("s4");
     var context = BrowseContext.builder().precedingQuery(esQuery).precedingLimit(3).anchor("s4").build();
 
@@ -205,7 +209,7 @@ class AuthorityBrowseServiceTest {
   @Test
   void browse_positive_around() {
     var query = "headingRef > s0 or headingRef < s0";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, true, true, 2);
+    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, null, true, true, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(false));
     mockMultiSearchRequest(request,
@@ -220,7 +224,7 @@ class AuthorityBrowseServiceTest {
   @Test
   void browse_positive_aroundWithoutHighlighting() {
     var query = "headingRef > s0 or headingRef < s0";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, true, false, 2);
+    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, null, true, false, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(false));
     mockMultiSearchRequest(request,
@@ -235,7 +239,7 @@ class AuthorityBrowseServiceTest {
   @Test
   void browse_positive_aroundIncluding() {
     var query = "headingRef < s0 or headingRef >= s0";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, true, true, 2);
+    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, null, true, true, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
@@ -253,7 +257,7 @@ class AuthorityBrowseServiceTest {
   @Test
   void browse_positive_aroundIncludingWithoutHighlighting() {
     var query = "headingRef < s0 or headingRef >= s0";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, true, false, 2);
+    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, null, true, false, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
@@ -271,7 +275,7 @@ class AuthorityBrowseServiceTest {
   @Test
   void browse_positive_aroundIncludingMissingAnchor() {
     var query = "headingRef <= s0 or headingRef > s0";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, true, true, 2);
+    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, null, true, true, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
@@ -289,7 +293,7 @@ class AuthorityBrowseServiceTest {
   @Test
   void browse_positive_aroundIncludingMissingAnchorWithoutHighlighting() {
     var query = "headingRef <= s0 or headingRef > s0";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, true, false, 2);
+    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 5, TARGET_FIELD, null, true, false, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
@@ -307,7 +311,7 @@ class AuthorityBrowseServiceTest {
   private static SearchSourceBuilder searchSource(String heading, int size, SortOrder sortOrder) {
     return SearchSourceBuilder.searchSource()
       .query(boolQuery().filter(termsQuery("authRefType", "Authorized", "Reference")))
-      .searchAfter(new String[] {heading}).from(0).size(size)
+      .searchAfter(new String[]{heading}).from(0).size(size)
       .sort(fieldSort(TARGET_FIELD).order(sortOrder))
       .fetchSource((String[]) null, null);
   }

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
@@ -79,7 +79,7 @@ class CallNumberBrowseServiceTest {
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(BrowseResult.of(11, "A3", "C2", List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(11, "A 13", "C 12", List.of(
       cnBrowseItem(instance("A3"), "A3"),
       cnBrowseItem(instance("A4"), "A4"),
       cnBrowseItem(0, "B", true),
@@ -159,7 +159,7 @@ class CallNumberBrowseServiceTest {
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(BrowseResult.of(2, "C1", null, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(2, "C 11", null, List.of(
       cnBrowseItem(instance("C1"), "C1"), cnBrowseItem(instance("C2"), "C2"))));
   }
 
@@ -189,7 +189,7 @@ class CallNumberBrowseServiceTest {
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(BrowseResult.of(5, "C1", "C2", List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(5, "C 11", "C 12", List.of(
       cnBrowseItem(instance("C1"), "C1"), cnBrowseItem(instance("C2"), "C2"))));
   }
 
@@ -223,7 +223,7 @@ class CallNumberBrowseServiceTest {
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(BrowseResult.of(2, null, "A2", List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(2, null, "A 12", List.of(
       cnBrowseItem(instance("A1"), "A1"), cnBrowseItem(instance("A2"), "A2"))));
   }
 
@@ -241,7 +241,7 @@ class CallNumberBrowseServiceTest {
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(BrowseResult.of(5, "A4", "A5", List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(5, "A 14", "A 15", List.of(
       cnBrowseItem(instance("A4"), "A4"), cnBrowseItem(instance("A5"), "A5"))));
   }
 

--- a/src/test/java/org/folio/search/service/browse/SubjectBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/SubjectBrowseServiceTest.java
@@ -67,7 +67,7 @@ class SubjectBrowseServiceTest {
   @Test
   void browse_positive_forward() {
     var query = "subject > s0";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, false, 5);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, false, 5);
     var esQuery = rangeQuery(TARGET_FIELD).gt("s0");
     var context = BrowseContext.builder().succeedingQuery(esQuery).succeedingLimit(5).anchor("s0").build();
     var expectedSearchSource = searchSource("s0", 6, ASC);
@@ -88,7 +88,7 @@ class SubjectBrowseServiceTest {
   @Test
   void browse_positive_emptySearchResult() {
     var query = "subject > s0";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, false, 5);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, false, 5);
     var esQuery = rangeQuery(TARGET_FIELD).gt("s0");
     var context = BrowseContext.builder().succeedingQuery(esQuery).succeedingLimit(5).anchor("s0").build();
     var expectedSearchSource = searchSource("s0", 6, ASC);
@@ -106,7 +106,7 @@ class SubjectBrowseServiceTest {
   @Test
   void browse_positive_backward() {
     var query = "subject < s4";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 3, TARGET_FIELD, null, false, 3);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 3, TARGET_FIELD, null, null, false, 3);
     var esQuery = rangeQuery(TARGET_FIELD).lt("s4");
     var context = BrowseContext.builder().precedingQuery(esQuery).precedingLimit(3).anchor("s4").build();
     var expectedSearchSource = searchSource("s4", 4, DESC);
@@ -127,7 +127,7 @@ class SubjectBrowseServiceTest {
   @ValueSource(booleans = {true, false})
   void browse_positive_forwardIncluding(boolean highlightMatch) {
     var query = "subject >= s0";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, highlightMatch, 5);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, highlightMatch, 5);
     var esQuery = rangeQuery(TARGET_FIELD).gte("s0");
     var context = BrowseContext.builder().succeedingQuery(esQuery).succeedingLimit(5).anchor("s0").build();
     var browsingSearchResult = searchResult(
@@ -151,7 +151,7 @@ class SubjectBrowseServiceTest {
   @ValueSource(booleans = {true, false})
   void browse_positive_forwardIncludingAnchorNotFound(boolean highlightMatch) {
     var query = "subject >= s0";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, highlightMatch, 5);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, highlightMatch, 5);
     var browsingSearchResult = searchResult(
       subjectBrowseItem("s1"), subjectBrowseItem("s2"), subjectBrowseItem("s3"),
       subjectBrowseItem("s4"), subjectBrowseItem("s5"));
@@ -175,7 +175,7 @@ class SubjectBrowseServiceTest {
   @ValueSource(booleans = {true, false})
   void browse_positive_backwardIncluding(boolean highlightMatch) {
     var query = "subject <= s4";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 3, TARGET_FIELD, null, highlightMatch, 3);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 3, TARGET_FIELD, null, null, highlightMatch, 3);
     var browsingSearchResult = searchResult(browseItems("s3", "s2", "s1", "s0"));
     var esQuery = rangeQuery(TARGET_FIELD).lte("s4");
     var context = BrowseContext.builder().precedingQuery(esQuery).precedingLimit(3).anchor("s4").build();
@@ -195,7 +195,7 @@ class SubjectBrowseServiceTest {
   @Test
   void browse_positive_forwardIncludingTermMissing() {
     var query = "subject >= s0";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, "subject", null, false, 5);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, "subject", null, null, false, 5);
     var esQuery = rangeQuery("subject").gte("s0");
     var context = BrowseContext.builder().succeedingQuery(esQuery).succeedingLimit(5).anchor("s0").build();
     var browsingSearchResult = searchResult(browseItems("s1", "s2"));
@@ -215,7 +215,7 @@ class SubjectBrowseServiceTest {
   @Test
   void browse_positive_around() {
     var query = "subject > s0 or subject < s0";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, true, 2);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, true, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(false));
     mockMultiSearchRequest(request, List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)), List.of(
@@ -232,7 +232,7 @@ class SubjectBrowseServiceTest {
   @Test
   void browse_positive_aroundWhenPrevAndNextValuesMissing() {
     var query = "subject > s0 or subject < s0";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, true, 2);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, true, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(false));
     mockMultiSearchRequest(request, List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)), List.of(
@@ -249,7 +249,7 @@ class SubjectBrowseServiceTest {
   @Test
   void browse_positive_aroundWithoutHighlighting() {
     var query = "subject > s0 or subject < s0";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, false, 2);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, false, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(false));
     mockMultiSearchRequest(request, List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)),
@@ -265,7 +265,7 @@ class SubjectBrowseServiceTest {
   @Test
   void browse_positive_aroundIncluding() {
     var query = "subject < s0 or subject >= s0";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, true, 2);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, true, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
@@ -285,7 +285,7 @@ class SubjectBrowseServiceTest {
   @Test
   void browse_positive_aroundIncludingWithoutHighlighting() {
     var query = "subject < s0 or subject >= s0";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, false, 2);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, false, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
@@ -305,7 +305,7 @@ class SubjectBrowseServiceTest {
   @Test
   void browse_positive_aroundIncludingMissingAnchor() {
     var query = "subject <= s0 or subject > s0";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, true, 2);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, true, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
@@ -325,7 +325,7 @@ class SubjectBrowseServiceTest {
   @Test
   void browse_positive_aroundIncludingMissingAnchorWithoutHighlighting() {
     var query = "subject <= s0 or subject > s0";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, false, 2);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, false, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
@@ -345,7 +345,7 @@ class SubjectBrowseServiceTest {
   private static SearchSourceBuilder searchSource(String subject, int size, SortOrder sortOrder) {
     return SearchSourceBuilder.searchSource()
       .query(matchAllQuery())
-      .searchAfter(new String[] {subject}).from(0).size(size)
+      .searchAfter(new String[]{subject}).from(0).size(size)
       .sort(fieldSort(TARGET_FIELD).order(sortOrder));
   }
 


### PR DESCRIPTION
## Purpose
Fix searching by shelving order.
Fix browsing prev/next by shelving order.

## Approach
- Remove termProcessor for `itemEffectiveShelvingOrder`
- Return to using shelving order in prev/next
- Add sub-field for browsing.
  - Firstly we will browse around by call-number (`callNumber>="RR 720" or callNumber<"RR 720"`)
  - Then take prev/next shelving order and browse in one direction by shelving order 
    (`itemEffectiveShelvingOrder>"RR 3720"`)