### PR TITLE
MSEARCH-412 Extend contributor's index with authority ID field

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -91,7 +91,7 @@
     },
     {
       "id": "browse",
-      "version": "0.4",
+      "version": "0.5",
       "handlers": [
         {
           "methods": [ "GET" ],

--- a/src/main/java/org/folio/search/integration/KafkaMessageProducer.java
+++ b/src/main/java/org/folio/search/integration/KafkaMessageProducer.java
@@ -78,6 +78,7 @@ public class KafkaMessageProducer {
       .name(contributor.getName())
       .nameTypeId(contributor.getContributorNameTypeId())
       .typeId(contributor.getContributorTypeId())
+      .authorityId(contributor.getAuthorityId())
       .build();
   }
 
@@ -103,7 +104,9 @@ public class KafkaMessageProducer {
   }
 
   private String getContributorId(String tenantId, Contributor contributor) {
-    return sha1Hex(tenantId + "|" + //NOSONAR
-      contributor.getContributorNameTypeId() + "|" + toRootLowerCase(contributor.getName()));
+    return sha1Hex(tenantId
+      + "|" + contributor.getContributorNameTypeId()
+      + "|" + toRootLowerCase(contributor.getName())
+      + "|" + contributor.getAuthorityId());
   }
 }

--- a/src/main/java/org/folio/search/integration/KafkaMessageProducer.java
+++ b/src/main/java/org/folio/search/integration/KafkaMessageProducer.java
@@ -104,7 +104,7 @@ public class KafkaMessageProducer {
   }
 
   private String getContributorId(String tenantId, Contributor contributor) {
-    return sha1Hex(tenantId
+    return sha1Hex(tenantId //NOSONAR
       + "|" + contributor.getContributorNameTypeId()
       + "|" + toRootLowerCase(contributor.getName())
       + "|" + contributor.getAuthorityId());

--- a/src/main/java/org/folio/search/model/event/ContributorEvent.java
+++ b/src/main/java/org/folio/search/model/event/ContributorEvent.java
@@ -12,4 +12,5 @@ public class ContributorEvent {
   String name;
   String nameTypeId;
   String typeId;
+  String authorityId;
 }

--- a/src/main/java/org/folio/search/model/index/ContributorResource.java
+++ b/src/main/java/org/folio/search/model/index/ContributorResource.java
@@ -14,5 +14,7 @@ public class ContributorResource {
 
   private String contributorNameTypeId;
 
+  private String authorityId;
+
   private Set<String> instances;
 }

--- a/src/main/java/org/folio/search/repository/InstanceContributorsRepository.java
+++ b/src/main/java/org/folio/search/repository/InstanceContributorsRepository.java
@@ -50,8 +50,8 @@ public class InstanceContributorsRepository extends AbstractResourceRepository {
       var documents = entry.getValue();
       var instanceIdsToCreate = new HashSet<String>();
       var instanceIdsToDelete = new HashSet<String>();
-      var nameIdsToCreate = new HashSet<String>();
-      var nameIdsToDelete = new HashSet<String>();
+      var typeIdsToCreate = new HashSet<String>();
+      var typeIdsToDelete = new HashSet<String>();
       for (var document : documents) {
         var eventPayload = getPayload(document);
         var action = document.getAction();
@@ -60,10 +60,10 @@ public class InstanceContributorsRepository extends AbstractResourceRepository {
         var pair = instanceId + "|" + typeId;
         if (action == IndexActionType.INDEX) {
           instanceIdsToCreate.add(pair);
-          nameIdsToCreate.add(typeId);
+          typeIdsToCreate.add(typeId);
         } else {
           instanceIdsToDelete.add(pair);
-          nameIdsToDelete.add(typeId);
+          typeIdsToDelete.add(typeId);
         }
       }
 
@@ -75,7 +75,7 @@ public class InstanceContributorsRepository extends AbstractResourceRepository {
         .script(new Script(INLINE, DEFAULT_SCRIPT_LANG, SCRIPT_1,
           Map.of("ins", instanceIdsToCreate, "del", instanceIdsToDelete)))
         .upsert(getContributorJsonBody(getPayload(searchDocument), subtract(instanceIdsToCreate, instanceIdsToDelete),
-          subtractSorted(nameIdsToCreate, nameIdsToDelete)), JSON);
+          subtractSorted(typeIdsToCreate, typeIdsToDelete)), JSON);
 
       bulkRequest.add(upsertRequest);
     }
@@ -87,13 +87,14 @@ public class InstanceContributorsRepository extends AbstractResourceRepository {
            : getSuccessIndexOperationResponse();
   }
 
-  private String getContributorJsonBody(ContributorEvent payload, Set<String> instanceIds, Set<String> nameTypeIds) {
+  private String getContributorJsonBody(ContributorEvent payload, Set<String> instanceIds, Set<String> typeIds) {
     var resource = new ContributorResource();
     resource.setId(payload.getId());
     resource.setName(payload.getName());
-    resource.setContributorTypeId(nameTypeIds);
+    resource.setContributorTypeId(typeIds);
     resource.setContributorNameTypeId(payload.getNameTypeId());
     resource.setInstances(instanceIds);
+    resource.setAuthorityId(payload.getAuthorityId());
     return jsonConverter.toJson(resource);
   }
 

--- a/src/main/java/org/folio/search/service/browse/ContributorBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/ContributorBrowseService.java
@@ -60,6 +60,7 @@ public class ContributorBrowseService extends
         .name(item.getName())
         .contributorTypeId(toListSafe(item.getContributorTypeId()))
         .contributorNameTypeId(item.getContributorNameTypeId())
+        .authorityId(item.getAuthorityId())
         .isAnchor(isAnchor)
         .totalRecords(calculateTotalRecords(item)));
   }

--- a/src/main/resources/elasticsearch/index/contributor.json
+++ b/src/main/resources/elasticsearch/index/contributor.json
@@ -5,8 +5,8 @@
     "refresh_interval": "1s",
     "codec": "best_compression",
     "mapping.total_fields.limit": 1000,
-    "sort.field": [ "name", "contributorNameTypeId" ],
-    "sort.order": [ "asc", "asc" ]
+    "sort.field": [ "name", "contributorNameTypeId", "authorityId" ],
+    "sort.order": [ "asc", "asc", "asc" ]
   },
   "analysis": {
     "normalizer": {

--- a/src/main/resources/model/contributor.json
+++ b/src/main/resources/model/contributor.json
@@ -21,6 +21,10 @@
     },
     "instances": {
       "index": "source"
+    },
+    "authorityId": {
+      "index": "keyword",
+      "showInResponse": [ "browse" ]
     }
   }
 }

--- a/src/main/resources/swagger.api/examples/browseContributorsResult.sample
+++ b/src/main/resources/swagger.api/examples/browseContributorsResult.sample
@@ -1,0 +1,55 @@
+{
+  "totalRecords":5,
+  "next":"Paul McCartney",
+  "items": [
+    {
+      "name": "Anthony Kiedis",
+      "contributorTypeId": [
+        "2a165833-1673-493f-934b-f3d3c8fcb299"
+      ],
+      "contributorNameTypeId": "e2ef4075-310a-4447-a231-712bf10cc985",
+      "authorityId": "7ff32633-cc49-4332-870a-b05e329d2a2d",
+      "isAnchor": false,
+      "totalRecords":1
+    },
+    {
+      "name": "Bon Jovi",
+      "contributorTypeId": [
+        "2a165833-1673-493f-934b-f3d3c8fcb299",
+        "3ae36e29-e38f-457c-8fcf-1974a6cb63d3",
+        "653ffe66-aa3f-4f1c-a090-c42c4011ef40"
+      ],
+      "contributorNameTypeId": "e2ef4075-310a-4447-a231-712bf10cc985",
+      "authorityId": "0a4c6d10-2161-4f64-aace-9e919489b6c9",
+      "isAnchor": false,
+      "totalRecords": 2
+    },
+    {
+      "name": "John Lennon",
+      "isAnchor": true,
+      "totalRecords": 0
+    },
+    {
+      "name": "Klaus Meine",
+      "contributorTypeId": [
+        "2a165833-1673-493f-934b-f3d3c8fcb299",
+        "3ae36e29-e38f-457c-8fcf-1974a6cb63d3"
+      ],
+      "contributorNameTypeId": "e2ef4075-310a-4447-a231-712bf10cc985",
+      "authorityId": "7ff32633-cc49-4332-870a-b05e329d2a2d",
+      "isAnchor": false,
+      "totalRecords": 2
+    },
+    {
+      "name": "Paul McCartney",
+      "contributorTypeId": [
+        "2a165833-1673-493f-934b-f3d3c8fcb299",
+        "3ae36e29-e38f-457c-8fcf-1974a6cb63d3"
+      ],
+      "contributorNameTypeId": "e2ef4075-310a-4447-a231-712bf10cc985",
+      "authorityId": "0a4c6d10-2161-4f64-aace-9e919489b6c9",
+      "isAnchor": false,
+      "totalRecords": 2
+    }
+  ]
+}

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -247,7 +247,7 @@ paths:
           description: 'Search result for browsing by contributor'
           content:
             application/json:
-              example: examples/searchResult.sample
+              example: examples/browseContributorsResult.sample
               schema:
                 $ref: '#/components/schemas/contributorBrowseResult'
         '400':

--- a/src/main/resources/swagger.api/schemas/contributor.json
+++ b/src/main/resources/swagger.api/schemas/contributor.json
@@ -19,6 +19,10 @@
       "type": "string",
       "description": "Contributor type terms defined by the MARC code list for relators"
     },
+    "authorityId": {
+      "type": "string",
+      "description": "ID of authority record that controls the contributor"
+    },
     "primary": {
       "type": "boolean",
       "description": "Whether this is the primary contributor"

--- a/src/main/resources/swagger.api/schemas/response/instanceContributorBrowseItem.json
+++ b/src/main/resources/swagger.api/schemas/response/instanceContributorBrowseItem.json
@@ -19,6 +19,10 @@
       "type": "string",
       "description": "Contributor type terms defined by the MARC code list for relators"
     },
+    "authorityId": {
+      "type": "string",
+      "description": "ID of authority record that controls the contributor"
+    },
     "isAnchor": {
       "type": "boolean",
       "description": "Marks if current value is anchor or not"

--- a/src/test/java/org/folio/search/controller/BrowseContributorIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorIT.java
@@ -58,6 +58,8 @@ class BrowseContributorIT extends BaseIntegrationTest {
   private static final String[] TYPE_IDS =
     array("2a165833-1673-493f-934b-f3d3c8fcb299", "3ae36e29-e38f-457c-8fcf-1974a6cb63d3",
       "653ffe66-aa3f-4f1c-a090-c42c4011ef40");
+  private static final String[] AUTHORITY_IDS =
+    array("0a4c6d10-2161-4f64-aace-9e919489b6c9", "7ff32633-cc49-4332-870a-b05e329d2a2d");
   private static final Instance[] INSTANCES = instances();
 
   @BeforeAll
@@ -75,7 +77,7 @@ class BrowseContributorIT extends BaseIntegrationTest {
         .indices(getIndexName(SearchUtils.CONTRIBUTOR_RESOURCE, TENANT_ID))
         .routing(TENANT_ID);
       var searchResponse = restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
-      assertThat(searchResponse.getHits().getTotalHits().value).isEqualTo(10);
+      assertThat(searchResponse.getHits().getTotalHits().value).isEqualTo(12);
     });
   }
 
@@ -93,123 +95,128 @@ class BrowseContributorIT extends BaseIntegrationTest {
     var backwardIncludingQuery = "name <= {value}";
 
     return Stream.of(arguments(aroundQuery, "John", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Bon Jovi").next("Klaus Meine").items(
-          List.of(contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], TYPE_IDS[0]),
-            contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(0, true, "John"),
-            contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
-            contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null)))),
+        new InstanceContributorBrowseResult().totalRecords(12).prev("Bon Jovi").next("John Lennon").items(List.of(
+          contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], TYPE_IDS[2]),
+          contributorBrowseItem(0, true, "John"),
+          contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(1, "John Lennon", NAME_TYPE_IDS[2], null, TYPE_IDS[0])))),
 
       arguments(aroundQuery, "Lenon", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Klaus Meine").next(null).items(
-          List.of(contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
-            contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
-            contributorBrowseItem(0, true, "Lenon"),
-            contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
+        new InstanceContributorBrowseResult().totalRecords(12).prev("Klaus Meine").next("Paul McCartney").items(List.of(
+          contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], (String[]) null),
+          contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(0, true, "Lenon"),
+          contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(1, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[2])))),
 
       arguments(aroundIncludingQuery, "Meine", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Klaus Meine").next(null).items(
-          List.of(contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
-            contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
-            contributorBrowseItem(0, true, "Meine"),
-            contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
+        new InstanceContributorBrowseResult().totalRecords(12).prev("Klaus Meine").next("Paul McCartney").items(List.of(
+          contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], (String[]) null),
+          contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(0, true, "Meine"),
+          contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(1, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[2])))),
 
       arguments(aroundIncludingQuery, "Klaus Meine", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("George Harrison").next("Paul McCartney").items(
-          List.of(contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
-            contributorBrowseItem(1, true, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
-            contributorBrowseItem(2, true, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
-            contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2])))),
+        new InstanceContributorBrowseResult().totalRecords(12).prev("John Lennon").next("Paul McCartney").items(List.of(
+          contributorBrowseItem(1, "John Lennon", NAME_TYPE_IDS[2], null, TYPE_IDS[0]),
+          contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(1, true, "Klaus Meine", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], (String[]) null),
+          contributorBrowseItem(2, true, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1])))),
 
       arguments(aroundIncludingQuery, "Zak", 25,
-        new InstanceContributorBrowseResult().totalRecords(10).prev(null).next(null).items(
-          List.of(contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], TYPE_IDS[0]),
-            contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], TYPE_IDS[0]),
-            contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
-            contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
-            contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
-            contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
-            contributorBrowseItem(0, true, "Zak")))),
+        new InstanceContributorBrowseResult().totalRecords(12).prev(null).next(null).items(List.of(
+          contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[2]),
+          contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0],
+            TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
+          contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], TYPE_IDS[2]),
+          contributorBrowseItem(1, "John Lennon", NAME_TYPE_IDS[2], null, TYPE_IDS[0]),
+          contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], (String[]) null),
+          contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(1, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[2]),
+          contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(0, true, "Zak")))),
 
       arguments(aroundIncludingQuery, "PMC", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Klaus Meine").next(null).items(
-          List.of(contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
-            contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(0, true, "PMC"),
-            contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
+        new InstanceContributorBrowseResult().totalRecords(12).prev("Paul McCartney").next(null).items(List.of(
+          contributorBrowseItem(1, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[2]),
+          contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(0, true, "PMC"),
+          contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
 
       arguments(aroundIncludingQuery, "a", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev(null).next("Anthony Kiedis").items(
-          List.of(contributorBrowseItem(0, true, "a"),
-            contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], TYPE_IDS[0])))),
+        new InstanceContributorBrowseResult().totalRecords(12).prev(null).next("Anthony Kiedis").items(List.of(
+          contributorBrowseItem(0, true, "a"),
+          contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[2]),
+          contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0])))),
 
       arguments(aroundIncludingQuery, "z", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Paul McCartney").next(null).items(
-          List.of(contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
-            contributorBrowseItem(0, true, "z")))),
+        new InstanceContributorBrowseResult().totalRecords(12).prev("Paul McCartney").next(null).items(List.of(
+          contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(0, true, "z")))),
 
       // browsing forward
       arguments(forwardQuery, "ringo", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Ringo Starr").next(null)
-          .items(List.of(contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
+        new InstanceContributorBrowseResult().totalRecords(12).prev("Ringo Starr").next(null).items(List.of(
+          contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
 
-      arguments(forwardQuery, "anthony", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Anthony Kiedis").next("George Harrison").items(
-          List.of(contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], TYPE_IDS[0]),
-            contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], TYPE_IDS[0]),
-            contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2])))),
+      arguments(forwardQuery, "anthony", 5, new InstanceContributorBrowseResult()
+        .totalRecords(12).prev("Anthony Kiedis").next("George Harrison").items(List.of(
+          contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[2]),
+          contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0],
+            TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
+          contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], TYPE_IDS[2])))),
 
-      arguments(forwardQuery, "Z", 10, new InstanceContributorBrowseResult().totalRecords(10).items(emptyList())),
+      arguments(forwardQuery, "Z", 10, new InstanceContributorBrowseResult().totalRecords(12).items(emptyList())),
 
       arguments(forwardIncludingQuery, "Ringo Starr", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Ringo Starr").next(null)
-          .items(List.of(contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
+        new InstanceContributorBrowseResult().totalRecords(12).prev("Ringo Starr").next(null).items(List.of(
+          contributorBrowseItem(2, "Ringo Starr", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1])))),
 
-      arguments(forwardIncludingQuery, "anthony", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("Anthony Kiedis").next("George Harrison").items(
-          List.of(contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], TYPE_IDS[0]),
-            contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], TYPE_IDS[0]),
-            contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2])))),
+      arguments(forwardIncludingQuery, "anthony", 5, new InstanceContributorBrowseResult()
+        .totalRecords(12).prev("Anthony Kiedis").next("George Harrison").items(List.of(
+          contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[2]),
+          contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(1, "Bon Jovi", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0],
+            TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
+          contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], TYPE_IDS[2])))),
 
       // browsing backward
       arguments(backwardQuery, "Ringo Starr", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("George Harrison").next("Paul McCartney").items(
-          List.of(contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
-            contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
-            contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
-            contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2])))),
+        new InstanceContributorBrowseResult().totalRecords(12).prev("John Lennon").next("Paul McCartney").items(List.of(
+          contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], (String[]) null),
+          contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(1, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[2]),
+          contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1])))),
 
       arguments(backwardQuery, "R", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("George Harrison").next("Paul McCartney").items(
-          List.of(contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
-            contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
-            contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
-            contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2])))),
+        new InstanceContributorBrowseResult().totalRecords(12).prev("John Lennon").next("Paul McCartney").items(List.of(
+          contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], (String[]) null),
+          contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(1, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[2]),
+          contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1])))),
 
-      arguments(backwardQuery, "A", 10, new InstanceContributorBrowseResult().totalRecords(10).items(emptyList())),
+      arguments(backwardQuery, "A", 10, new InstanceContributorBrowseResult().totalRecords(12).items(emptyList())),
 
       arguments(backwardIncludingQuery, "ringo", 5,
-        new InstanceContributorBrowseResult().totalRecords(10).prev("George Harrison").next("Paul McCartney").items(
-          List.of(contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-            contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
-            contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], (String[]) null),
-            contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
-            contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2])))));
+        new InstanceContributorBrowseResult().totalRecords(12).prev("John Lennon").next("Paul McCartney").items(List.of(
+          contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], AUTHORITY_IDS[1], TYPE_IDS[0]),
+          contributorBrowseItem(1, "Klaus Meine", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], (String[]) null),
+          contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
+          contributorBrowseItem(1, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[2]),
+          contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1])))));
   }
 
   private static Instance[] instances() {
@@ -225,54 +232,62 @@ class BrowseContributorIT extends BaseIntegrationTest {
   private static List<List<Object>> contributorBrowseInstanceData() {
     return List.of(
       List.of("instance #00", List.of(
-        contributor("Darth Vader", NAME_TYPE_IDS[0], TYPE_IDS[0])
+        contributor("Darth Vader", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0])
       )),
       List.of("instance #01", List.of(
-        contributor("Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[0]),
-        contributor("Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0]),
-        contributor("Anthony Kiedis", NAME_TYPE_IDS[0], TYPE_IDS[0])
+        contributor("Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0]),
+        contributor("Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0]),
+        contributor("Anthony Kiedis", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0])
       )),
       List.of("instance #02", List.of(
-        contributor("Bon Jovi", NAME_TYPE_IDS[1], TYPE_IDS[0]),
-        contributor("Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[1]),
-        contributor("Anthony Kiedis", NAME_TYPE_IDS[1], TYPE_IDS[2])
+        contributor("Bon Jovi", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0]),
+        contributor("Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[1]),
+        contributor("Anthony Kiedis", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[2])
       )),
       List.of("instance #03", List.of(
-        contributor("Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[1]),
-        contributor("Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[2]),
-        contributor("Klaus Meine", NAME_TYPE_IDS[1], null)
+        contributor("Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[1]),
+        contributor("Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[2]),
+        contributor("Klaus Meine", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], null)
       )),
       List.of("instance #04", List.of(
-        contributor("John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
-        contributor("Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1]),
-        contributor("George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-        contributor("Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[0])
+        contributor("John Lennon", NAME_TYPE_IDS[2], AUTHORITY_IDS[1], TYPE_IDS[0]),
+        contributor("Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0]),
+        contributor("George Harrison", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], TYPE_IDS[2]),
+        contributor("Ringo Starr", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0])
       )),
       List.of("instance #05", List.of(
-        contributor("John Lennon", NAME_TYPE_IDS[2], TYPE_IDS[0]),
-        contributor("Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[2]),
-        contributor("George Harrison", NAME_TYPE_IDS[1], TYPE_IDS[2]),
-        contributor("Ringo Starr", NAME_TYPE_IDS[1], TYPE_IDS[1])
+        contributor("John Lennon", NAME_TYPE_IDS[2], AUTHORITY_IDS[1], TYPE_IDS[0]),
+        contributor("Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[1]),
+        contributor("George Harrison", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], TYPE_IDS[2]),
+        contributor("Ringo Starr", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[1])
+      )),
+      List.of("instance #06", List.of(
+        contributor("Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[2]),
+        contributor("John Lennon", NAME_TYPE_IDS[2], null, TYPE_IDS[0])
       )));
   }
 
-  private static Contributor contributor(String name, String nameTypeId, String typeId) {
-    return new Contributor().name(name).contributorNameTypeId(nameTypeId).contributorTypeId(typeId);
+  private static Contributor contributor(String name, String nameTypeId, String authorityId, String typeId) {
+    return new Contributor()
+      .name(name)
+      .contributorNameTypeId(nameTypeId)
+      .contributorTypeId(typeId)
+      .authorityId(authorityId);
   }
 
   private static Stream<Arguments> facetQueriesProvider() {
     return Stream.of(arguments("name=*", array("contributorNameTypeId"), mapOf("contributorNameTypeId",
-        facet(facetItem(NAME_TYPE_IDS[0], 4), facetItem(NAME_TYPE_IDS[1], 5), facetItem(NAME_TYPE_IDS[2], 1)))),
+        facet(facetItem(NAME_TYPE_IDS[0], 5), facetItem(NAME_TYPE_IDS[1], 5), facetItem(NAME_TYPE_IDS[2], 2)))),
 
       arguments("name=*", array("contributorNameTypeId:2"),
-        mapOf("contributorNameTypeId", facet(facetItem(NAME_TYPE_IDS[0], 4), facetItem(NAME_TYPE_IDS[1], 5)))),
+        mapOf("contributorNameTypeId", facet(facetItem(NAME_TYPE_IDS[0], 5), facetItem(NAME_TYPE_IDS[1], 5)))),
 
       arguments("contributorNameTypeId==\"" + NAME_TYPE_IDS[0] + "\"", array("contributorNameTypeId:1"),
-        mapOf("contributorNameTypeId", facet(facetItem(NAME_TYPE_IDS[0], 4)))),
+        mapOf("contributorNameTypeId", facet(facetItem(NAME_TYPE_IDS[0], 5)))),
 
       arguments("contributorNameTypeId==(\"" + NAME_TYPE_IDS[1] + "\" or \"" + NAME_TYPE_IDS[2] + "\")",
         array("contributorNameTypeId:2"),
-        mapOf("contributorNameTypeId", facet(facetItem(NAME_TYPE_IDS[1], 5), facetItem(NAME_TYPE_IDS[2], 1)))));
+        mapOf("contributorNameTypeId", facet(facetItem(NAME_TYPE_IDS[1], 5), facetItem(NAME_TYPE_IDS[2], 2)))));
   }
 
   @MethodSource("contributorBrowsingDataProvider")
@@ -296,13 +311,13 @@ class BrowseContributorIT extends BaseIntegrationTest {
         + "and contributorNameTypeId==" + NAME_TYPE_IDS[0]).param("limit", "5");
 
     var actual = parseResponse(doGet(request), InstanceContributorBrowseResult.class);
-    var expected = new InstanceContributorBrowseResult().totalRecords(4).prev(null).next(null).items(
+    var expected = new InstanceContributorBrowseResult().totalRecords(5).prev(null).next("Paul McCartney").items(
       List.of(
-        contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], TYPE_IDS[0]),
-        contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
+        contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0]),
+        contributorBrowseItem(2, "Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
         contributorBrowseItem(0, true, "John Lennon"),
-        contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], TYPE_IDS[0], TYPE_IDS[1]),
-        contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2])));
+        contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
+        contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1])));
 
     assertThat(actual).isEqualTo(expected);
   }

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -198,8 +198,9 @@ public class TestUtils {
   }
 
   public static InstanceContributorBrowseItem contributorBrowseItem(Integer totalRecords, String name,
-                                                                    String nameTypeId, String... typeIds) {
-    return contributorBrowseItem(totalRecords, false, name, nameTypeId, typeIds);
+                                                                    String nameTypeId, String authorityId,
+                                                                    String... typeIds) {
+    return contributorBrowseItem(totalRecords, false, name, nameTypeId, authorityId, typeIds);
   }
 
   public static InstanceContributorBrowseItem contributorBrowseItem(Integer totalRecords, boolean isAnchor,
@@ -207,11 +208,13 @@ public class TestUtils {
     return new InstanceContributorBrowseItem().name(name).totalRecords(totalRecords).isAnchor(isAnchor);
   }
 
-  public static InstanceContributorBrowseItem contributorBrowseItem(Integer totalRecords, boolean isAnchor, String name,
-                                                                    String nameTypeId, String... typeIds) {
+  public static InstanceContributorBrowseItem contributorBrowseItem(Integer totalRecords, boolean isAnchor,
+                                                                    String name, String nameTypeId,
+                                                                    String authorityId, String... typeIds) {
     return new InstanceContributorBrowseItem()
       .name(name)
       .contributorNameTypeId(nameTypeId)
+      .authorityId(authorityId)
       .contributorTypeId(typeIds != null ? Arrays.asList(typeIds) : null)
       .totalRecords(totalRecords)
       .isAnchor(isAnchor);


### PR DESCRIPTION
## Purpose
It's needed to have info if a contributor is controlled by authority on browse contributors screen

## Approach
- Update API schema
- Update contributor index mappings
- Update contributor indexing logic
- Update contributor browse logic
- Update browse interface version

### Changes checklist
- [x] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [x] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed

### Learning
[MSEARCH-412](https://issues.folio.org/browse/MSEARCH-412)
