### PR TITLE
MSEARCH-421 Add sourceFileId and naturalId to authority search/browse response

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * MSEARCH-410 Indexed the identifiers.identifierTypeId fields
 * MSEARCH-416 Enable BROWSE_CN_INTERMEDIATE_VALUES and BROWSE_CN_INTERMEDIATE_REMOVE_DUPLICATES environment variables
 * MSEARCH-418 Supports also instance-storage interface version 9.0
+* MSEARCH-421 Add sourceFileId and naturalId to authority search/browse response
 
 ## 1.7.5 2022-09-02
 * MSEARCH-414 Browse by call-numbers and shelvingOrder, add subfield for browsing

--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ request parameters:
 > * _headingType_
 > * _authRefType_
 > * _headingRef_
+> * _sourceFileId_
+> * _naturalId_
 
 ##### Matching all records
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -39,7 +39,7 @@
     },
     {
       "id": "search",
-      "version": "0.8",
+      "version": "0.9",
       "handlers": [
         {
           "methods": [ "GET" ],
@@ -91,7 +91,7 @@
     },
     {
       "id": "browse",
-      "version": "0.5",
+      "version": "0.6",
       "handlers": [
         {
           "methods": [ "GET" ],

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -310,6 +310,14 @@
           "index": "source"
         }
       }
+    },
+    "sourceFileId": {
+      "index": "keyword",
+      "showInResponse": [ "search", "browse" ]
+    },
+    "naturalId": {
+      "index": "keyword",
+      "showInResponse": [ "search", "browse" ]
     }
   },
   "searchFields": {

--- a/src/main/resources/swagger.api/schemas/authority.json
+++ b/src/main/resources/swagger.api/schemas/authority.json
@@ -244,6 +244,14 @@
     "headingRef": {
       "type": "string",
       "description": "Generated field by mod-search, used to easily identity the heading/reference of the record that provides authority information"
+    },
+    "sourceFileId": {
+      "type": "string",
+      "description": "Authority source file id; UUID"
+    },
+    "naturalId": {
+      "type": "string",
+      "description": "Authority Natural ID"
     }
   }
 }

--- a/src/test/java/org/folio/search/controller/BrowseAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseAuthorityIT.java
@@ -343,11 +343,13 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
   }
 
   private static Authority authority(int index) {
-    return new Authority().id("id-" + index).subjectHeadings(String.format("Authority #%02d", index));
+    return new Authority().id("id-" + index).subjectHeadings(String.format("Authority #%02d", index))
+      .sourceFileId("5de462a2-7a90-4467-b77f-b2057d6d69b6").naturalId("nbc123435");
   }
 
   private static Authority authority(int index, String headingRef, String headingType, String authRefType) {
-    return new Authority().id("id-" + index).headingRef(headingRef).authRefType(authRefType).headingType(headingType);
+    return new Authority().id("id-" + index).headingRef(headingRef).authRefType(authRefType).headingType(headingType)
+      .sourceFileId("5de462a2-7a90-4467-b77f-b2057d6d69b6").naturalId("nbc123435");
   }
 
   private static AuthorityBrowseItem authorityBrowseItem(String heading, int index, String type, String headingType) {

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -1,8 +1,10 @@
 package org.folio.search.controller;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.folio.search.sample.SampleAuthorities.getAuthorityNaturalId;
 import static org.folio.search.sample.SampleAuthorities.getAuthoritySampleAsMap;
 import static org.folio.search.sample.SampleAuthorities.getAuthoritySampleId;
+import static org.folio.search.sample.SampleAuthorities.getAuthoritySourceFileId;
 import static org.folio.search.utils.TestUtils.parseResponse;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -236,6 +238,8 @@ class SearchAuthorityIT extends BaseIntegrationTest {
   private static Authority authority(String headingType, String authRefType, String headingRef) {
     return new Authority()
       .id(getAuthoritySampleId())
+      .sourceFileId(getAuthoritySourceFileId())
+      .naturalId(getAuthorityNaturalId())
       .headingType(headingType)
       .authRefType(authRefType)
       .headingRef(headingRef);

--- a/src/test/java/org/folio/search/sample/SampleAuthorities.java
+++ b/src/test/java/org/folio/search/sample/SampleAuthorities.java
@@ -19,6 +19,8 @@ public class SampleAuthorities {
     OBJECT_MAPPER.convertValue(AUTHORITY_RECORD_AS_MAP, Authority.class);
 
   private static final String AUTHORITY_RECORD_ID = AUTHORITY_RECORD.getId();
+  private static final String AUTHORITY_SOURCE_FILE_ID = AUTHORITY_RECORD.getSourceFileId();
+  private static final String AUTHORITY_NATURAL_ID = AUTHORITY_RECORD.getNaturalId();
 
   public static Authority getAuthoritySample() {
     return AUTHORITY_RECORD;
@@ -30,5 +32,13 @@ public class SampleAuthorities {
 
   public static String getAuthoritySampleId() {
     return AUTHORITY_RECORD_ID;
+  }
+
+  public static String getAuthoritySourceFileId() {
+    return AUTHORITY_SOURCE_FILE_ID;
+  }
+
+  public static String getAuthorityNaturalId() {
+    return AUTHORITY_NATURAL_ID;
   }
 }

--- a/src/test/resources/samples/authority-sample/authority.json
+++ b/src/test/resources/samples/authority-sample/authority.json
@@ -58,5 +58,7 @@
       "noteTypeId": "36a62267-d921-4904-bfd1-d2a4958fb67c",
       "value": "an authority note"
     }
-  ]
+  ],
+  "sourceFileId": "5de462a2-7a90-4467-b77f-b2057d6d69b6",
+  "naturalId": "nbc123435"
 }


### PR DESCRIPTION
## Purpose
Source File and Natural ID info are required for UI to generate $0 URI when it links an authority to a bib field.

JIRA: https://issues.folio.org/browse/MSEARCH-421

## Approach
- update index mappings
- update response schemas
- update tests

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
