### PR TITLE
Bump Elasticsearch from 7.17.5 to 7.17.6

### DIFF
--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:7.17.5
+FROM elasticsearch:7.17.6
 
 # Switch from /dev/random to /dev/urandom, otherwise the plugin installer needs many minutes to get
 # random numbers to verify the signature of the downloaded plugins.


### PR DESCRIPTION
In #cc-elasticsearch-opensearch-discussion Slack channel people asked about the latest patch version.
7.17.6 has been released on 24 August 2022:
https://www.elastic.co/blog/elastic-stack-7-17-6-released