### PR TITLE
MSEARCH-430 Inventory Elastic Search (Morning Glory). Keyword search throw unexpected results when the search only contains numbers and dashes.

### DIFF
--- a/src/main/java/org/folio/search/cql/builders/AllTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/AllTermQueryBuilder.java
@@ -20,17 +20,17 @@ public class AllTermQueryBuilder extends FulltextQueryBuilder {
       var stringTerm = (String) term;
       var terms = stringTerm.split("\\s+");
       if (terms.length == 1) {
-        return multiMatchQuery(terms[0], fields);
+        return getMultiMatchQuery(terms[0], fields);
       }
 
       var boolQuery = boolQuery();
       for (var singleTerm : terms) {
-        boolQuery.must(multiMatchQuery(singleTerm, fields));
+        boolQuery.must(getMultiMatchQuery(singleTerm, fields));
       }
       return boolQuery;
     }
 
-    return multiMatchQuery(term, fields).operator(AND).type(CROSS_FIELDS);
+    return getMultiMatchQuery(term, fields);
   }
 
   @Override
@@ -46,5 +46,9 @@ public class AllTermQueryBuilder extends FulltextQueryBuilder {
   @Override
   public Set<String> getSupportedComparators() {
     return Set.of("all", "adj");
+  }
+
+  private QueryBuilder getMultiMatchQuery(Object term, String... fieldNames) {
+    return multiMatchQuery(term, fieldNames).operator(AND).type(CROSS_FIELDS);
   }
 }

--- a/src/test/java/org/folio/search/controller/SearchByAllFieldsIT.java
+++ b/src/test/java/org/folio/search/controller/SearchByAllFieldsIT.java
@@ -35,7 +35,7 @@ class SearchByAllFieldsIT extends BaseIntegrationTest {
     "Cooperative information systems",
     "0262012103",
     "2003065165",
-    "Antoniou, Grigoris",
+    "Antoniou, Grigoris matthew",
     "TK5105.88815 .A58 2004",
     "Cambridge, Mass.",
 
@@ -70,7 +70,7 @@ class SearchByAllFieldsIT extends BaseIntegrationTest {
     "Cooperative information systems",
     "0262012103",
     "2003065165",
-    "Antoniou, Grigoris",
+    "Antoniou, Grigoris matthew",
     "TK5105.88815 .A58 2004",
     "Cambridge, Mass.",
     "2020-12-08T15:47:13.625+00:00",

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -73,7 +73,8 @@ class SearchInstanceIT extends BaseIntegrationTest {
     "itemPublicNotes == {value}, private circulation note",
     "holdingsPublicNotes == {value}, librarian private note",
     "issn = {value}, 03178471",
-    "oclc = {value}, 0262012103"
+    "oclc = {value}, 0262012103",
+    "(keyword all {value}), 0747-0088"
   })
   @DisplayName("can search by instances (nothing found)")
   void searchByInstances_parameterized_zeroResults(String query, String value) throws Throwable {
@@ -372,7 +373,10 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("holdingsIdentifiers all {value}", "hold000000000009"),
       arguments("holdingsIdentifiers == {value}", "1d76ee84-d776-48d2-ab96-140c24e39ac5"),
       arguments("holdingsIdentifiers all {value}", "9b8ec096-fa2e-451b-8e7a-6d1c977ee946"),
-      arguments("holdingsIdentifiers all {value}", "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19")
+      arguments("holdingsIdentifiers all {value}", "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19"),
+
+      //search by multiple different parameters
+      arguments("(keyword all {value})", "wolves matthew 9781609383657")
     );
   }
 }

--- a/src/test/java/org/folio/search/cql/CqlSearchQueryConverterTest.java
+++ b/src/test/java/org/folio/search/cql/CqlSearchQueryConverterTest.java
@@ -98,7 +98,7 @@ class CqlSearchQueryConverterTest {
   void convert_positive_searchByGroupOfOneField() {
     when(searchFieldProvider.getFields(RESOURCE_NAME, "group")).thenReturn(List.of("field"));
     var actual = cqlSearchQueryConverter.convert("group all value", RESOURCE_NAME);
-    assertThat(actual).isEqualTo(searchSource().query(multiMatchQuery("value", "field")));
+    assertThat(actual).isEqualTo(searchSource().query(getMultiMatchQuery("value", "field")));
   }
 
   @Test
@@ -140,7 +140,7 @@ class CqlSearchQueryConverterTest {
 
     var actual = cqlSearchQueryConverter.convert(FIELD + " all value", RESOURCE_NAME);
 
-    assertThat(actual).isEqualTo(searchSource().query(multiMatchQuery("value", "field.*")));
+    assertThat(actual).isEqualTo(searchSource().query(getMultiMatchQuery("value", "field.*")));
   }
 
   @Test
@@ -399,31 +399,31 @@ class CqlSearchQueryConverterTest {
   private static Stream<Arguments> convertCqlQuerySearchGroupDataProvider() {
     return Stream.of(
       arguments("(title all \"test-query\") sortby title",
-        searchSource().query(multiMatchQuery("test-query", TITLE_FIELDS))),
+        searchSource().query(getMultiMatchQuery("test-query", TITLE_FIELDS))),
 
       arguments("title any \"test-query\"",
         searchSource().query(multiMatchQuery("test-query", TITLE_FIELDS))),
 
       arguments("title adj \"test-query\"",
-        searchSource().query(multiMatchQuery("test-query", TITLE_FIELDS))),
+        searchSource().query(getMultiMatchQuery("test-query", TITLE_FIELDS))),
 
       arguments("title == \"test-query\"",
         searchSource().query(multiMatchQuery("test-query", TITLE_FIELDS).type(PHRASE))),
 
       arguments("((title all \"test-query\") and languages=(\"eng\" or \"ger\")) sortby title",
         searchSource().query(boolQuery()
-          .must(multiMatchQuery("test-query", TITLE_FIELDS))
+          .must(getMultiMatchQuery("test-query", TITLE_FIELDS))
           .must(boolQuery()
             .should(matchQuery("languages", "eng").operator(AND))
             .should(matchQuery("languages", "ger").operator(AND))))),
 
       arguments("title all \"test-query\" not contributors = \"test-contributor\"",
         searchSource().query(boolQuery()
-          .must(multiMatchQuery("test-query", TITLE_FIELDS))
+          .must(getMultiMatchQuery("test-query", TITLE_FIELDS))
           .mustNot(matchQuery("contributors", "test-contributor").operator(AND)))),
 
       arguments("title all \"test-query\"",
-        searchSource().query(multiMatchQuery("test-query", TITLE_FIELDS))),
+        searchSource().query(getMultiMatchQuery("test-query", TITLE_FIELDS))),
 
       arguments("title = \"*test-query\"",
         searchSource().query(boolQuery()
@@ -433,7 +433,7 @@ class CqlSearchQueryConverterTest {
 
       arguments("title = \"test-query\"",
         searchSource().query(
-          multiMatchQuery("test-query", "title.*", "source.*", "source").operator(AND).type(CROSS_FIELDS)))
+          getMultiMatchQuery("test-query", "title.*", "source.*", "source")))
     );
   }
 
@@ -449,6 +449,10 @@ class CqlSearchQueryConverterTest {
     var fieldDescription = keywordField();
     fieldDescription.setSearchTermProcessor(processorName);
     return fieldDescription;
+  }
+
+  private static QueryBuilder getMultiMatchQuery(Object term, String... fieldNames) {
+    return multiMatchQuery(term, fieldNames).operator(AND).type(CROSS_FIELDS);
   }
 
   @TestConfiguration

--- a/src/test/resources/samples/semantic-web-primer/instance.json
+++ b/src/test/resources/samples/semantic-web-primer/instance.json
@@ -2,7 +2,7 @@
   "id": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",
   "hrid": "inst000000000022",
   "source": "FOLIO",
-  "title": "A semantic web primer",
+  "title": "A semantic web primer 0747-0850 wolves",
   "indexTitle": "Semantic web primer",
   "alternativeTitles": [
     {
@@ -29,6 +29,10 @@
   "identifiers": [
     {
       "value": "0262012103",
+      "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422"
+    },
+    {
+      "value": "9781609383657",
       "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422"
     },
     {
@@ -62,7 +66,7 @@
   ],
   "contributors": [
     {
-      "name": "Antoniou, Grigoris",
+      "name": "Antoniou, Grigoris matthew",
       "contributorTypeId": "6e09d47d-95e2-4d8a-831b-f777b8ef6d81",
       "contributorTypeText": null,
       "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"


### PR DESCRIPTION
## Purpose
Return results for "keyword all" query only if all keywords match

## Approach
- add "AND" operator and "CROSS_FIELDS" type for "AllTermQueryBuilder" "getQuery"

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed

### Learning
[MSEARCH-430](https://issues.folio.org/browse/MSEARCH-430)
