### PR TITLE
MSEARCH-439 Transferring items from one instance to another results in multiple matches when searching

### DIFF
--- a/src/main/java/org/folio/search/service/ResourceService.java
+++ b/src/main/java/org/folio/search/service/ResourceService.java
@@ -150,9 +150,9 @@ public class ResourceService {
   }
 
   /**
-   * There may be a case when some data is moved between instances
-   * In such case old and new fields of the event will have different instanceId
-   * This method will create 2 events out of 1 and erase 'old' field in an original event
+   * There may be a case when some data is moved between instances.
+   * In such case old and new fields of the event will have different instanceId.
+   * This method will create 2 events out of 1 and erase 'old' field in an original event.
    * */
   private List<ResourceEvent> extractEventsForDataMove(List<ResourceEvent> resourceEvents) {
     if (resourceEvents == null) {
@@ -175,7 +175,7 @@ public class ResourceService {
           return Stream.of(oldEvent, newEvent);
         }
 
-        return Stream.of(resourceEvent);})
+        return Stream.of(resourceEvent); })
       .collect(toList());
   }
 

--- a/src/test/java/org/folio/search/service/ResourceServiceTest.java
+++ b/src/test/java/org/folio/search/service/ResourceServiceTest.java
@@ -176,14 +176,14 @@ class ResourceServiceTest {
     var oldData = mapOf("instanceId", RESOURCE_ID_SECOND, "title", "old title");
     var newData = mapOf("instanceId", RESOURCE_ID, "title", "new title");
     var resourceEvent = resourceEvent(RESOURCE_ID, RESOURCE_NAME, UPDATE, newData, oldData);
-    var oldResourceEvent = resourceEvent(RESOURCE_ID_SECOND, RESOURCE_NAME, UPDATE, oldData, null);
-    var newResourceEvent = resourceEvent(RESOURCE_ID, RESOURCE_NAME, UPDATE, newData, null);
+    var oldEvent = resourceEvent(RESOURCE_ID_SECOND, RESOURCE_NAME, UPDATE, oldData, null);
+    var newEvent = resourceEvent(RESOURCE_ID, RESOURCE_NAME, UPDATE, newData, null);
     var fetchedEvents = List.of(resourceEvent(RESOURCE_ID_SECOND, RESOURCE_NAME, CREATE, oldData, null),
       resourceEvent(RESOURCE_ID, RESOURCE_NAME, CREATE, newData, null));
     var expectedResponse = getSuccessIndexOperationResponse();
     var searchBodies = List.of(searchDocumentBody(asJsonString(oldData)), searchDocumentBody(asJsonString(newData)));
 
-    when(resourceFetchService.fetchInstancesByIds(List.of(oldResourceEvent, newResourceEvent))).thenReturn(fetchedEvents);
+    when(resourceFetchService.fetchInstancesByIds(List.of(oldEvent, newEvent))).thenReturn(fetchedEvents);
     when(searchDocumentConverter.convert(fetchedEvents)).thenReturn(mapOf(RESOURCE_NAME, searchBodies));
     when(indexRepository.indexExists(INDEX_NAME)).thenReturn(true);
     when(primaryResourceRepository.indexResources(searchBodies)).thenReturn(expectedResponse);

--- a/src/test/java/org/folio/search/service/ResourceServiceTest.java
+++ b/src/test/java/org/folio/search/service/ResourceServiceTest.java
@@ -11,6 +11,7 @@ import static org.folio.search.utils.SearchResponseHelper.getErrorIndexOperation
 import static org.folio.search.utils.SearchResponseHelper.getSuccessIndexOperationResponse;
 import static org.folio.search.utils.TestConstants.INDEX_NAME;
 import static org.folio.search.utils.TestConstants.RESOURCE_ID;
+import static org.folio.search.utils.TestConstants.RESOURCE_ID_SECOND;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestUtils.asJsonString;
 import static org.folio.search.utils.TestUtils.mapOf;
@@ -171,11 +172,34 @@ class ResourceServiceTest {
   }
 
   @Test
+  void indexResourcesById_positive_moveDataBetweenInstances() {
+    var oldData = mapOf("instanceId", RESOURCE_ID_SECOND, "title", "old title");
+    var newData = mapOf("instanceId", RESOURCE_ID, "title", "new title");
+    var resourceEvent = resourceEvent(RESOURCE_ID, RESOURCE_NAME, UPDATE, newData, oldData);
+    var oldResourceEvent = resourceEvent(RESOURCE_ID_SECOND, RESOURCE_NAME, UPDATE, oldData, null);
+    var newResourceEvent = resourceEvent(RESOURCE_ID, RESOURCE_NAME, UPDATE, newData, null);
+    var fetchedEvents = List.of(resourceEvent(RESOURCE_ID_SECOND, RESOURCE_NAME, CREATE, oldData, null),
+      resourceEvent(RESOURCE_ID, RESOURCE_NAME, CREATE, newData, null));
+    var expectedResponse = getSuccessIndexOperationResponse();
+    var searchBodies = List.of(searchDocumentBody(asJsonString(oldData)), searchDocumentBody(asJsonString(newData)));
+
+    when(resourceFetchService.fetchInstancesByIds(List.of(oldResourceEvent, newResourceEvent))).thenReturn(fetchedEvents);
+    when(searchDocumentConverter.convert(fetchedEvents)).thenReturn(mapOf(RESOURCE_NAME, searchBodies));
+    when(indexRepository.indexExists(INDEX_NAME)).thenReturn(true);
+    when(primaryResourceRepository.indexResources(searchBodies)).thenReturn(expectedResponse);
+    when(resourceDescriptionService.find(RESOURCE_NAME)).thenReturn(of(resourceDescription(RESOURCE_NAME)));
+    doNothing().when(kafkaMessageProducer).prepareAndSendContributorEvents(anyList());
+
+    var response = indexService.indexResourcesById(List.of(resourceEvent));
+    assertThat(response).isEqualTo(expectedResponse);
+  }
+
+  @Test
   void indexResourcesById_positive_deleteEvent() {
     var expectedDocuments = List.of(searchDocumentBodyToDelete());
     var resourceEvents = List.of(resourceEvent(RESOURCE_ID, RESOURCE_NAME, DELETE));
 
-    when(resourceFetchService.fetchInstancesByIds(null)).thenReturn(emptyList());
+    when(resourceFetchService.fetchInstancesByIds(emptyList())).thenReturn(emptyList());
     when(searchDocumentConverter.convert(emptyList())).thenReturn(emptyMap());
     when(searchDocumentConverter.convert(resourceEvents)).thenReturn(mapOf(RESOURCE_NAME, expectedDocuments));
     when(indexRepository.indexExists(INDEX_NAME)).thenReturn(true);
@@ -223,7 +247,7 @@ class ResourceServiceTest {
     var eventIds = List.of(resourceEvent(randomId(), RESOURCE_NAME, CREATE));
 
     when(indexRepository.indexExists(INDEX_NAME)).thenReturn(false);
-    when(resourceFetchService.fetchInstancesByIds(null)).thenReturn(emptyList());
+    when(resourceFetchService.fetchInstancesByIds(emptyList())).thenReturn(emptyList());
     when(searchDocumentConverter.convert(null)).thenReturn(emptyMap());
     when(searchDocumentConverter.convert(emptyList())).thenReturn(emptyMap());
     when(primaryResourceRepository.indexResources(null)).thenReturn(getSuccessIndexOperationResponse());

--- a/src/test/java/org/folio/search/utils/TestConstants.java
+++ b/src/test/java/org/folio/search/utils/TestConstants.java
@@ -14,6 +14,7 @@ public class TestConstants {
   public static final String ENV = "folio";
   public static final String TENANT_ID = "test_tenant";
   public static final String RESOURCE_ID = "d148dd82-56b0-4ddb-a638-83ca1ee97e0a";
+  public static final String RESOURCE_ID_SECOND = "d148dd82-56b0-4ddb-a638-83ca1ee97e0b";
   public static final String EMPTY_OBJECT = "{}";
   public static final String RESOURCE_NAME = getResourceName(TestResource.class);
   public static final String INDEX_NAME = String.join("_", ENV, RESOURCE_NAME, TENANT_ID);


### PR DESCRIPTION
## Purpose
Remove item from old instance when moved

## Approach
- Divide event into two separate when "old" instanceId differs form "new" instanceId

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed

### Learning
[MSEARCH-439](https://issues.folio.org/browse/MSEARCH-439)
