### PR TITLE
MSEARCH-456 Call-number with same instance as anchor disappears

### DIFF
--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseResultConverter.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseResultConverter.java
@@ -75,10 +75,8 @@ public class CallNumberBrowseResultConverter {
 
   private static List<CallNumberBrowseItem> populateItemsWithIntermediateResults(
     List<CallNumberBrowseItem> browseItems, BrowseContext ctx, boolean removeDuplicates, boolean isBrowsingForward) {
-    var lower = browseItems.get(0).getShelfKey();
-    var upper = browseItems.get(browseItems.size() - 1).getShelfKey();
     return browseItems.stream()
-      .map(item -> getCallNumberBrowseItemsBetween(item, lower, upper, removeDuplicates))
+      .map(item -> getCallNumberBrowseItemsBetween(item, removeDuplicates))
       .flatMap(Collection::stream)
       .filter(browseItem -> isValidBrowseItem(browseItem, ctx, isBrowsingForward))
       .sorted(comparing(CallNumberBrowseItem::getShelfKey))
@@ -102,9 +100,7 @@ public class CallNumberBrowseResultConverter {
     return isBrowsingForward ? comparisonResult > 0 : comparisonResult < 0;
   }
 
-  private static List<CallNumberBrowseItem> getCallNumberBrowseItemsBetween(CallNumberBrowseItem browseItem,
-                                                                            String lower, String upper,
-                                                                            boolean removeDuplicates) {
+  private static List<CallNumberBrowseItem> getCallNumberBrowseItemsBetween(CallNumberBrowseItem browseItem, boolean removeDuplicates) {
     var itemsByShelfKeys = toStreamSafe(browseItem.getInstance().getItems())
       .filter(item -> StringUtils.isNotBlank(item.getEffectiveShelvingOrder()))
       .collect(groupingBy(item -> toRootUpperCase(item.getEffectiveShelvingOrder()), LinkedHashMap::new, toList()));
@@ -113,7 +109,6 @@ public class CallNumberBrowseResultConverter {
       .map(Item::getEffectiveShelvingOrder).distinct()
       .filter(StringUtils::isNotBlank)
       .map(StringUtils::toRootUpperCase)
-      .filter(shelfKey -> shelfKey.compareTo(lower) >= 0 && shelfKey.compareTo(upper) <= 0)
       .map(shelfKey -> mapToCallNumberBrowseItem(browseItem, shelfKey, findFirst(itemsByShelfKeys.get(shelfKey))));
 
     if (removeDuplicates) {

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseResultConverter.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseResultConverter.java
@@ -100,7 +100,8 @@ public class CallNumberBrowseResultConverter {
     return isBrowsingForward ? comparisonResult > 0 : comparisonResult < 0;
   }
 
-  private static List<CallNumberBrowseItem> getCallNumberBrowseItemsBetween(CallNumberBrowseItem browseItem, boolean removeDuplicates) {
+  private static List<CallNumberBrowseItem> getCallNumberBrowseItemsBetween(CallNumberBrowseItem browseItem,
+                                                                            boolean removeDuplicates) {
     var itemsByShelfKeys = toStreamSafe(browseItem.getInstance().getItems())
       .filter(item -> StringUtils.isNotBlank(item.getEffectiveShelvingOrder()))
       .collect(groupingBy(item -> toRootUpperCase(item.getEffectiveShelvingOrder()), LinkedHashMap::new, toList()));

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseResultConverterTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseResultConverterTest.java
@@ -161,7 +161,8 @@ class CallNumberBrowseResultConverterTest {
         forwardContext(), true, List.of(
           cnBrowseItem(instance("B1", "B2", "C2"), "B1"),
           cnBrowseItem(instance("B1", "B2", "C2"), "B2"),
-          cnBrowseItem(instance("C1", "C2"), "C1"))),
+          cnBrowseItem(instance("C1", "C2"), "C1"),
+          cnBrowseItem(2, "C2"))),
 
       arguments("forward: n resources, results collapsed",
         searchHits("A1", "A1", "A2", "A2", "A2", "A3", "A4", "A4", "A5", "A6", "A6"),
@@ -190,6 +191,7 @@ class CallNumberBrowseResultConverterTest {
       arguments("backward: 2 resources (intermediate call numbers are populated)",
         List.of(searchHit("C4", instance("C1", "C2", "C4")), searchHit("B2", instance("B1", "B2"))),
         backwardContext(), false, List.of(
+          cnBrowseItem(instance("B1", "B2"), "B1"),
           cnBrowseItem(instance("B1", "B2"), "B2"),
           cnBrowseItem(instance("C1", "C2", "C4"), "C1"),
           cnBrowseItem(instance("C1", "C2", "C4"), "C2"),


### PR DESCRIPTION
## Purpose
Call-number with same instance as anchor disappears

## Approach
Remove filtering intermediate items by `lower` and `upper` shelfKey. Because `lower` and `upper` depend on what anchor you are searching for;

**Example:**
Instance with Items ['A1', 'A2', 'A3']
If you are searching for 'A3' then the lower value will be 'A3'. And 'A1', 'A2' will be cut off.

This changes will not affect final size list, because we are sorting and trimming the results
 
### Learning
https://issues.folio.org/browse/MSEARCH-456