### PR TITLE
MSEARCH-479 Stabilize contributors browse integration tests

### DIFF
--- a/src/test/java/org/folio/search/controller/BrowseContributorIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorIT.java
@@ -23,10 +23,10 @@ import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
 import static org.opensearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;

--- a/src/test/java/org/folio/search/controller/BrowseContributorIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorIT.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.apache.commons.lang3.StringUtils;
 import org.folio.search.domain.dto.Contributor;
 import org.folio.search.domain.dto.Facet;
@@ -306,14 +305,32 @@ class BrowseContributorIT extends BaseIntegrationTest {
       .thenComparing((o1, o2) -> StringUtils.compare(o1.getContributorNameTypeId(), o2.getContributorNameTypeId()))
     );
 
-    List<String> actualNames = actual.getItems().stream().map(InstanceContributorBrowseItem::getName).collect(Collectors.toList());
-    List<String> expectedNames = expected.getItems().stream().map(InstanceContributorBrowseItem::getName).collect(Collectors.toList());
+    List<String> actualNames = actual.getItems()
+      .stream()
+      .map(InstanceContributorBrowseItem::getName)
+      .collect(Collectors.toList());
+    List<String> expectedNames = expected.getItems()
+      .stream()
+      .map(InstanceContributorBrowseItem::getName)
+      .collect(Collectors.toList());
 
-    List<String> actualNameTypeIds = actual.getItems().stream().map(InstanceContributorBrowseItem::getContributorNameTypeId).collect(Collectors.toList());
-    List<String> expectedNameTypeIds = expected.getItems().stream().map(InstanceContributorBrowseItem::getContributorNameTypeId).collect(Collectors.toList());
+    List<String> actualNameTypeIds = actual.getItems()
+      .stream()
+      .map(InstanceContributorBrowseItem::getContributorNameTypeId)
+      .collect(Collectors.toList());
+    List<String> expectedNameTypeIds = expected.getItems()
+      .stream()
+      .map(InstanceContributorBrowseItem::getContributorNameTypeId)
+      .collect(Collectors.toList());
 
-    List<Boolean> actualIsAnchors = actual.getItems().stream().map(InstanceContributorBrowseItem::getIsAnchor).collect(Collectors.toList());
-    List<Boolean> expectedIsAnchors = expected.getItems().stream().map(InstanceContributorBrowseItem::getIsAnchor).collect(Collectors.toList());
+    List<Boolean> actualIsAnchors = actual.getItems()
+      .stream()
+      .map(InstanceContributorBrowseItem::getIsAnchor)
+      .collect(Collectors.toList());
+    List<Boolean> expectedIsAnchors = expected.getItems()
+      .stream()
+      .map(InstanceContributorBrowseItem::getIsAnchor)
+      .collect(Collectors.toList());
 
     assertEquals(expectedNames, actualNames);
     assertEquals(expectedNameTypeIds, actualNameTypeIds);


### PR DESCRIPTION
## Purpose
Avoid random failure of Contributor browse integration test cases 

## Approach
Previously test method was sorting actual retrieved result's items field by only two fields: _Name_ and _ContributorNameTypeId_. Now three more field sorting added: _TotalRecords_, _AuthorityId_ and _Items.size()_

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[https://issues.folio.org/browse/MSEARCH-479](https://issues.folio.org/browse/MSEARCH-479)