### PR TITLE
MSEARCH-497 Anchor query result for subject browse returns >= 1 result

### DIFF
--- a/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
@@ -29,7 +29,10 @@ public class SubjectBrowseService extends AbstractBrowseServiceBySearchAfter<Sub
 
   @Override
   protected SearchSourceBuilder getAnchorSearchQuery(BrowseRequest request, BrowseContext context) {
-    return searchSource().query(termQuery(request.getTargetField(), context.getAnchor())).from(0).size(1);
+    log.debug("getAnchorSearchQuery:: by [request: {}]", request);
+    return searchSource().query(termQuery(request.getTargetField(), context.getAnchor()))
+      .size(context.getLimit(context.isBrowsingForward()))
+      .from(0);
   }
 
   @Override

--- a/src/test/java/org/folio/search/controller/BrowseContributorIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorIT.java
@@ -16,23 +16,19 @@ import static org.folio.search.utils.TestUtils.facetItem;
 import static org.folio.search.utils.TestUtils.mapOf;
 import static org.folio.search.utils.TestUtils.parseResponse;
 import static org.folio.search.utils.TestUtils.randomId;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
 import static org.opensearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.StringUtils;
 import org.folio.search.domain.dto.Contributor;
 import org.folio.search.domain.dto.Facet;
 import org.folio.search.domain.dto.FacetResult;
 import org.folio.search.domain.dto.Instance;
-import org.folio.search.domain.dto.InstanceContributorBrowseItem;
 import org.folio.search.domain.dto.InstanceContributorBrowseResult;
 import org.folio.search.domain.dto.RecordType;
 import org.folio.search.support.base.BaseIntegrationTest;
@@ -300,44 +296,10 @@ class BrowseContributorIT extends BaseIntegrationTest {
       .param("limit", String.valueOf(limit));
 
     var actual = parseResponse(doGet(request), InstanceContributorBrowseResult.class);
-    actual.getItems().sort(Comparator.comparing(InstanceContributorBrowseItem::getName, StringUtils::compareIgnoreCase)
-      .thenComparing((o1, o2) -> StringUtils.compare(o1.getContributorNameTypeId(), o2.getContributorNameTypeId()))
-    );
-
-    List<String> actualNames = actual.getItems()
-      .stream()
-      .map(InstanceContributorBrowseItem::getName)
-      .toList();
-    List<String> expectedNames = expected.getItems()
-      .stream()
-      .map(InstanceContributorBrowseItem::getName)
-      .toList();
-
-    List<String> actualNameTypeIds = actual.getItems()
-      .stream()
-      .map(InstanceContributorBrowseItem::getContributorNameTypeId)
-      .toList();
-    List<String> expectedNameTypeIds = expected.getItems()
-      .stream()
-      .map(InstanceContributorBrowseItem::getContributorNameTypeId)
-      .toList();
-
-    List<Boolean> actualIsAnchors = actual.getItems()
-      .stream()
-      .map(InstanceContributorBrowseItem::getIsAnchor)
-      .toList();
-    List<Boolean> expectedIsAnchors = expected.getItems()
-      .stream()
-      .map(InstanceContributorBrowseItem::getIsAnchor)
-      .toList();
-
-    assertEquals(expectedNames, actualNames);
-    assertEquals(expectedNameTypeIds, actualNameTypeIds);
-    assertEquals(expectedIsAnchors, actualIsAnchors);
-
-    assertEquals(expected.getNext(), actual.getNext());
-    assertEquals(expected.getPrev(), actual.getPrev());
-    assertEquals(expected.getTotalRecords(), actual.getTotalRecords());
+    assertThat(actual).usingRecursiveComparison()
+      .ignoringFields("items.authorityId", "items.totalRecords",
+        "items.contributorTypeId", "items.contributorNameTypeId")
+      .isEqualTo(expected);
   }
 
   @Test

--- a/src/test/java/org/folio/search/controller/BrowseContributorIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorIT.java
@@ -298,7 +298,7 @@ class BrowseContributorIT extends BaseIntegrationTest {
     var actual = parseResponse(doGet(request), InstanceContributorBrowseResult.class);
     assertThat(actual).usingRecursiveComparison()
       .ignoringFields("items.authorityId", "items.totalRecords",
-        "items.contributorTypeId", "items.contributorNameTypeId")
+        "items.contributorTypeId", "items.contributorNameTypeId", "items.totalRecords")
       .isEqualTo(expected);
   }
 

--- a/src/test/java/org/folio/search/controller/BrowseSubjectIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseSubjectIT.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.ONE_MINUTE;
 import static org.awaitility.Durations.ONE_SECOND;
+import static org.folio.search.model.Pair.pair;
 import static org.folio.search.support.base.ApiEndpoints.instanceSubjectBrowsePath;
 import static org.folio.search.utils.SearchUtils.getIndexName;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
@@ -23,6 +24,7 @@ import java.util.stream.Stream;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Subject;
 import org.folio.search.domain.dto.SubjectBrowseResult;
+import org.folio.search.model.Pair;
 import org.folio.search.support.base.BaseIntegrationTest;
 import org.folio.search.utils.SearchUtils;
 import org.folio.spring.test.type.IntegrationTest;
@@ -41,6 +43,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 @IntegrationTest
 class BrowseSubjectIT extends BaseIntegrationTest {
 
+  private static final String MUSIC_AUTHORITY_ID_1 = "e62bbefe-adf5-4b1e-b3e7-43d877b0c91a";
+  private static final String MUSIC_AUTHORITY_ID_2 = "308c950f-8209-4f2e-9702-0c004a9f21bc";
   private static final Instance[] INSTANCES = instances();
 
   @BeforeAll
@@ -51,7 +55,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
         .source(searchSource().query(matchAllQuery()).trackTotalHits(true).from(0).size(0))
         .indices(getIndexName(SearchUtils.INSTANCE_SUBJECT_RESOURCE, TENANT_ID));
       var searchResponse = restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
-      assertThat(searchResponse.getHits().getTotalHits().value).isEqualTo(22);
+      assertThat(searchResponse.getHits().getTotalHits().value).isEqualTo(23);
     });
   }
 
@@ -70,7 +74,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
 
     return Stream.of(
       arguments(aroundQuery, "water", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Textbooks").next("Water--Microbiology")
+        .totalRecords(23).prev("Textbooks").next("Water--Microbiology")
         .items(List.of(
           subjectBrowseItem(1, "Textbooks"),
           subjectBrowseItem(1, "United States"),
@@ -79,7 +83,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Water--Microbiology")))),
 
       arguments(aroundQuery, "biology", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev(null).next("Database design")
+        .totalRecords(23).prev(null).next("Database design")
         .items(List.of(
           subjectBrowseItem(2, "Biography"),
           subjectBrowseItem(0, "biology", true),
@@ -87,7 +91,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Database design")))),
 
       arguments(aroundIncludingQuery, "water", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Textbooks").next("Water--Microbiology")
+        .totalRecords(23).prev("Textbooks").next("Water--Microbiology")
         .items(List.of(
           subjectBrowseItem(1, "Textbooks"),
           subjectBrowseItem(1, "United States"),
@@ -96,7 +100,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Water--Microbiology")))),
 
       arguments(aroundIncludingQuery, "biology", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev(null).next("Database design")
+        .totalRecords(23).prev(null).next("Database design")
         .items(List.of(
           subjectBrowseItem(2, "Biography"),
           subjectBrowseItem(0, "biology", true),
@@ -104,7 +108,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Database design")))),
 
       arguments(aroundIncludingQuery, "music", 25, new SubjectBrowseResult()
-        .totalRecords(22).prev(null).next("Water--Microbiology")
+        .totalRecords(23).prev(null).next("Water--Analysis")
         .items(List.of(
           subjectBrowseItem(2, "Biography"),
           subjectBrowseItem(1, "Book"),
@@ -113,7 +117,8 @@ class BrowseSubjectIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Europe"),
           subjectBrowseItem(1, "Fantasy"),
           subjectBrowseItem(3, "History"),
-          subjectBrowseItem(3, "Music", true),
+          subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_2, true),
+          subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_1, true),
           subjectBrowseItem(1, "Philosophy"),
           subjectBrowseItem(1, "Religion"),
           subjectBrowseItem(1, "Rules"),
@@ -124,42 +129,41 @@ class BrowseSubjectIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Textbooks"),
           subjectBrowseItem(1, "United States"),
           subjectBrowseItem(1, "Water"),
-          subjectBrowseItem(1, "Water--Analysis"),
-          subjectBrowseItem(1, "Water--Microbiology")))),
+          subjectBrowseItem(1, "Water--Analysis")))),
 
       arguments(aroundIncludingQuery, "music", 11, new SubjectBrowseResult()
-        .totalRecords(22).prev("Database design").next("Science--Methodology")
+        .totalRecords(23).prev("Database design").next("Science")
         .items(List.of(
           subjectBrowseItem(1, "Database design"),
           subjectBrowseItem(1, "Database management"),
           subjectBrowseItem(1, "Europe"),
           subjectBrowseItem(1, "Fantasy"),
           subjectBrowseItem(3, "History"),
-          subjectBrowseItem(3, "Music", true),
+          subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_2, true),
+          subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_1, true),
           subjectBrowseItem(1, "Philosophy"),
           subjectBrowseItem(1, "Religion"),
           subjectBrowseItem(1, "Rules"),
-          subjectBrowseItem(1, "Science"),
-          subjectBrowseItem(1, "Science--Methodology")))),
+          subjectBrowseItem(1, "Science")))),
 
       arguments(aroundIncludingQuery, "FC", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Europe").next("Music")
+        .totalRecords(23).prev("Europe").next("Music")
         .items(List.of(
           subjectBrowseItem(1, "Europe"),
           subjectBrowseItem(1, "Fantasy"),
           subjectBrowseItem(0, "FC", true),
           subjectBrowseItem(3, "History"),
-          subjectBrowseItem(3, "Music")))),
+          subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_2)))),
 
       arguments(aroundIncludingQuery, "a", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev(null).next("Book")
+        .totalRecords(23).prev(null).next("Book")
         .items(List.of(
           subjectBrowseItem(0, "a", true),
           subjectBrowseItem(2, "Biography"),
           subjectBrowseItem(1, "Book")))),
 
       arguments(aroundIncludingQuery, "z", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Water--Purification").next(null)
+        .totalRecords(23).prev("Water--Purification").next(null)
         .items(List.of(
           subjectBrowseItem(1, "Water--Purification"),
           subjectBrowseItem(1, "Water-supply"),
@@ -167,7 +171,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
 
       // browsing forward
       arguments(forwardQuery, "water", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Water--Analysis").next(null)
+        .totalRecords(23).prev("Water--Analysis").next(null)
         .items(List.of(
           subjectBrowseItem(1, "Water--Analysis"),
           subjectBrowseItem(1, "Water--Microbiology"),
@@ -175,7 +179,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Water-supply")))),
 
       arguments(forwardQuery, "biology", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Book").next("Fantasy")
+        .totalRecords(23).prev("Book").next("Fantasy")
         .items(List.of(
           subjectBrowseItem(1, "Book"),
           subjectBrowseItem(1, "Database design"),
@@ -185,18 +189,18 @@ class BrowseSubjectIT extends BaseIntegrationTest {
 
       // checks if collapsing works in forward direction
       arguments(forwardQuery, "F", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Fantasy").next("Religion")
+        .totalRecords(23).prev("Fantasy").next("Philosophy")
         .items(List.of(
           subjectBrowseItem(1, "Fantasy"),
           subjectBrowseItem(3, "History"),
-          subjectBrowseItem(3, "Music"),
-          subjectBrowseItem(1, "Philosophy"),
-          subjectBrowseItem(1, "Religion")))),
+          subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_2),
+          subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_1),
+          subjectBrowseItem(1, "Philosophy")))),
 
-      arguments(forwardQuery, "Z", 10, subjectBrowseResult(22, emptyList())),
+      arguments(forwardQuery, "Z", 10, subjectBrowseResult(23, emptyList())),
 
       arguments(forwardIncludingQuery, "water", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Water").next(null)
+        .totalRecords(23).prev("Water").next(null)
         .items(List.of(
           subjectBrowseItem(1, "Water"),
           subjectBrowseItem(1, "Water--Analysis"),
@@ -205,7 +209,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Water-supply")))),
 
       arguments(forwardIncludingQuery, "biology", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Book").next("Fantasy")
+        .totalRecords(23).prev("Book").next("Fantasy")
         .items(List.of(
           subjectBrowseItem(1, "Book"),
           subjectBrowseItem(1, "Database design"),
@@ -215,7 +219,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
 
       // browsing backward
       arguments(backwardQuery, "water", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Science--Methodology").next("United States")
+        .totalRecords(23).prev("Science--Methodology").next("United States")
         .items(List.of(
           subjectBrowseItem(1, "Science--Methodology"),
           subjectBrowseItem(1, "Science--Philosophy"),
@@ -224,7 +228,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "United States")))),
 
       arguments(backwardQuery, "fun", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Book").next("Fantasy")
+        .totalRecords(23).prev("Book").next("Fantasy")
         .items(List.of(
           subjectBrowseItem(1, "Book"),
           subjectBrowseItem(1, "Database design"),
@@ -233,7 +237,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Fantasy")))),
 
       arguments(backwardQuery, "G", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Book").next("Fantasy")
+        .totalRecords(23).prev("Book").next("Fantasy")
         .items(List.of(
           subjectBrowseItem(1, "Book"),
           subjectBrowseItem(1, "Database design"),
@@ -241,10 +245,10 @@ class BrowseSubjectIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Europe"),
           subjectBrowseItem(1, "Fantasy")))),
 
-      arguments(backwardQuery, "A", 10, subjectBrowseResult(22, emptyList())),
+      arguments(backwardQuery, "A", 10, subjectBrowseResult(23, emptyList())),
 
       arguments(backwardIncludingQuery, "water", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Science--Philosophy").next("Water")
+        .totalRecords(23).prev("Science--Philosophy").next("Water")
         .items(List.of(
           subjectBrowseItem(1, "Science--Philosophy"),
           subjectBrowseItem(1, "Text"),
@@ -253,7 +257,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
           subjectBrowseItem(1, "Water")))),
 
       arguments(backwardIncludingQuery, "fun", 5, new SubjectBrowseResult()
-        .totalRecords(22).prev("Book").next("Fantasy")
+        .totalRecords(23).prev("Book").next("Fantasy")
         .items(List.of(
           subjectBrowseItem(1, "Book"),
           subjectBrowseItem(1, "Database design"),
@@ -274,7 +278,14 @@ class BrowseSubjectIT extends BaseIntegrationTest {
     return new Instance()
       .id(randomId())
       .title((String) data.get(0))
-      .subjects(((List<String>) data.get(1)).stream().map(val -> new Subject().value(val)).collect(Collectors.toList()))
+      .subjects(((List<Object>) data.get(1)).stream()
+        .map(val -> {
+          if (val instanceof Pair<?, ?> pair) {
+            return new Subject().value(String.valueOf(pair.getFirst())).authorityId(String.valueOf(pair.getSecond()));
+          } else {
+            return new Subject().value(String.valueOf(val));
+          }
+        }).collect(Collectors.toList()))
       .staffSuppress(false)
       .discoverySuppress(false)
       .holdings(emptyList());
@@ -282,14 +293,14 @@ class BrowseSubjectIT extends BaseIntegrationTest {
 
   private static List<List<Object>> subjectBrowseInstanceData() {
     return List.of(
-      List.of("instance #01", List.of("History", "Music", "Biography")),
-      List.of("instance #02", List.of("Fantasy", "Music")),
+      List.of("instance #01", List.of("History", pair("Music", MUSIC_AUTHORITY_ID_1), "Biography")),
+      List.of("instance #02", List.of("Fantasy", pair("Music", MUSIC_AUTHORITY_ID_2))),
       List.of("instance #03", List.of("United States", "History", "Rules")),
-      List.of("instance #04", List.of("Europe", "Music")),
+      List.of("instance #04", List.of("Europe", pair("Music", MUSIC_AUTHORITY_ID_1))),
       List.of("instance #05", List.of("Book", "Text", "Biography")),
       List.of("instance #06", List.of("Religion", "History", "Philosophy")),
       List.of("instance #07", List.of("Science", "Science--Methodology", "Science--Philosophy")),
-      List.of("instance #08", List.of("Water", "Water-supply")),
+      List.of("instance #08", List.of("Water", "Water-supply", pair("Music", MUSIC_AUTHORITY_ID_2))),
       List.of("instance #09", List.of("Water--Analysis", "Water--Purification", "Water--Microbiology")),
       List.of("instance #10", List.of("Database design", "Database management", "Textbooks"))
     );
@@ -303,7 +314,9 @@ class BrowseSubjectIT extends BaseIntegrationTest {
       .param("query", prepareQuery(query, '"' + anchor + '"'))
       .param("limit", String.valueOf(limit));
     var actual = parseResponse(doGet(request), SubjectBrowseResult.class);
-    assertThat(actual).isEqualTo(expected);
+
+    assertThat(actual).usingRecursiveComparison().ignoringFields("items.authorityId")
+      .isEqualTo(expected);
   }
 
   @Test
@@ -314,7 +327,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
       .param("precedingRecordsCount", "2");
     var actual = parseResponse(doGet(request), SubjectBrowseResult.class);
     assertThat(actual).isEqualTo(new SubjectBrowseResult()
-      .totalRecords(22).prev("Textbooks")
+      .totalRecords(23).prev("Textbooks")
       .items(List.of(
         subjectBrowseItem(1, "Textbooks"),
         subjectBrowseItem(1, "United States"),
@@ -334,12 +347,12 @@ class BrowseSubjectIT extends BaseIntegrationTest {
     var actual = parseResponse(doGet(request), SubjectBrowseResult.class);
 
     assertThat(actual).isEqualTo(new SubjectBrowseResult()
-      .totalRecords(22).prev("Database management").next("Music")
+      .totalRecords(23).prev("Database management").next("Music")
       .items(List.of(
         subjectBrowseItem(1, "Database management"),
         subjectBrowseItem(1, "Europe"),
         subjectBrowseItem(1, "Fantasy"),
         subjectBrowseItem(3, "History"),
-        subjectBrowseItem(3, "Music"))));
+        subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_2))));
   }
 }

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -51,7 +51,6 @@ import lombok.SneakyThrows;
 import org.folio.search.cql.EffectiveShelvingOrderTermProcessor;
 import org.folio.search.domain.dto.Authority;
 import org.folio.search.domain.dto.AuthorityBrowseItem;
-import org.folio.search.domain.dto.AuthorityBrowseResult;
 import org.folio.search.domain.dto.CallNumberBrowseItem;
 import org.folio.search.domain.dto.CallNumberBrowseResult;
 import org.folio.search.domain.dto.Facet;
@@ -194,8 +193,20 @@ public class TestUtils {
     return new SubjectBrowseItem().value(subject).totalRecords(totalRecords);
   }
 
+  public static SubjectBrowseItem subjectBrowseItem(Integer totalRecords, String subject, String authorityId) {
+    return new SubjectBrowseItem().value(subject).authorityId(authorityId).totalRecords(totalRecords);
+  }
+
   public static SubjectBrowseItem subjectBrowseItem(Integer totalRecords, String subject, boolean isAnchor) {
     return new SubjectBrowseItem().value(subject).totalRecords(totalRecords).isAnchor(isAnchor);
+  }
+
+  public static SubjectBrowseItem subjectBrowseItem(Integer totalRecords, String subject, String authorityId,
+                                                    boolean isAnchor) {
+    return new SubjectBrowseItem().value(subject)
+      .authorityId(authorityId)
+      .totalRecords(totalRecords)
+      .isAnchor(isAnchor);
   }
 
   public static SubjectBrowseItem subjectBrowseItem(String subject) {
@@ -231,10 +242,6 @@ public class TestUtils {
 
   public static AuthorityBrowseItem authorityBrowseItem(String heading, Authority authority, boolean isAnchor) {
     return new AuthorityBrowseItem().headingRef(heading).isAnchor(isAnchor).authority(authority);
-  }
-
-  public static AuthorityBrowseResult authorityBrowseResult(int size, List<AuthorityBrowseItem> items) {
-    return new AuthorityBrowseResult().items(items).totalRecords(size);
   }
 
   public static String randomId() {


### PR DESCRIPTION
## Purpose
Fix bug when two same "Subject" values with different links are displayed as one result when browse

## Approach
Modify anchor query to search for more then 1 match

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging