### PR TITLE
    MSEARCH-513  An error occurs when searching by the first call num…

### DIFF
--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Service;
 public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBrowseItem> {
 
   private static final int ADDITIONAL_REQUEST_SIZE = 100;
-  private static final int ADDITIONAL_REQEST_SIZE_MAX = 500;
+  private static final int ADDITIONAL_REQUEST_SIZE_MAX = 500;
   private final SearchRepository searchRepository;
   private final CqlSearchQueryConverter cqlSearchQueryConverter;
   private final CallNumberBrowseQueryProvider callNumberBrowseQueryProvider;

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBrowseItem> {
 
   private static final int ADDITIONAL_REQUEST_SIZE = 100;
+  private static final int ADDITIONAL_REQEST_SIZE_MAX = 500;
   private final SearchRepository searchRepository;
   private final CqlSearchQueryConverter cqlSearchQueryConverter;
   private final CallNumberBrowseQueryProvider callNumberBrowseQueryProvider;
@@ -89,7 +90,7 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
     BrowseResult<CallNumberBrowseItem> precedingResult = BrowseResult.empty();
     precedingQuery.size(ADDITIONAL_REQUEST_SIZE);
 
-    while (precedingResult.getRecords().isEmpty()) {
+    while (precedingResult.getRecords().isEmpty() && precedingQuery.from() <= ADDITIONAL_REQEST_SIZE_MAX) {
       int offset = precedingQuery.from() + precedingQuery.size();
       int size = precedingQuery.size() * 2;
       log.debug("additionalPrecedingRequests:: request offset {}, size {}", offset, size);

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -90,7 +90,7 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
     BrowseResult<CallNumberBrowseItem> precedingResult = BrowseResult.empty();
     precedingQuery.size(ADDITIONAL_REQUEST_SIZE);
 
-    while (precedingResult.getRecords().isEmpty() && precedingQuery.from() <= ADDITIONAL_REQEST_SIZE_MAX) {
+    while (precedingResult.getRecords().isEmpty() && precedingQuery.from() <= ADDITIONAL_REQUEST_SIZE_MAX) {
       int offset = precedingQuery.from() + precedingQuery.size();
       int size = precedingQuery.size() * 2;
       log.debug("additionalPrecedingRequests:: request offset {}, size {}", offset, size);

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
@@ -78,6 +78,26 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       )));
   }
 
+  //https://issues.folio.org/browse/MSEARCH-513
+  @Test
+  void browseByCallNumber_browsingVeryFirstCallNumberWithNoException() {
+    var request = get(instanceCallNumberBrowsePath())
+        .param("query", prepareQuery("callNumber >= {value} or callNumber < {value}", "\"AB 14 C72 NO 220\""))
+        .param("limit", "10")
+        .param("highlightMatch", "true")
+        .param("expandAll", "true")
+        .param("precedingRecordsCount", "5");
+    var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
+    assertThat(actual).isEqualTo(new CallNumberBrowseResult()
+        .totalRecords(32).prev(null).next("CE 216 B6713 X 541993").items(List.of(
+            cnBrowseItem(instance("instance #31"), "AB 14 C72 NO 220", true),
+            cnBrowseItem(instance("instance #25"), "AC 11 A4 VOL 235"),
+            cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
+            cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
+            cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993")
+        )));
+  }
+
   @Test
   void browseByCallNumber_browsingAroundWithoutHighlightMatch() {
     var request = get(instanceCallNumberBrowsePath())


### PR DESCRIPTION
## Approach
Added limit on while loop in CallNumberBrowseService.additionalPrecedingRequests(). When there is no precedding call numbers (very first call number) this loop run to infinity (to exception).

### Learning
[_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._](https://issues.folio.org/browse/MSEARCH-513)