### PR TITLE
 MSEARCH-515 Create endpoint to support CN browse by types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 * Remove required `instance-authority-links`
 
 ### Features
-* Create endpoint to support call-numbers browse by types ([MSEARCH-514](https://issues.folio.org/browse/MSEARCH-514))
+* Extend call-numbers browse endpoint to support filtering by types ([MSEARCH-514](https://issues.folio.org/browse/MSEARCH-514))
 
 ### Tech Dept
 * Change logic of linked titles count on authority search/browse ([MSEARCH-501](https://issues.folio.org/browse/MSEARCH-501))

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 ### New APIs versions
 * Remove required `instance-authority-links`
 
+### Features
+* Create endpoint to support call-numbers browse by types ([MSEARCH-514](https://issues.folio.org/browse/MSEARCH-514))
+
 ### Tech Dept
 * Change logic of linked titles count on authority search/browse ([MSEARCH-501](https://issues.folio.org/browse/MSEARCH-501))
 

--- a/README.md
+++ b/README.md
@@ -691,21 +691,22 @@ In case where options are similar, secondary sort is used
 
 ### Browse API
 
-| METHOD | URL                              | DESCRIPTION                                                                                     |
-|:-------|:---------------------------------|:------------------------------------------------------------------------------------------------|
-| GET    | `/browse/subjects/instances`     | Browse by instance's subjects                                                                   |
-| GET    | `/browse/contributors/instances` | Browse by instance's contributors                                                               |
-| GET    | `/browse/call-numbers/instances` | Browse by instance's call-numbers. [call number browsing](doc/browsing.md#call-number-browsing) |
-| GET    | `/browse/authorities`            | Browse by authority's headings                                                                  |
+| METHOD | URL                                               | DESCRIPTION                                                                                            |
+|:-------|:--------------------------------------------------|:-------------------------------------------------------------------------------------------------------|
+| GET    | `/browse/subjects/instances`                      | Browse by instance's subjects                                                                          |
+| GET    | `/browse/contributors/instances`                  | Browse by instance's contributors                                                                      |
+| GET    | `/browse/call-numbers/instances`                  | Browse by instance's call-numbers. [call number browsing](doc/browsing.md#call-number-browsing)        |
+| GET    | `/browse/authorities`                             | Browse by authority's headings                                                                         |
 
 **Query parameters**
 
-| Parameter             | Type    | Default value | Description                                                                          |
-|:----------------------|:--------|:--------------|:-------------------------------------------------------------------------------------|
-| query                 | string  | -             | A CQL query for browsing                                                             |
-| limit                 | integer | 100           | Number of records in response                                                        |
-| highlightMatch        | boolean | true          | Whether to highlight matched resource (or add empty object containing anchor) or not |
-| precedingRecordsCount | integer | limit / 2     | Amount of preceding records for browsing around                                      |
+| Parameter             | Type    | Default value | Possible values                     | Description                                                                          |
+|:----------------------|:--------|:--------------|:------------------------------------|:-------------------------------------------------------------------------------------|
+| query                 | string  | -             |                                     | A CQL query for browsing                                                             |
+| limit                 | integer | 100           |                                     | Number of records in response                                                        |
+| highlightMatch        | boolean | true          |                                     | Whether to highlight matched resource (or add empty object containing anchor) or not |
+| precedingRecordsCount | integer | limit / 2     |                                     | Amount of preceding records for browsing around                                      |
+| callNumberType        | string  | -             | lc, dewey, nlm, sudoc, other, local | Filters the result of call-number browse by it's type                                |
 
 The query operator works as it described in [CQL Query operators](#cql-query-operators) section. Anchor will be included
 only if `<=` or `>=` are used in the query. Otherwise, the empty row will be added if `highlightMatch` is equal to `true`.

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -91,12 +91,17 @@
     },
     {
       "id": "browse",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [ "GET" ],
           "pathPattern": "/browse/call-numbers/instances",
           "permissionsRequired": [ "browse.call-numbers.instances.collection.get" ]
+        },
+        {
+          "methods": [ "GET" ],
+          "pathPattern": "/browse/call-numbers-{callNumberType}/instances",
+          "permissionsRequired": [ "browse.call-numbers-types.instances.collection.get" ]
         },
         {
           "methods": [ "GET" ],
@@ -247,6 +252,11 @@
     {
       "permissionName": "browse.call-numbers.instances.collection.get",
       "displayName": "Browse - provides collections of browse items for instance by call number",
+      "description": "Browse instances by given query"
+    },
+    {
+      "permissionName": "browse.call-numbers-types.instances.collection.get",
+      "displayName": "Browse - provides collections of browse items for instance by call number types",
       "description": "Browse instances by given query"
     },
     {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -100,11 +100,6 @@
         },
         {
           "methods": [ "GET" ],
-          "pathPattern": "/browse/call-numbers-{callNumberType}/instances",
-          "permissionsRequired": [ "browse.call-numbers-types.instances.collection.get" ]
-        },
-        {
-          "methods": [ "GET" ],
           "pathPattern": "/browse/subjects/instances",
           "permissionsRequired": [ "browse.subjects.instances.collection.get" ]
         },
@@ -252,11 +247,6 @@
     {
       "permissionName": "browse.call-numbers.instances.collection.get",
       "displayName": "Browse - provides collections of browse items for instance by call number",
-      "description": "Browse instances by given query"
-    },
-    {
-      "permissionName": "browse.call-numbers-types.instances.collection.get",
-      "displayName": "Browse - provides collections of browse items for instance by call number types",
       "description": "Browse instances by given query"
     },
     {

--- a/pom.xml
+++ b/pom.xml
@@ -474,6 +474,7 @@
                 <interfaceOnly>true</interfaceOnly>
                 <useSpringBoot3>true</useSpringBoot3>
                 <requestMappingMode>api_interface</requestMappingMode>
+                <generatedConstructorWithRequiredArgs>false</generatedConstructorWithRequiredArgs>
               </configOptions>
             </configuration>
           </execution>

--- a/src/main/java/org/folio/search/configuration/WebConfig.java
+++ b/src/main/java/org/folio/search/configuration/WebConfig.java
@@ -1,5 +1,6 @@
 package org.folio.search.configuration;
 
+import org.folio.search.domain.dto.CallNumberType;
 import org.folio.search.domain.dto.RecordType;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
@@ -11,13 +12,21 @@ public class WebConfig implements WebMvcConfigurer {
 
   @Override
   public void addFormatters(FormatterRegistry registry) {
-    registry.addConverter(new StringToEnumConverter());
+    registry.addConverter(new StringToRecordTypeEnumConverter());
+    registry.addConverter(new StringToCallNumberTypeEnumConverter());
   }
 
-  private static class StringToEnumConverter implements Converter<String, RecordType> {
+  private static class StringToRecordTypeEnumConverter implements Converter<String, RecordType> {
     @Override
     public RecordType convert(String source) {
       return RecordType.valueOf(source.toUpperCase());
+    }
+  }
+
+  private static class StringToCallNumberTypeEnumConverter implements Converter<String, CallNumberType> {
+    @Override
+    public CallNumberType convert(String source) {
+      return CallNumberType.valueOf(source.toUpperCase());
     }
   }
 }

--- a/src/main/java/org/folio/search/controller/BrowseController.java
+++ b/src/main/java/org/folio/search/controller/BrowseController.java
@@ -10,10 +10,12 @@ import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
 import static org.folio.search.utils.SearchUtils.INSTANCE_SUBJECT_RESOURCE;
 import static org.folio.search.utils.SearchUtils.SHELVING_ORDER_BROWSING_FIELD;
 import static org.folio.search.utils.SearchUtils.SUBJECT_BROWSING_FIELD;
+import static org.folio.search.utils.SearchUtils.TYPED_CALL_NUMBER_BROWSING_FIELD;
 
 import lombok.RequiredArgsConstructor;
 import org.folio.search.domain.dto.AuthorityBrowseResult;
 import org.folio.search.domain.dto.CallNumberBrowseResult;
+import org.folio.search.domain.dto.CallNumberType;
 import org.folio.search.domain.dto.ContributorBrowseResult;
 import org.folio.search.domain.dto.SubjectBrowseResult;
 import org.folio.search.exception.RequestValidationException;
@@ -41,6 +43,42 @@ public class BrowseController implements BrowseApi {
   private final ContributorBrowseService contributorBrowseService;
 
   @Override
+  public ResponseEntity<AuthorityBrowseResult> browseAuthorities(String query, String tenant,
+                                                                 Integer limit, Boolean expandAll,
+                                                                 Boolean highlightMatch,
+                                                                 Integer precedingRecordsCount) {
+    var browseRequest = getBrowseRequestBuilder(query, tenant, limit, expandAll, highlightMatch, precedingRecordsCount)
+      .resource(AUTHORITY_RESOURCE).targetField(AUTHORITY_BROWSING_FIELD).build();
+    var browseResult = authorityBrowseService.browse(browseRequest);
+    return ResponseEntity.ok(new AuthorityBrowseResult()
+      .items(browseResult.getRecords())
+      .totalRecords(browseResult.getTotalRecords())
+      .prev(browseResult.getPrev())
+      .next(browseResult.getNext()));
+  }
+
+  @Override
+  public ResponseEntity<CallNumberBrowseResult> browseInstancesByCallNumber(String query, String tenant,
+                                                                            Integer limit, Boolean expandAll,
+                                                                            Boolean highlightMatch,
+                                                                            Integer precedingRecordsCount,
+                                                                            CallNumberType callNumberType) {
+    var browseRequest = getBrowseRequestBuilder(query, tenant, limit, expandAll, highlightMatch, precedingRecordsCount)
+      .resource(INSTANCE_RESOURCE)
+      .targetField(SHELVING_ORDER_BROWSING_FIELD)
+      .subField(callNumberType == null ? CALL_NUMBER_BROWSING_FIELD : TYPED_CALL_NUMBER_BROWSING_FIELD)
+      .refinedCondition(callNumberType != null ? callNumberType.getValue() : null)
+      .build();
+
+    var instanceByCallNumber = callNumberBrowseService.browse(browseRequest);
+    return ResponseEntity.ok(new CallNumberBrowseResult()
+      .items(instanceByCallNumber.getRecords())
+      .totalRecords(instanceByCallNumber.getTotalRecords())
+      .prev(instanceByCallNumber.getPrev())
+      .next(instanceByCallNumber.getNext()));
+  }
+
+  @Override
   public ResponseEntity<ContributorBrowseResult> browseInstancesByContributor(String query, String tenant,
                                                                               Integer limit, Boolean highlightMatch,
                                                                               Integer precedingRecordsCount) {
@@ -56,23 +94,6 @@ public class BrowseController implements BrowseApi {
   }
 
   @Override
-  public ResponseEntity<CallNumberBrowseResult> browseInstancesByCallNumber(String query, String tenant,
-                                                                            Integer limit, Boolean expandAll,
-                                                                            Boolean highlightMatch,
-                                                                            Integer precedingRecordsCount) {
-    var browseRequest = getBrowseRequestBuilder(query, tenant, limit, expandAll, highlightMatch, precedingRecordsCount)
-      .resource(INSTANCE_RESOURCE).targetField(SHELVING_ORDER_BROWSING_FIELD).subField(CALL_NUMBER_BROWSING_FIELD)
-      .build();
-
-    var instanceByCallNumber = callNumberBrowseService.browse(browseRequest);
-    return ResponseEntity.ok(new CallNumberBrowseResult()
-      .items(instanceByCallNumber.getRecords())
-      .totalRecords(instanceByCallNumber.getTotalRecords())
-      .prev(instanceByCallNumber.getPrev())
-      .next(instanceByCallNumber.getNext()));
-  }
-
-  @Override
   public ResponseEntity<SubjectBrowseResult> browseInstancesBySubject(String query, String tenant,
                                                                       Integer limit, Boolean highlightMatch,
                                                                       Integer precedingRecordsCount) {
@@ -81,21 +102,6 @@ public class BrowseController implements BrowseApi {
 
     var browseResult = subjectBrowseService.browse(browseRequest);
     return ResponseEntity.ok(new SubjectBrowseResult()
-      .items(browseResult.getRecords())
-      .totalRecords(browseResult.getTotalRecords())
-      .prev(browseResult.getPrev())
-      .next(browseResult.getNext()));
-  }
-
-  @Override
-  public ResponseEntity<AuthorityBrowseResult> browseAuthorities(String query, String tenant,
-                                                                 Integer limit, Boolean expandAll,
-                                                                 Boolean highlightMatch,
-                                                                 Integer precedingRecordsCount) {
-    var browseRequest = getBrowseRequestBuilder(query, tenant, limit, expandAll, highlightMatch, precedingRecordsCount)
-      .resource(AUTHORITY_RESOURCE).targetField(AUTHORITY_BROWSING_FIELD).build();
-    var browseResult = authorityBrowseService.browse(browseRequest);
-    return ResponseEntity.ok(new AuthorityBrowseResult()
       .items(browseResult.getRecords())
       .totalRecords(browseResult.getTotalRecords())
       .prev(browseResult.getPrev())

--- a/src/main/java/org/folio/search/model/service/BrowseRequest.java
+++ b/src/main/java/org/folio/search/model/service/BrowseRequest.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.folio.search.model.ResourceRequest;
 
 @Data
-@Builder
+@Builder()
 @RequiredArgsConstructor(staticName = "of")
 public class BrowseRequest implements ResourceRequest {
 
@@ -41,6 +41,11 @@ public class BrowseRequest implements ResourceRequest {
   private final String subField;
 
   /**
+   * Refined condition for browse.
+   */
+  private final String refinedCondition;
+
+  /**
    * Whether to return only basic properties or entire instance.
    */
   private final Boolean expandAll;
@@ -54,4 +59,11 @@ public class BrowseRequest implements ResourceRequest {
    * Number of preceding records for virtual shelf browsing. Works only when browsing around.
    */
   private final Integer precedingRecordsCount;
+
+  public static BrowseRequest of(String resource, String tenantId, String query, Integer limit, String targetField,
+                                 String subField, Boolean expandAll, Boolean highlightMatch,
+                                 Integer precedingRecordsCount) {
+    return new BrowseRequest(resource, tenantId, query, limit, targetField, subField, null, expandAll,
+      highlightMatch, precedingRecordsCount);
+  }
 }

--- a/src/main/java/org/folio/search/model/types/CallNumberType.java
+++ b/src/main/java/org/folio/search/model/types/CallNumberType.java
@@ -1,0 +1,47 @@
+package org.folio.search.model.types;
+
+import java.util.Optional;
+import lombok.Getter;
+
+@Getter
+public enum CallNumberType {
+
+  LC("95467209-6d7b-468b-94df-0f5d7ad2747d", CallNumberTypeSource.SYSTEM, 1),
+  DEWEY("03dd64d0-5626-4ecd-8ece-4531e0069f35", CallNumberTypeSource.SYSTEM, 2),
+  NLM("054d460d-d6b9-4469-9e37-7a78a2266655", CallNumberTypeSource.SYSTEM, 3),
+  SUDOC("fc388041-6cd0-4806-8a74-ebe3b9ab4c6e", CallNumberTypeSource.SYSTEM, 4),
+  OTHER("6caca63e-5651-4db6-9247-3205156e9699", CallNumberTypeSource.SYSTEM, 5),
+  LOCAL("*", CallNumberTypeSource.LOCAL, 6);
+
+  private final String id;
+  private final CallNumberTypeSource source;
+  /**
+   * Number that is used for browsing by typed call number.
+   */
+  private final int number;
+
+  CallNumberType(String id, CallNumberTypeSource source, int number) {
+    this.id = id;
+    this.source = source;
+    this.number = number;
+  }
+
+  public static Optional<CallNumberType> fromName(String name) {
+    for (CallNumberType value : values()) {
+      if (value.name().equalsIgnoreCase(name)) {
+        return Optional.of(value);
+      }
+    }
+    return Optional.empty();
+  }
+
+  public static Optional<CallNumberType> fromId(String id) {
+    for (CallNumberType value : values()) {
+      if (value.getId().equalsIgnoreCase(id)) {
+        return Optional.of(value);
+      }
+    }
+    return Optional.empty();
+  }
+
+}

--- a/src/main/java/org/folio/search/model/types/CallNumberTypeSource.java
+++ b/src/main/java/org/folio/search/model/types/CallNumberTypeSource.java
@@ -1,0 +1,15 @@
+package org.folio.search.model.types;
+
+import lombok.Getter;
+
+@Getter
+public enum CallNumberTypeSource {
+  SYSTEM("system"),
+  LOCAL("local");
+
+  private final String source;
+
+  CallNumberTypeSource(String source) {
+    this.source = source;
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessor.java
@@ -2,13 +2,13 @@ package org.folio.search.service.setter.item;
 
 import static org.folio.search.client.InventoryReferenceDataClient.ReferenceDataType.CALL_NUMBER_TYPES;
 import static org.folio.search.model.client.CqlQueryParam.SOURCE;
+import static org.folio.search.model.types.CallNumberTypeSource.LOCAL;
 import static org.folio.search.utils.CallNumberUtils.getCallNumberAsLong;
 import static org.folio.search.utils.CollectionUtils.toLinkedHashSet;
 import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.integration.ReferenceDataService;
+import org.folio.search.model.types.CallNumberType;
 import org.folio.search.service.setter.FieldProcessor;
 import org.springframework.stereotype.Component;
 
@@ -24,23 +25,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ItemTypedCallNumberProcessor implements FieldProcessor<Instance, Set<Long>> {
 
-  static final String LC_ID = "95467209-6d7b-468b-94df-0f5d7ad2747d";
-  static final String DEWEY_ID = "03dd64d0-5626-4ecd-8ece-4531e0069f35";
-  static final String NLM_ID = "054d460d-d6b9-4469-9e37-7a78a2266655";
-  static final String SUDOC_ID = "fc388041-6cd0-4806-8a74-ebe3b9ab4c6e";
-  static final String OTHER_SCHEME_ID = "6caca63e-5651-4db6-9247-3205156e9699";
-
-  private static final String SYSTEM_SOURCE = "system";
-  private static final String LOCAL_SOURCE = "local";
-  static final List<String> LOCAL_CALL_NUMBER_TYPES_SOURCES = Collections.singletonList(LOCAL_SOURCE);
-  private static final Map<CallNumberKey, Integer> CALL_NUMBER_PREFIX_MAP = Map.of(
-    new CallNumberKey(StringUtils.EMPTY, LOCAL_SOURCE), 0,
-    new CallNumberKey(LC_ID, SYSTEM_SOURCE), 1,
-    new CallNumberKey(DEWEY_ID, SYSTEM_SOURCE), 2,
-    new CallNumberKey(NLM_ID, SYSTEM_SOURCE), 3,
-    new CallNumberKey(SUDOC_ID, SYSTEM_SOURCE), 4,
-    new CallNumberKey(OTHER_SCHEME_ID, SYSTEM_SOURCE), 5
-  );
+  static final List<String> LOCAL_CALL_NUMBER_TYPES_SOURCES = Collections.singletonList(LOCAL.getSource());
 
   private final ReferenceDataService referenceDataService;
 
@@ -52,6 +37,12 @@ public class ItemTypedCallNumberProcessor implements FieldProcessor<Instance, Se
       .filter(value -> value > 0)
       .sorted()
       .collect(toLinkedHashSet());
+  }
+
+  public Optional<Integer> getCallNumberTypedPrefix(String callNumberTypeId) {
+    boolean isLocal = isLocalCallNumberTypeId(callNumberTypeId);
+    return isLocal ? Optional.of(CallNumberType.LOCAL.getNumber())
+                   : CallNumberType.fromId(callNumberTypeId).map(CallNumberType::getNumber);
   }
 
   private Long toCallNumberLongRepresentation(Item item) {
@@ -66,22 +57,9 @@ public class ItemTypedCallNumberProcessor implements FieldProcessor<Instance, Se
     }
   }
 
-  public Optional<Integer> getCallNumberTypedPrefix(String callNumberTypeId) {
-    boolean isLocal = isLocalCallNumberTypeId(callNumberTypeId);
-    var callNumberKey = new CallNumberKey(callNumberTypeId, isLocal ? LOCAL_SOURCE : SYSTEM_SOURCE);
-    return Optional.ofNullable(CALL_NUMBER_PREFIX_MAP.get(callNumberKey));
-  }
-
   private boolean isLocalCallNumberTypeId(String callNumberTypeId) {
     return referenceDataService.fetchReferenceData(CALL_NUMBER_TYPES, SOURCE, LOCAL_CALL_NUMBER_TYPES_SOURCES)
       .contains(callNumberTypeId);
   }
 
-  public record CallNumberKey(String callNumberTypeId, String callNumberSource) {
-
-    public CallNumberKey(String callNumberTypeId, String callNumberSource) {
-      this.callNumberSource = callNumberSource;
-      this.callNumberTypeId = !callNumberSource.equals(SYSTEM_SOURCE) ? StringUtils.EMPTY : callNumberTypeId;
-    }
-  }
 }

--- a/src/main/java/org/folio/search/utils/CallNumberUtils.java
+++ b/src/main/java/org/folio/search/utils/CallNumberUtils.java
@@ -137,6 +137,9 @@ public class CallNumberUtils {
    * @return numeric representation of given call-number value
    */
   public static Long getCallNumberAsLong(String callNumber, int firstPosition) {
+    if (firstPosition <= 0) {
+      return getCallNumberAsLong(callNumber);
+    }
     long startVal = convertChar(firstPosition, CN_MAX_CHARS);
     return callNumberToLong(callNumber, startVal, CN_MAX_CHARS - 1);
   }
@@ -144,7 +147,7 @@ public class CallNumberUtils {
   private static long callNumberToLong(String callNumber, long startVal, int maxChars) {
     var cleanCallNumber = cleanCallNumber(callNumber, maxChars);
     if (StringUtils.isBlank(cleanCallNumber)) {
-      return 0L;
+      return startVal;
     }
     long result = startVal;
     for (int i = 0; i < cleanCallNumber.length(); i++) {

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -39,6 +39,7 @@ public class SearchUtils {
   public static final String INSTANCE_CONTRIBUTORS_FIELD_NAME = "contributors";
   public static final String IS_BOUND_WITH_FIELD_NAME = "isBoundWith";
   public static final String CALL_NUMBER_BROWSING_FIELD = "callNumber";
+  public static final String TYPED_CALL_NUMBER_BROWSING_FIELD = "typedCallNumber";
   public static final String SHELVING_ORDER_BROWSING_FIELD = "itemEffectiveShelvingOrder";
   public static final String SUBJECT_BROWSING_FIELD = "value";
   public static final String CONTRIBUTOR_BROWSING_FIELD = "name";

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Search API
-  version: v1
+  version: v2.1.0
   description: Search API
 
 servers:
@@ -82,7 +82,7 @@ paths:
           required: true
           in: path
           schema:
-            "$ref": "#/components/schemas/RecordType"
+            $ref: '#/components/schemas/RecordType'
         - $ref: '#/components/parameters/cql-query'
         - $ref: '#/components/parameters/facet-param'
         - $ref: '#/components/parameters/x-okapi-tenant-header'
@@ -196,6 +196,12 @@ paths:
         - $ref: '#/components/parameters/x-okapi-tenant-header'
         - $ref: '#/components/parameters/highlight-match'
         - $ref: '#/components/parameters/preceding-records-count'
+        - in: query
+          name: callNumberType
+          description: Type of call number
+          required: false
+          schema:
+            $ref: '#/components/schemas/CallNumberType'
       responses:
         '200':
           description: 'Search result for browsing by call number'
@@ -528,7 +534,10 @@ components:
     reindexRequest:
       $ref: schemas/request/reindexRequest.json
     RecordType:
-      enum: [ "instances", "authorities", "contributors" ]
+      enum: [ instances, authorities, contributors ]
+      type: string
+    CallNumberType:
+      enum: [ lc, dewey, nlm, sudoc, other, local ]
       type: string
 
   responses:

--- a/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIT.java
@@ -1,0 +1,242 @@
+package org.folio.search.controller;
+
+import static java.util.Collections.emptyList;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.model.types.CallNumberType.DEWEY;
+import static org.folio.search.model.types.CallNumberType.LC;
+import static org.folio.search.model.types.CallNumberType.NLM;
+import static org.folio.search.model.types.CallNumberType.OTHER;
+import static org.folio.search.model.types.CallNumberType.SUDOC;
+import static org.folio.search.support.base.ApiEndpoints.instanceCallNumberBrowsePath;
+import static org.folio.search.utils.TestUtils.cnBrowseItem;
+import static org.folio.search.utils.TestUtils.getShelfKeyFromCallNumber;
+import static org.folio.search.utils.TestUtils.parseResponse;
+import static org.folio.search.utils.TestUtils.randomId;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.folio.search.domain.dto.CallNumberBrowseResult;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Item;
+import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
+import org.folio.search.support.base.BaseIntegrationTest;
+import org.folio.spring.test.type.IntegrationTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@IntegrationTest
+class BrowseTypedCallNumberIT extends BaseIntegrationTest {
+
+  private static final String LOCAL_TYPE_1 = "6fd29f52-5c9c-44d0-b529-e9c5eb3a0aba";
+  private static final String LOCAL_TYPE_2 = "654d7565-b277-4dfa-8b7d-fbf306d9d0cd";
+  private static final Instance[] INSTANCES = instances();
+  private static final Map<String, Instance> INSTANCE_MAP =
+    Arrays.stream(INSTANCES).collect(toMap(Instance::getTitle, identity()));
+
+  @BeforeAll
+  static void prepare() {
+    setUpTenant(INSTANCES);
+  }
+
+  @AfterAll
+  static void cleanUp() {
+    removeTenant();
+  }
+
+  @Test
+  void browseByCallNumberLc_browsingAroundWhenPrecedingRecordsCountIsSpecified() {
+    var request = get(instanceCallNumberBrowsePath())
+      .param("query",
+        prepareQuery("typedCallNumber < {value} or typedCallNumber >= {value}", "\"DA 3890 A2 B76 42002\""))
+      .param("callNumberType", "lc")
+      .param("limit", "5")
+      .param("expandAll", "true")
+      .param("precedingRecordsCount", "4");
+    var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
+    assertThat(actual).isEqualTo(new CallNumberBrowseResult()
+      .totalRecords(23).prev("DA 43880 O6 M15").next("DA 43890 A2 B76 542002").items(List.of(
+        cnBrowseItem(instance("instance #05"), "DA 3880 O6 M15"),
+        cnBrowseItem(instance("instance #13"), "DA 3880 O6 M81"),
+        cnBrowseItem(instance("instance #02"), "DA 3880 O6 M96"),
+        cnBrowseItem(instance("instance #14"), "DA 3890 A1 I72 41885"),
+        cnBrowseItem(instance("instance #22"), "DA 3890 A2 B76 42002", true)
+      )));
+  }
+
+  @Test
+  void browseByCallNumberDewey_browsingAroundWhenPrecedingRecordsCountIsSpecified() {
+    var request = get(instanceCallNumberBrowsePath())
+      .param("query", prepareQuery("typedCallNumber < {value} or typedCallNumber >= {value}", "\"CE 16 B6724 41993\""))
+      .param("callNumberType", "dewey")
+      .param("limit", "5")
+      .param("expandAll", "true")
+      .param("precedingRecordsCount", "4");
+    var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
+    assertThat(actual).isEqualTo(new CallNumberBrowseResult()
+      .totalRecords(6).prev(null).next("CE 216 B6724 541993").items(List.of(
+        cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993"),
+        cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993", true)
+      )));
+  }
+
+  @Test
+  void browseByCallNumberNlm_browsingAroundWhenPrecedingRecordsCountIsSpecified() {
+    var request = get(instanceCallNumberBrowsePath())
+      .param("query",
+        prepareQuery("typedCallNumber < {value} or typedCallNumber >= {value}", "\"AC 11 E8 NO 14 P S1487\""))
+      .param("callNumberType", "nlm")
+      .param("limit", "5")
+      .param("expandAll", "true")
+      .param("precedingRecordsCount", "4");
+    var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
+    assertThat(actual).isEqualTo(new CallNumberBrowseResult()
+      .totalRecords(4).prev(null).next(null).items(List.of(
+        cnBrowseItem(instance("instance #25"), "AC 11 A4 VOL 235"),
+        cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
+        cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487", true)
+      )));
+  }
+
+  @Test
+  void browseByCallNumberSudoc_browsingAroundWhenPrecedingRecordsCountIsSpecified() {
+    var request = get(instanceCallNumberBrowsePath())
+      .param("query", prepareQuery("typedCallNumber < {value} or typedCallNumber >= {value}", "\"PR 44034 B38 41993\""))
+      .param("callNumberType", "sudoc")
+      .param("limit", "5")
+      .param("expandAll", "true")
+      .param("precedingRecordsCount", "4");
+    var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
+    assertThat(actual).isEqualTo(new CallNumberBrowseResult()
+      .totalRecords(5).prev(null).next(null).items(List.of(
+        cnBrowseItem(instance("instance #12"), "DC 211 N52 VOL 14"),
+        cnBrowseItem(instance("instance #10"), "DC 3201 B34 41972"),
+        cnBrowseItem(instance("instance #17"), "GA 16 A63 41581"),
+        cnBrowseItem(instance("instance #16"), "PR 44034 B38 41993", true)
+      )));
+  }
+
+  @Test
+  void browseByCallNumberLocal_browsingAroundWhenPrecedingRecordsCountIsSpecified() {
+    var request = get(instanceCallNumberBrowsePath())
+      .param("query",
+        prepareQuery("typedCallNumber < {value} or typedCallNumber >= {value}", "\"F  PR1866.S63 V.1 C.1\""))
+      .param("callNumberType", "local")
+      .param("limit", "5")
+      .param("expandAll", "true")
+      .param("precedingRecordsCount", "4");
+    var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
+    assertThat(actual).isEqualTo(new CallNumberBrowseResult()
+      .totalRecords(12).prev("DB 211 A66 SUPPL NO 211").next("F  PR1866.S63 V.1 C.1").items(List.of(
+        cnBrowseItem(instance("instance #23"), "DB 11 A66 SUPPL NO 11"),
+        cnBrowseItem(instance("instance #35"), "E 12.11 I12 288 D"),
+        cnBrowseItem(instance("instance #33"), "E 12.11 I2 298"),
+        cnBrowseItem(instance("instance #27"), "E 211 A506"),
+        cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1", true)
+      )));
+  }
+
+  @Test
+  void browseByCallNumberLocal_browsingForwardIncluding() {
+    var request = get(instanceCallNumberBrowsePath())
+      .param("query", prepareQuery("itemEffectiveShelvingOrder >= {value}", "\"F  PR1866.S63 V.1 C.1\""))
+      .param("callNumberType", "local")
+      .param("limit", "5")
+      .param("expandAll", "true");
+    var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
+    assertThat(actual).isEqualTo(new CallNumberBrowseResult()
+      .totalRecords(5).prev("F  PR1866.S63 V.1 C.1").next(null).items(List.of(
+        cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1"),
+        cnBrowseItem(instance("instance #37"), "FC 17 B89"),
+        cnBrowseItem(instance("instance #30"), "GA 16 G32 41557 V1"),
+        cnBrowseItem(instance("instance #26"), "PR 17 I55 42006"),
+        cnBrowseItem(instance("instance #40"), "PR 213 E5 41999")
+      )));
+  }
+
+  private static Instance[] instances() {
+    return callNumberBrowseInstanceData().stream()
+      .map(BrowseTypedCallNumberIT::instance)
+      .toArray(Instance[]::new);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Instance instance(List<Object> data) {
+    var items = ((List<String>) data.get(1)).stream()
+      .map(callNumber -> new Item()
+        .id(randomId())
+        .discoverySuppress(false)
+        .effectiveCallNumberComponents(new ItemEffectiveCallNumberComponents().callNumber(callNumber))
+        .effectiveShelvingOrder(getShelfKeyFromCallNumber(callNumber))
+        .itemLevelCallNumberTypeId(data.get(2).toString()))
+      .toList();
+
+    return new Instance()
+      .id(randomId())
+      .title((String) data.get(0))
+      .staffSuppress(false)
+      .discoverySuppress(false)
+      .isBoundWith(false)
+      .items(items)
+      .holdings(emptyList());
+  }
+
+  private static Instance instance(String title) {
+    return INSTANCE_MAP.get(title);
+  }
+
+  private static List<List<Object>> callNumberBrowseInstanceData() {
+    return List.of(
+      List.of("instance #01", List.of("DA 3880 O6 J72"), LC.getId()),
+      List.of("instance #02", List.of("DA 3880 O6 M96"), LC.getId()),
+      List.of("instance #03", List.of("DA 3880 O6 L5 41955"), LC.getId()),
+      List.of("instance #04", List.of("CE 16 D86 X 41998"), DEWEY.getId()),
+      List.of("instance #05", List.of("DA 3880 O6 M15"), LC.getId()),
+      List.of("instance #06", List.of("DA 3880 O6 L6 V1"), LC.getId()),
+      List.of("instance #07", List.of("DA 3870 H47 41975"), LC.getId()),
+      List.of("instance #08", List.of("AC 11 A67 X 42000"), NLM.getId()),
+      List.of("instance #09", List.of("DA 3700 C95 NO 18"), LC.getId()),
+      List.of("instance #10", List.of("DC 3201 B34 41972"), SUDOC.getId()),
+      List.of("instance #11", List.of("DA 3880 K56 M27 41984"), LC.getId()),
+      List.of("instance #12", List.of("DC 211 N52 VOL 14"), SUDOC.getId()),
+      List.of("instance #13", List.of("DA 3880 O6 M81"), LC.getId()),
+      List.of("instance #14", List.of("DA 3890 A1 I72 41885"), LC.getId()),
+      List.of("instance #15", List.of("DA 3880 O6 L76"), LC.getId()),
+      List.of("instance #16", List.of("PR 44034 B38 41993"), SUDOC.getId()),
+      List.of("instance #17", List.of("GA 16 A63 41581"), SUDOC.getId()),
+      List.of("instance #18", List.of("AC 11 E8 NO 14 P S1487"), NLM.getId()),
+      List.of("instance #19", List.of("DA 3890 A2 F57 42011"), LC.getId()),
+      List.of("instance #20", List.of("DA 3880 O6 L75"), LC.getId()),
+      List.of("instance #21", List.of("FC 17 B89"), OTHER.getId()),
+      List.of("instance #22", List.of("DA 3890 A2 B76 42002"), LC.getId()),
+      List.of("instance #23", List.of("DB 11 A66 SUPPL NO 11"), LOCAL_TYPE_1),
+      List.of("instance #24", List.of("DA 3900 C39 NO 11"), LC.getId()),
+      List.of("instance #25", List.of("AC 11 A4 VOL 235"), NLM.getId()),
+      List.of("instance #26", List.of("PR 17 I55 42006"), LOCAL_TYPE_1),
+      List.of("instance #27", List.of("E 211 A506"), LOCAL_TYPE_1),
+      List.of("instance #28", List.of("DB 11 A31 BD 3124"), LOCAL_TYPE_2),
+      List.of("instance #29", List.of("DA 3880 O6 D5"), LC.getId()),
+      List.of("instance #30", List.of("GA 16 G32 41557 V1"), LOCAL_TYPE_2),
+      List.of("instance #31", List.of("AB 14 C72 NO 220"), LOCAL_TYPE_1),
+      List.of("instance #32", List.of("DA 3880 O5 C3 V1"), LC.getId()),
+      List.of("instance #33", List.of("E 12.11 I2 298"), LOCAL_TYPE_1),
+      List.of("instance #34", List.of("DA 3900 C89 V1"), LC.getId()),
+      List.of("instance #35", List.of("E 12.11 I12 288 D"), LOCAL_TYPE_2),
+      List.of("instance #36", List.of("DA 3700 B91 L79"), LC.getId()),
+      List.of("instance #37", List.of("FC 17 B89"), LOCAL_TYPE_2),
+      List.of("instance #38", List.of("CE 210 K297 41858"), DEWEY.getId()),
+      List.of("instance #39", List.of("GA 16 D64 41548A"), OTHER.getId()),
+      List.of("instance #40", List.of("PR 213 E5 41999"), LOCAL_TYPE_2),
+      List.of("instance #41", List.of("DA 3870 B55 41868"), LC.getId()),
+      List.of("instance #42", List.of("FA 46252 3977 12 237"), OTHER.getId()),
+      List.of("instance #43", List.of("FA 42010 3546 256"), OTHER.getId()),
+      List.of("instance #44", List.of("CE 16 B6713 X 41993"), DEWEY.getId()),
+      List.of("instance #45", List.of("CE 16 B6724 41993"), DEWEY.getId()),
+      List.of("instance #46", List.of("F  PR1866.S63 V.1 C.1"), LOCAL_TYPE_1)
+    );
+  }
+}

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseQueryProviderTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseQueryProviderTest.java
@@ -95,7 +95,8 @@ class CallNumberBrowseQueryProviderTest {
   void get_positive_forwardWithEnabledOptimization() {
     var size = 25;
     when(queryConfiguration.isCallNumberBrowseOptimizationEnabled()).thenReturn(true);
-    when(browseRangeService.getRangeBoundaryForBrowsing(TENANT_ID, ANCHOR, size, true)).thenReturn(Optional.of(100L));
+    when(browseRangeService.getRangeBoundaryForBrowsing(TENANT_ID, ANCHOR, RANGE_FIELD, -1, size, true))
+      .thenReturn(Optional.of(100L));
 
     var context = BrowseContext.builder().anchor(ANCHOR).succeedingLimit(5).build();
     var actual = mockCallNumberConversion(() -> queryProvider.get(request(true), context, true));
@@ -130,7 +131,8 @@ class CallNumberBrowseQueryProviderTest {
   void get_positive_backwardWithEnabledOptimization() {
     var size = 25;
     when(queryConfiguration.isCallNumberBrowseOptimizationEnabled()).thenReturn(true);
-    when(browseRangeService.getRangeBoundaryForBrowsing(TENANT_ID, ANCHOR, size, false)).thenReturn(Optional.of(100L));
+    when(browseRangeService.getRangeBoundaryForBrowsing(TENANT_ID, ANCHOR, RANGE_FIELD, -1, size, false))
+      .thenReturn(Optional.of(100L));
 
     var context = BrowseContext.builder().anchor(ANCHOR).precedingLimit(5).build();
     var actual = mockCallNumberConversion(() -> queryProvider.get(request(true), context, false));
@@ -148,7 +150,7 @@ class CallNumberBrowseQueryProviderTest {
   }
 
   private static SearchSourceBuilder expectedSucceedingQuery(int size) {
-    return expectedSucceedingQuery(size, rangeQuery(RANGE_FIELD).gte(ANCHOR_AS_NUMBER));
+    return expectedSucceedingQuery(size, rangeQuery(RANGE_FIELD).gte(ANCHOR_AS_NUMBER).lte(0L));
   }
 
   private static SearchSourceBuilder expectedSucceedingQuery(int size, QueryBuilder queryBuilder) {
@@ -157,7 +159,7 @@ class CallNumberBrowseQueryProviderTest {
   }
 
   private static SearchSourceBuilder expectedPrecedingQuery(int size) {
-    return expectedPrecedingQuery(size, rangeQuery(RANGE_FIELD).lte(ANCHOR_AS_NUMBER));
+    return expectedPrecedingQuery(size, rangeQuery(RANGE_FIELD).gte(0L).lte(ANCHOR_AS_NUMBER));
   }
 
   private static SearchSourceBuilder expectedPrecedingQuery(int size, QueryBuilder queryBuilder) {
@@ -166,7 +168,12 @@ class CallNumberBrowseQueryProviderTest {
   }
 
   private static BrowseRequest request(boolean expandAll) {
-    return BrowseRequest.builder().resource(RESOURCE_NAME).tenantId(TENANT_ID).expandAll(expandAll).build();
+    return BrowseRequest.builder()
+      .resource(RESOURCE_NAME)
+      .tenantId(TENANT_ID)
+      .subField("callNumber")
+      .expandAll(expandAll)
+      .build();
   }
 
   private static String precedingQuerySortScript() {

--- a/src/test/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessorTest.java
@@ -4,12 +4,7 @@ import static org.apache.commons.collections4.SetUtils.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.client.InventoryReferenceDataClient.ReferenceDataType.CALL_NUMBER_TYPES;
 import static org.folio.search.model.client.CqlQueryParam.SOURCE;
-import static org.folio.search.service.setter.item.ItemTypedCallNumberProcessor.DEWEY_ID;
-import static org.folio.search.service.setter.item.ItemTypedCallNumberProcessor.LC_ID;
 import static org.folio.search.service.setter.item.ItemTypedCallNumberProcessor.LOCAL_CALL_NUMBER_TYPES_SOURCES;
-import static org.folio.search.service.setter.item.ItemTypedCallNumberProcessor.NLM_ID;
-import static org.folio.search.service.setter.item.ItemTypedCallNumberProcessor.OTHER_SCHEME_ID;
-import static org.folio.search.service.setter.item.ItemTypedCallNumberProcessor.SUDOC_ID;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -19,6 +14,7 @@ import java.util.stream.Stream;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.integration.ReferenceDataService;
+import org.folio.search.model.types.CallNumberType;
 import org.folio.spring.test.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,26 +33,6 @@ class ItemTypedCallNumberProcessorTest {
 
   private @InjectMocks ItemTypedCallNumberProcessor processor;
 
-  private static Instance instance(Item... items) {
-    return new Instance().items(List.of(items));
-  }
-
-  private static Item item(String effectiveShelvingOrder, String callNumberTypeId) {
-    return new Item().effectiveShelvingOrder(effectiveShelvingOrder).itemLevelCallNumberTypeId(callNumberTypeId);
-  }
-
-  public static Stream<Arguments> emptyCallNumberAfterProcessingSource() {
-    return Stream.of(
-      Arguments.arguments(null, null),
-      Arguments.arguments("", ""),
-      Arguments.arguments("", LC_ID),
-      Arguments.arguments("AAA", ""),
-      Arguments.arguments(null, LC_ID),
-      Arguments.arguments("AAA", null),
-      Arguments.arguments("()[]", LC_ID)
-    );
-  }
-
   @Test
   void getFieldValue_multipleValue_positive() {
     var localCnId = UUID.randomUUID().toString();
@@ -65,19 +41,19 @@ class ItemTypedCallNumberProcessorTest {
       .thenReturn(Set.of(localCnId));
     var eventBody = instance(
       item("HD 11", localCnId),
-      item("HD 11", LC_ID),
-      item("HD 11", DEWEY_ID),
-      item("HD 11", NLM_ID),
-      item("HD 11", SUDOC_ID),
-      item("HD 11", OTHER_SCHEME_ID)
+      item("HD 11", CallNumberType.LC.getId()),
+      item("HD 11", CallNumberType.DEWEY.getId()),
+      item("HD 11", CallNumberType.NLM.getId()),
+      item("HD 11", CallNumberType.SUDOC.getId()),
+      item("HD 11", CallNumberType.OTHER.getId())
     );
     var actual = processor.getFieldValue(eventBody);
-    assertThat(actual).containsExactly(84787310808212480L,
-      229342416757269504L,
+    assertThat(actual).containsExactly(229342416757269504L,
       373897522706326528L,
       518452628655383552L,
       663007734604440576L,
-      807562840553497600L);
+      807562840553497600L,
+      952117946502554624L);
   }
 
   @ParameterizedTest
@@ -95,5 +71,24 @@ class ItemTypedCallNumberProcessorTest {
     var eventBody = instance(item("AA 123", UUID.randomUUID().toString()));
     var actual = processor.getFieldValue(eventBody);
     assertThat(actual).isEmpty();
+  }
+
+  public static Stream<Arguments> emptyCallNumberAfterProcessingSource() {
+    return Stream.of(
+      Arguments.arguments(null, null),
+      Arguments.arguments("", ""),
+      Arguments.arguments("", CallNumberType.LC.getId()),
+      Arguments.arguments("AAA", ""),
+      Arguments.arguments(null, CallNumberType.LC.getId()),
+      Arguments.arguments("AAA", null)
+    );
+  }
+
+  private static Instance instance(Item... items) {
+    return new Instance().items(List.of(items));
+  }
+
+  private static Item item(String effectiveShelvingOrder, String callNumberTypeId) {
+    return new Item().effectiveShelvingOrder(effectiveShelvingOrder).itemLevelCallNumberTypeId(callNumberTypeId);
   }
 }

--- a/src/test/resources/mappings/inventory.json
+++ b/src/test/resources/mappings/inventory.json
@@ -145,6 +145,16 @@
               "id": "5ba6b62e-6858-490a-8102-5b1369873835",
               "name": "Shelving control number",
               "source": "local"
+            },
+            {
+              "id": "6fd29f52-5c9c-44d0-b529-e9c5eb3a0aba",
+              "name": "Mykolaiv local number",
+              "source": "local"
+            },
+            {
+              "id": "654d7565-b277-4dfa-8b7d-fbf306d9d0cd",
+              "name": "Kharkiv local number",
+              "source": "local"
             }
           ]
         },


### PR DESCRIPTION
## Purpose
Create endpoint to support call-numbers browse by types

## Approach
- Design API endpoint `/browse/call-numbers-{callNumberType}/instances` 
- Add logic to CallNumberBrowseQueryProvider and CallNumberBrowseRangeService to support new type of browse

### Changes checklist
- [x] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [x] Interface versions changes
- [ ] Interface dependencies added, or removed
- [x] Permissions changed, added, or removed
- [ ] Check logging.
