### PR TITLE
MSEARCH-520 Allow long queries for POST /search/resources/jobs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 ### Features
 * Extend call-numbers browse endpoint to support filtering by types ([MSEARCH-514](https://issues.folio.org/browse/MSEARCH-514))
+* Endpoint POST /search/resources/jobs have to be able to use long queries ([MSEARCH-520](https://issues.folio.org/browse/MSEARCH-520))
 
 ### Tech Dept
 * Change logic of linked titles count on authority search/browse ([MSEARCH-501](https://issues.folio.org/browse/MSEARCH-501))

--- a/src/main/resources/changelog/changelog-master.xml
+++ b/src/main/resources/changelog/changelog-master.xml
@@ -5,4 +5,5 @@
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
   <include file="changes/initial_schema.xml" relativeToChangelogFile="true"/>
+  <include file="changes/v2.1/change_resource_ids_job_query_type.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog/changes/v2.1/change_resource_ids_job_query_type.xml
+++ b/src/main/resources/changelog/changes/v2.1/change_resource_ids_job_query_type.xml
@@ -1,0 +1,17 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <changeSet id="MSEARCH-520@@change_resource_ids_job_query_type" author="Viacheslav_Kolesnyk">
+    <preConditions onFail="MARK_RAN">
+        <tableExists tableName="resource_ids_job"/>
+    </preConditions>
+
+    <comment>Change query column type of resource_ids_job table from varchar(255) to text for long query support</comment>
+
+    <modifyDataType tableName="resource_ids_job" columnName="query" newDataType="text"/>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Purpose
Endpoint POST /search/resources/jobs have to be able to start a job if the query is longer than 255 characters.

## Approach
- Add liquibase script to change 'query' column type to 'text'

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
[MSEARCH-520](https://issues.folio.org/browse/MSEARCH-520)
