### PR TITLE
MSEARCH-437 Extend `reindex` endpoint with passing index settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
 ## v2.1.0 In progress
 ### New APIs versions
 * Remove required `instance-authority-links`
+* Provides `indices v0.5`
 
 ### Features
 * Extend call-numbers browse endpoint to support filtering by types ([MSEARCH-514](https://issues.folio.org/browse/MSEARCH-514))
 * Endpoint POST /search/resources/jobs have to be able to use long queries ([MSEARCH-520](https://issues.folio.org/browse/MSEARCH-520))
+* Extend `reindex` endpoint with passing index settings  ([MSEARCH-437](https://issues.folio.org/browse/MSEARCH-437))
 
 ### Tech Dept
 * Change logic of linked titles count on authority search/browse ([MSEARCH-501](https://issues.folio.org/browse/MSEARCH-501))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "indices",
-      "version": "0.4",
+      "version": "0.5",
       "handlers": [
         {
           "methods": [ "POST" ],

--- a/src/main/java/org/folio/search/service/es/SearchSettingsHelper.java
+++ b/src/main/java/org/folio/search/service/es/SearchSettingsHelper.java
@@ -1,5 +1,6 @@
 package org.folio.search.service.es;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.SerializationException;
@@ -23,11 +24,21 @@ public class SearchSettingsHelper {
    * @return elasticsearch settings as {@link String} object with JSON object inside
    */
   public String getSettings(String resource) {
+    return getSettingsJson(resource).toString();
+  }
+
+  /**
+   * Provides elasticsearch settings for given resource name.
+   *
+   * @param resource resource name as {@link String} object
+   * @return elasticsearch settings as {@link JsonNode} object
+   */
+  public JsonNode getSettingsJson(String resource) {
     log.debug("getSettings:: by [resource: {}]", resource);
 
     var resourceSettings = localFileProvider.read(getIndexSettingsPath(resource));
     try {
-      return jsonConverter.asJsonTree(resourceSettings).toString();
+      return jsonConverter.asJsonTree(resourceSettings);
     } catch (SerializationException e) {
       throw new ResourceDescriptionException(String.format(
         "Failed to load resource index settings [resourceName: %s], msg: %s", resource, e.getMessage()));

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -361,7 +361,7 @@ paths:
           application/json:
             example: examples/reindexRequest.sample
             schema:
-              $ref: schemas/request/reindexRequest.json
+              $ref: '#/components/schemas/reindexRequest'
       parameters:
         - $ref: '#/components/parameters/x-okapi-tenant-header'
       responses:

--- a/src/main/resources/swagger.api/schemas/indexSettings.json
+++ b/src/main/resources/swagger.api/schemas/indexSettings.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Elasticsearch/Opensearch index settings",
+  "type": "object",
+  "properties": {
+    "numberOfShards": {
+      "type": "integer",
+      "description": "The number of primary shards that an index should have.",
+      "minimum": 1,
+      "maximum": 100
+    },
+    "numberOfReplicas": {
+      "type": "integer",
+      "description": "The number of replicas each primary shard has.",
+      "minimum": 1,
+      "maximum": 100
+    },
+    "refreshInterval": {
+      "type": "integer",
+      "description": "How often to make new changes to the index visible to search (seconds). '-1' disables refresh.",
+      "minimum": -1,
+      "maximum": 3600
+    }
+  }
+}

--- a/src/main/resources/swagger.api/schemas/request/reindexRequest.json
+++ b/src/main/resources/swagger.api/schemas/request/reindexRequest.json
@@ -12,6 +12,10 @@
       "type": "string",
       "description": "Resource name to run reindex for",
       "default": "instance"
+    },
+    "indexSettings": {
+      "description": "Index settings to apply for index",
+      "$ref": "../indexSettings.json"
     }
   }
 }

--- a/src/test/java/org/folio/search/utils/TestConstants.java
+++ b/src/test/java/org/folio/search/utils/TestConstants.java
@@ -4,6 +4,8 @@ import static org.folio.search.utils.SearchUtils.getResourceName;
 import static org.folio.search.utils.TestUtils.randomId;
 import static org.folio.spring.tools.config.properties.FolioEnvironment.getFolioEnvName;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.folio.search.utils.TestUtils.TestResource;
@@ -16,6 +18,7 @@ public class TestConstants {
   public static final String RESOURCE_ID = "d148dd82-56b0-4ddb-a638-83ca1ee97e0a";
   public static final String RESOURCE_ID_SECOND = "d148dd82-56b0-4ddb-a638-83ca1ee97e0b";
   public static final String EMPTY_OBJECT = "{}";
+  public static final JsonNode EMPTY_JSON_OBJECT = JsonNodeFactory.instance.objectNode();
   public static final String RESOURCE_NAME = getResourceName(TestResource.class);
   public static final String INDEX_NAME = String.join("_", ENV, RESOURCE_NAME, TENANT_ID);
 


### PR DESCRIPTION
## Purpose
Extend `reindex` endpoint with passing index settings
[MSEARCH-437](https://issues.folio.org/browse/MSEARCH-437)

## Approach
- Add index settings to `reindex` endpoint

### Changes checklist
- [x] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [x] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
