### PR TITLE
MSEARCH-523 Include call number type id from Holdings in Items record when not specified

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 ## v2.1.0 In progress
 ### New APIs versions
 * Remove required `instance-authority-links`
+* Provides `search v1.1`
+* Provides `browse v1.2`
 
 ### Features
 * Extend call-numbers browse endpoint to support filtering by types ([MSEARCH-514](https://issues.folio.org/browse/MSEARCH-514))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -39,7 +39,7 @@
     },
     {
       "id": "search",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [ "GET" ],
@@ -91,7 +91,7 @@
     },
     {
       "id": "browse",
-      "version": "1.1",
+      "version": "1.2",
       "handlers": [
         {
           "methods": [ "GET" ],

--- a/src/main/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessor.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
+import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
 import org.folio.search.integration.ReferenceDataService;
 import org.folio.search.model.types.CallNumberType;
 import org.folio.search.service.setter.FieldProcessor;
@@ -47,7 +48,9 @@ public class ItemTypedCallNumberProcessor implements FieldProcessor<Instance, Se
 
   private Long toCallNumberLongRepresentation(Item item) {
     var effectiveShelvingOrder = item.getEffectiveShelvingOrder();
-    var callNumberTypeId = item.getItemLevelCallNumberTypeId();
+    var callNumberTypeId = Optional.ofNullable(item.getEffectiveCallNumberComponents())
+      .map(ItemEffectiveCallNumberComponents::getTypeId)
+      .orElse(null);
     if (StringUtils.isAnyBlank(callNumberTypeId, effectiveShelvingOrder)) {
       return null;
     } else {

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -321,6 +321,10 @@
             "suffix": {
               "index": "source",
               "showInResponse": [ "search", "call-number-browse" ]
+            },
+            "typeId": {
+              "index": "source",
+              "showInResponse": [ "search", "call-number-browse" ]
             }
           }
         },

--- a/src/main/resources/swagger.api/schemas/item.json
+++ b/src/main/resources/swagger.api/schemas/item.json
@@ -67,6 +67,10 @@
         "suffix": {
           "type": "string",
           "description": "Effective Call Number Suffix is the suffix of the identifier assigned to an item or its holding and associated with the item."
+        },
+        "typeId": {
+          "type": "string",
+          "description": "Effective Call Number Type Id is the call number type id of the item, if available, otherwise that of the holding."
         }
       }
     },

--- a/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIT.java
@@ -170,9 +170,9 @@ class BrowseTypedCallNumberIT extends BaseIntegrationTest {
       .map(callNumber -> new Item()
         .id(randomId())
         .discoverySuppress(false)
-        .effectiveCallNumberComponents(new ItemEffectiveCallNumberComponents().callNumber(callNumber))
-        .effectiveShelvingOrder(getShelfKeyFromCallNumber(callNumber))
-        .itemLevelCallNumberTypeId(data.get(2).toString()))
+        .effectiveCallNumberComponents(new ItemEffectiveCallNumberComponents()
+          .callNumber(callNumber).typeId(data.get(2).toString()))
+        .effectiveShelvingOrder(getShelfKeyFromCallNumber(callNumber)))
       .toList();
 
     return new Instance()

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -169,7 +169,8 @@ class SearchInstanceIT extends BaseIntegrationTest {
 
   private static ItemEffectiveCallNumberComponents callNumber(String prefix, String suffix) {
     return new ItemEffectiveCallNumberComponents().prefix(prefix).suffix(suffix)
-      .callNumber("TK5105.88815 . A58 2004 FT MEADE");
+      .callNumber("TK5105.88815 . A58 2004 FT MEADE")
+      .typeId("512173a7-bd09-490e-b773-17d83f2b63fe");
   }
 
   private static Stream<Arguments> testDataProvider() {

--- a/src/test/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessorTest.java
@@ -1,6 +1,5 @@
 package org.folio.search.service.setter.item;
 
-import static org.apache.commons.collections4.SetUtils.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.client.InventoryReferenceDataClient.ReferenceDataType.CALL_NUMBER_TYPES;
 import static org.folio.search.model.client.CqlQueryParam.SOURCE;
@@ -13,6 +12,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
+import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
 import org.folio.search.integration.ReferenceDataService;
 import org.folio.search.model.types.CallNumberType;
 import org.folio.spring.test.type.UnitTest;
@@ -66,8 +66,6 @@ class ItemTypedCallNumberProcessorTest {
 
   @Test
   void getFieldValue_emptyCallNumberIfNotSystemOrNotLocal() {
-    when(referenceDataService.fetchReferenceData(CALL_NUMBER_TYPES, SOURCE, LOCAL_CALL_NUMBER_TYPES_SOURCES))
-      .thenReturn(emptySet());
     var eventBody = instance(item("AA 123", UUID.randomUUID().toString()));
     var actual = processor.getFieldValue(eventBody);
     assertThat(actual).isEmpty();
@@ -89,6 +87,8 @@ class ItemTypedCallNumberProcessorTest {
   }
 
   private static Item item(String effectiveShelvingOrder, String callNumberTypeId) {
-    return new Item().effectiveShelvingOrder(effectiveShelvingOrder).itemLevelCallNumberTypeId(callNumberTypeId);
+    return new Item()
+      .effectiveShelvingOrder(effectiveShelvingOrder)
+      .effectiveCallNumberComponents(new ItemEffectiveCallNumberComponents().typeId(callNumberTypeId));
   }
 }


### PR DESCRIPTION
## Purpose
For browsing by call number type, the Item needs to appear under the Call number type specified either in the Item record or inherited from the Holdings record 
[MSEARCH-523](https://issues.folio.org/browse/MSEARCH-523)

## Approach
- Use item.effectiveCallNumberComponents.typeId instead of item.itemLevelCallNumberTypeId for item call number type
- Add item.effectiveCallNumberComponents.typeId to search/browse responses

### Changes checklist
- [x] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [x] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
