### PR TITLE
MSEARCH-436 feat(reindex): Create endpoint to update index settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ## v2.1.0 In progress
 ### New APIs versions
 * Remove required `instance-authority-links`
-* Provides `indices v0.5`
+* Provides `indices v0.6`
 * Provides `search v1.1`
 * Provides `browse v1.2`
 
@@ -9,6 +9,7 @@
 * Extend call-numbers browse endpoint to support filtering by types ([MSEARCH-514](https://issues.folio.org/browse/MSEARCH-514))
 * Endpoint POST /search/resources/jobs have to be able to use long queries ([MSEARCH-520](https://issues.folio.org/browse/MSEARCH-520))
 * Extend `reindex` endpoint with passing index settings  ([MSEARCH-437](https://issues.folio.org/browse/MSEARCH-437))
+* Create ` PUT `/search/index/settings` endpoint to update index settings  ([MSEARCH-436](https://issues.folio.org/browse/MSEARCH-436))
 
 ### Tech Dept
 * Change logic of linked titles count on authority search/browse ([MSEARCH-501](https://issues.folio.org/browse/MSEARCH-501))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -34,6 +34,11 @@
             "inventory-storage.instance.reindex.post",
             "authority-storage.authority.reindex.post"
           ]
+        },
+        {
+          "methods": [ "PUT" ],
+          "pathPattern": "/search/index/settings",
+          "permissionsRequired": [ "search.index.settings.item.put" ]
         }
       ]
     },
@@ -233,6 +238,11 @@
       "permissionName": "search.index.records.collection.post",
       "displayName": "Search - saves resource to the search engine",
       "description": "Saves resource to the search engine"
+    },
+    {
+      "permissionName": "search.index.settings.item.put",
+      "displayName": "Search - updates settings for the index",
+      "description": "Updates settings for the index"
     },
     {
       "permissionName": "search.instances.collection.get",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "indices",
-      "version": "0.5",
+      "version": "0.6",
       "handlers": [
         {
           "methods": [ "POST" ],

--- a/src/main/java/org/folio/search/controller/IndexController.java
+++ b/src/main/java/org/folio/search/controller/IndexController.java
@@ -9,6 +9,7 @@ import org.folio.search.domain.dto.FolioIndexOperationResponse;
 import org.folio.search.domain.dto.ReindexJob;
 import org.folio.search.domain.dto.ReindexRequest;
 import org.folio.search.domain.dto.ResourceEvent;
+import org.folio.search.domain.dto.UpdateIndexSettingsRequest;
 import org.folio.search.domain.dto.UpdateMappingsRequest;
 import org.folio.search.rest.resource.IndexApi;
 import org.folio.search.service.IndexService;
@@ -50,5 +51,12 @@ public class IndexController implements IndexApi {
   public ResponseEntity<ReindexJob> reindexInventoryRecords(String tenantId, ReindexRequest request) {
     log.info("Attempting to start reindex for inventory [tenant: {}]", tenantId);
     return ResponseEntity.ok(indexService.reindexInventory(tenantId, request));
+  }
+
+  @Override
+  public ResponseEntity<FolioIndexOperationResponse> updateIndexSettings(String tenantId,
+                                                                         UpdateIndexSettingsRequest request) {
+    return ResponseEntity.ok(indexService.updateIndexSettings(request.getResourceName(), tenantId,
+      request.getIndexSettings()));
   }
 }

--- a/src/main/java/org/folio/search/repository/IndexRepository.java
+++ b/src/main/java/org/folio/search/repository/IndexRepository.java
@@ -15,6 +15,7 @@ import org.folio.search.domain.dto.FolioCreateIndexResponse;
 import org.folio.search.domain.dto.FolioIndexOperationResponse;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.admin.indices.refresh.RefreshRequest;
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.client.indices.CreateIndexRequest;
@@ -54,6 +55,27 @@ public class IndexRepository {
     return createIndexResponse.isAcknowledged()
       ? getSuccessFolioCreateIndexResponse(List.of(index))
       : getErrorFolioCreateIndexResponse(List.of(index));
+
+  }
+
+  /**
+   * Update index settings {@link UpdateSettingsRequest}.
+   *
+   * @param index    index name as {@link String} object
+   * @param settings settings JSON {@link String} object
+   * @return {@link FolioCreateIndexResponse} object
+   */
+  public FolioIndexOperationResponse updateIndexSettings(String index, String settings) {
+    var updateSettingsRequest = new UpdateSettingsRequest(index)
+      .settings(settings, JSON);
+
+    var updateIndexSettingsResponse = performExceptionalOperation(
+      () -> elasticsearchClient.indices().putSettings(updateSettingsRequest, RequestOptions.DEFAULT),
+      index, "putIndexSettingsApi");
+
+    return updateIndexSettingsResponse.isAcknowledged()
+      ? getSuccessIndexOperationResponse()
+      : getErrorIndexOperationResponse("Failed to put settings");
 
   }
 

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -351,6 +351,26 @@ paths:
                 $ref: '#/components/schemas/folioIndexOperationResponse'
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
+  /index/settings:
+    put:
+      operationId: updateIndexSettings
+      description: Update Index Settings data.
+      parameters:
+        - $ref: '#/components/parameters/x-okapi-tenant-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/updateIndexSettingsRequest'
+      responses:
+        '200':
+          description: Response with updated index settings and status (error message will be present if operation failed)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/folioIndexOperationResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
 
   /index/inventory/reindex:
     post:
@@ -534,6 +554,8 @@ components:
       $ref: schemas/errors.json
     reindexRequest:
       $ref: schemas/request/reindexRequest.json
+    updateIndexSettingsRequest:
+      $ref: schemas/request/updateIndexSettingsRequest.json
     RecordType:
       enum: [ instances, authorities, contributors ]
       type: string

--- a/src/main/resources/swagger.api/schemas/request/updateIndexSettingsRequest.json
+++ b/src/main/resources/swagger.api/schemas/request/updateIndexSettingsRequest.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Update Index Settings request body",
+  "type": "object",
+  "properties": {
+    "resourceName": {
+      "type": "string",
+      "description": "Resource name to run reindex for"
+    },
+    "indexSettings": {
+      "description": "Index settings to apply for index",
+      "$ref": "../indexSettings.json"
+    }
+  },
+  "required": ["resourceName"]
+}

--- a/src/test/java/org/folio/search/repository/IndexRepositoryTest.java
+++ b/src/test/java/org/folio/search/repository/IndexRepositoryTest.java
@@ -27,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.admin.indices.refresh.RefreshRequest;
 import org.opensearch.action.admin.indices.refresh.RefreshResponse;
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.client.IndicesClient;
 import org.opensearch.client.RestHighLevelClient;
@@ -81,6 +82,41 @@ class IndexRepositoryTest {
       .hasCauseExactlyInstanceOf(IOException.class)
       .hasMessage("Failed to perform elasticsearch request "
         + "[index=folio_test-resource_test_tenant, type=createIndexApi, message: err]");
+  }
+
+  @Test
+  void updateIndexSettings_positive() throws IOException {
+    var response = mock(AcknowledgedResponse.class);
+    when(restHighLevelClient.indices()).thenReturn(indices);
+    when(response.isAcknowledged()).thenReturn(true);
+    when(indices.putSettings(any(UpdateSettingsRequest.class), eq(DEFAULT))).thenReturn(response);
+
+    var folioResponse = indexRepository.updateIndexSettings(INDEX_NAME, EMPTY_OBJECT);
+    assertThat(folioResponse).isEqualTo(getSuccessIndexOperationResponse());
+  }
+
+  @Test
+  void updateIndexSettings_negative_failResponse() throws IOException {
+    var esResponse = mock(AcknowledgedResponse.class);
+    when(esResponse.isAcknowledged()).thenReturn(false);
+    when(restHighLevelClient.indices()).thenReturn(indices);
+    when(indices.putSettings(any(UpdateSettingsRequest.class), eq(DEFAULT))).thenReturn(esResponse);
+
+    var response = indexRepository.updateIndexSettings(INDEX_NAME, EMPTY_OBJECT);
+    assertThat(response).isEqualTo(getErrorIndexOperationResponse("Failed to put settings"));
+  }
+
+  @Test
+  void updateIndexSettings_negative_throwsException() throws IOException {
+    when(restHighLevelClient.indices()).thenReturn(indices);
+    when(indices.putSettings(any(UpdateSettingsRequest.class), eq(DEFAULT)))
+      .thenThrow(new IOException("err"));
+
+    assertThatThrownBy(() -> indexRepository.updateIndexSettings(INDEX_NAME, EMPTY_OBJECT))
+      .isInstanceOf(SearchOperationException.class)
+      .hasCauseExactlyInstanceOf(IOException.class)
+      .hasMessage("Failed to perform elasticsearch request "
+        + "[index=folio_test-resource_test_tenant, type=putIndexSettingsApi, message: err]");
   }
 
   @Test


### PR DESCRIPTION
- Create endpoint to update index settings number_of_shards number_of_replicas refresh_interval

Closes: MSEARCH-436

## Purpose
Create endpoint to update index settings

## Approach
- Add new PUT endpoint to update index settings number_of_shards number_of_replicas refresh_interval

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [x] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
