### PR TITLE
MSEARCH-436 feat(reindex): Create endpoint to update index Dynamic settings

### DIFF
--- a/src/main/java/org/folio/search/controller/IndexController.java
+++ b/src/main/java/org/folio/search/controller/IndexController.java
@@ -9,7 +9,7 @@ import org.folio.search.domain.dto.FolioIndexOperationResponse;
 import org.folio.search.domain.dto.ReindexJob;
 import org.folio.search.domain.dto.ReindexRequest;
 import org.folio.search.domain.dto.ResourceEvent;
-import org.folio.search.domain.dto.UpdateIndexSettingsRequest;
+import org.folio.search.domain.dto.UpdateIndexDynamicSettingsRequest;
 import org.folio.search.domain.dto.UpdateMappingsRequest;
 import org.folio.search.rest.resource.IndexApi;
 import org.folio.search.service.IndexService;
@@ -54,8 +54,8 @@ public class IndexController implements IndexApi {
   }
 
   @Override
-  public ResponseEntity<FolioIndexOperationResponse> updateIndexSettings(String tenantId,
-                                                                         UpdateIndexSettingsRequest request) {
+  public ResponseEntity<FolioIndexOperationResponse> updateIndexDynamicSettings(String tenantId,
+                                                                         UpdateIndexDynamicSettingsRequest request) {
     return ResponseEntity.ok(indexService.updateIndexSettings(request.getResourceName(), tenantId,
       request.getIndexSettings()));
   }

--- a/src/main/resources/elasticsearch/index/dynamicSettings.json
+++ b/src/main/resources/elasticsearch/index/dynamicSettings.json
@@ -1,0 +1,7 @@
+{
+  "index": {
+    "number_of_replicas": 2,
+    "refresh_interval": "1s"
+  }
+}
+

--- a/src/main/resources/swagger.api/mod-search.yaml
+++ b/src/main/resources/swagger.api/mod-search.yaml
@@ -353,15 +353,15 @@ paths:
           $ref: '#/components/responses/internalServerErrorResponse'
   /index/settings:
     put:
-      operationId: updateIndexSettings
-      description: Update Index Settings data.
+      operationId: updateIndexDynamicSettings
+      description: Update Index Dynamic Settings data.
       parameters:
         - $ref: '#/components/parameters/x-okapi-tenant-header'
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/updateIndexSettingsRequest'
+              $ref: '#/components/schemas/updateIndexDynamicSettingsRequest'
       responses:
         '200':
           description: Response with updated index settings and status (error message will be present if operation failed)
@@ -554,8 +554,8 @@ components:
       $ref: schemas/errors.json
     reindexRequest:
       $ref: schemas/request/reindexRequest.json
-    updateIndexSettingsRequest:
-      $ref: schemas/request/updateIndexSettingsRequest.json
+    updateIndexDynamicSettingsRequest:
+      $ref: schemas/request/updateIndexDynamicSettingsRequest.json
     RecordType:
       enum: [ instances, authorities, contributors ]
       type: string

--- a/src/main/resources/swagger.api/schemas/indexDynamicSettings.json
+++ b/src/main/resources/swagger.api/schemas/indexDynamicSettings.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Elasticsearch/Opensearch index dynamic settings",
+  "type": "object",
+  "properties": {
+    "numberOfReplicas": {
+      "type": "integer",
+      "description": "The number of replicas each primary shard has.",
+      "minimum": 1,
+      "maximum": 100
+    },
+    "refreshInterval": {
+      "type": "integer",
+      "description": "How often to make new changes to the index visible to search (seconds). '-1' disables refresh.",
+      "minimum": -1,
+      "maximum": 3600
+    }
+  }
+}

--- a/src/main/resources/swagger.api/schemas/request/updateIndexDynamicSettingsRequest.json
+++ b/src/main/resources/swagger.api/schemas/request/updateIndexDynamicSettingsRequest.json
@@ -5,11 +5,11 @@
   "properties": {
     "resourceName": {
       "type": "string",
-      "description": "Resource name to run reindex for"
+      "description": "Resource name to set index Settings"
     },
     "indexSettings": {
       "description": "Index settings to apply for index",
-      "$ref": "../indexSettings.json"
+      "$ref": "../indexDynamicSettings.json"
     }
   },
   "required": ["resourceName"]

--- a/src/test/java/org/folio/search/controller/IndexControllerTest.java
+++ b/src/test/java/org/folio/search/controller/IndexControllerTest.java
@@ -23,10 +23,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import org.folio.search.domain.dto.CreateIndexRequest;
-import org.folio.search.domain.dto.IndexSettings;
+import org.folio.search.domain.dto.IndexDynamicSettings;
 import org.folio.search.domain.dto.ReindexJob;
 import org.folio.search.domain.dto.ReindexRequest;
-import org.folio.search.domain.dto.UpdateIndexSettingsRequest;
+import org.folio.search.domain.dto.UpdateIndexDynamicSettingsRequest;
 import org.folio.search.domain.dto.UpdateMappingsRequest;
 import org.folio.search.exception.SearchOperationException;
 import org.folio.search.service.IndexService;
@@ -165,7 +165,7 @@ class IndexControllerTest {
 
   @Test
   void updateIndexSettings_positive() throws Exception {
-    when(indexService.updateIndexSettings(RESOURCE_NAME, TENANT_ID, createIndexSettings()))
+    when(indexService.updateIndexSettings(RESOURCE_NAME, TENANT_ID, createIndexDynamicSettings()))
       .thenReturn(getSuccessIndexOperationResponse());
     mockMvc.perform(preparePutRequest("/search/index/settings", asJsonString(updateIndexSettingsRequest())))
       .andExpect(status().isOk())
@@ -269,11 +269,12 @@ class IndexControllerTest {
     return new UpdateMappingsRequest().resourceName(RESOURCE_NAME);
   }
 
-  private static UpdateIndexSettingsRequest updateIndexSettingsRequest() {
-    return new UpdateIndexSettingsRequest().resourceName(RESOURCE_NAME).indexSettings(createIndexSettings());
+  private static UpdateIndexDynamicSettingsRequest updateIndexSettingsRequest() {
+    return new UpdateIndexDynamicSettingsRequest().resourceName(RESOURCE_NAME)
+        .indexSettings(createIndexDynamicSettings());
   }
 
-  private static IndexSettings createIndexSettings() {
-    return new IndexSettings().numberOfReplicas(2).numberOfShards(1).refreshInterval(1);
+  private static IndexDynamicSettings createIndexDynamicSettings() {
+    return new IndexDynamicSettings().numberOfReplicas(2).refreshInterval(1);
   }
 }


### PR DESCRIPTION

## Purpose
Create endpoint to update index Dynamic settings

## Approach
Removed numberOfShards property from the update settings endpoint as it is not available for update dynamically

Closes: MSEARCH-436

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
