### PR TITLE
MSEARCH-526 Fix bug when number of titles response is greater than real

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,11 @@
 ### Features
 * Extend call-numbers browse endpoint to support filtering by types ([MSEARCH-514](https://issues.folio.org/browse/MSEARCH-514))
 * Endpoint POST /search/resources/jobs have to be able to use long queries ([MSEARCH-520](https://issues.folio.org/browse/MSEARCH-520))
-* Extend `reindex` endpoint with passing index settings  ([MSEARCH-437](https://issues.folio.org/browse/MSEARCH-437))
-* Create ` PUT `/search/index/settings` endpoint to update index settings  ([MSEARCH-436](https://issues.folio.org/browse/MSEARCH-436))
+* Extend `reindex` endpoint with passing index settings ([MSEARCH-437](https://issues.folio.org/browse/MSEARCH-437))
+* Create `PUT /search/index/settings` endpoint to update index settings  ([MSEARCH-436](https://issues.folio.org/browse/MSEARCH-436))
+
+### Bug fixes
+* Fix bug when number of titles response is greater than real ([MSEARCH-526](https://issues.folio.org/browse/MSEARCH-526))
 
 ### Tech Dept
 * Change logic of linked titles count on authority search/browse ([MSEARCH-501](https://issues.folio.org/browse/MSEARCH-501))

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -1,0 +1,34 @@
+status = error
+name = PropertiesConfig
+packages = org.folio.spring.logging
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss} [$${folio:requestid:-}] [$${folio:tenantid:-}] [$${folio:userid:-}] [$${folio:moduleid:-}] %-5p %-20.20C{1} %m%n
+
+rootLogger.level = debug
+rootLogger.appenderRefs = debug
+rootLogger.appenderRef.stdout.ref = STDOUT
+
+
+# Debugging elasticsearch client
+loggers=esclient, esclientsniffer, tracer
+
+logger.esclient.name = org.opensearch.client
+logger.esclient.level = trace
+logger.esclient.appenderRefs = stdout
+logger.esclient.appenderRef.stdout.ref = STDOUT
+
+logger.esclientsniffer.name = org.opensearch.client.sniffer
+logger.esclientsniffer.level = trace
+logger.esclientsniffer.appenderRefs = stdout
+logger.esclientsniffer.appenderRef.stdout.ref = STDOUT
+
+logger.tracer.name=tracer
+logger.tracer.level=trace
+logger.tracer.appenderRefs = stdout
+logger.tracer.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
## Purpose
Fix bug when the number of titles response is greater than real

## Approach
For some reason, there could be a situation when the `instances` field of the subjects index is populated with a `null` value. Added actions to prevent such situations.

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.