### PR TITLE
MSEARCH-527: add browse option for NLM call number type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <spring-kafka.version>3.0.7</spring-kafka.version>
     <apache-commons-io.version>2.12.0</apache-commons-io.version>
     <apache-commons-collections.version>4.4</apache-commons-collections.version>
-    <marc4j.version>2.9.2</marc4j.version>
+    <marc4j.version>2.9.4</marc4j.version>
     <lombok.version>1.18.28</lombok.version>
     <lombok.mapstruct-binding.version>0.2.0</lombok.mapstruct-binding.version>
     <streamex.version>0.8.1</streamex.version>

--- a/src/main/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessor.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.marc4j.callnum.CallNumber;
 import org.marc4j.callnum.DeweyCallNumber;
 import org.marc4j.callnum.LCCallNumber;
+import org.marc4j.callnum.NlmCallNumber;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,7 +14,8 @@ public class EffectiveShelvingOrderTermProcessor implements SearchTermProcessor 
 
   @Override
   public String getSearchTerm(String inputTerm) {
-    return getValidShelfKey(new LCCallNumber(inputTerm))
+    return getValidShelfKey(new NlmCallNumber(inputTerm))
+      .or(() -> getValidShelfKey(new LCCallNumber(inputTerm)))
       .or(() -> getValidShelfKey(new DeweyCallNumber(inputTerm)))
       .orElse(normalizeEffectiveShelvingOrder(inputTerm))
       .trim();

--- a/src/test/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessorTest.java
@@ -1,6 +1,8 @@
 package org.folio.search.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.folio.spring.test.type.UnitTest;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -8,6 +10,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.marc4j.callnum.DeweyCallNumber;
 import org.marc4j.callnum.LCCallNumber;
+import org.marc4j.callnum.NlmCallNumber;
 
 @UnitTest
 class EffectiveShelvingOrderTermProcessorTest {
@@ -35,6 +38,38 @@ class EffectiveShelvingOrderTermProcessorTest {
   void getSearchTerm_parameterized_callNumber(String given) {
     var expected = new LCCallNumber(given).getShelfKey();
     var actual = searchTermProcessor.getSearchTerm(given);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "QS 11 .GA1 E53 2005", "QS 11 .GA1 F875d 1999", "QS 11 .GA1 Q6 2012", "QS 11 .GI8 P235s 2006",
+    "QS 124 B811m 1875", "QT 104 B736 2003", "QT 104 B736 2009", "WA 102.5 B62 2018", "WB 102.5 B62 2018",
+    "WC 250 M56 2011", "WC 250 M6 2011"
+    // uncomment the below sample call numbers once the necessary fix is added into marc4j library
+    //"W 100 B5315 2018", "W 600 B5315 2020",
+  })
+  void getSearchTerm_parameterized_validNlmCallNumber(String given) {
+    var expected = new NlmCallNumber(given).getShelfKey().trim();
+    var actual = searchTermProcessor.getSearchTerm(given);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "QA 11 .GA1 E53 2005", "QB 11 .GA1 F875d 1999", "QC 11 .GA1 Q6 2012", "QD 11 .GI8 P235s 2006",
+    "QE 124 B811m 1875", "QF 104 B736 2003", "QG 104 B736 2009", "AB 102.5 B5315 2018", "KDZ 102.5 B62 2018",
+    "BC 102.5 B62 2018", "CD 250 M56 2011", "RD 250 M6 2011", "ZA 11 .GA1 E53 2005"
+  })
+  void getSearchTerm_parameterized_invalidNlmAndValidLcCallNumber(String given) {
+    var lcCallNumber = new LCCallNumber(given);
+    var nlmCallNumber = new NlmCallNumber(given);
+    var expected = lcCallNumber.getShelfKey().trim();
+
+    var actual = searchTermProcessor.getSearchTerm(given);
+
+    assertFalse(nlmCallNumber.isValid());
+    assertTrue(lcCallNumber.isValid());
     assertThat(actual).isEqualTo(expected);
   }
 


### PR DESCRIPTION
Add browse option for National Library of Medicine (NLM) call number type and for this implement normalization for NLM that follows the normalization of LC classification:
- NLM call numbers have the item call number type "National Library of Medicine classification"
- LC call numbers have the item call number type "Library of Congress classification"

## Purpose
_Support browsing by NLM call number type_

## Approach
_Implements normalization for NLM that follows the normalization of LC classification_

### Changes checklist
- [ ] Adjust existing tests and add new ones for the the new implementation 

### Learning
_Closes: [MSEARCH-527](https://issues.folio.org/browse/MSEARCH-527)_
