### PR TITLE
MSEARCH-541: Kafka topic deletion by tenant id added when tenant disabled.

### DIFF
--- a/src/main/java/org/folio/search/service/SearchTenantService.java
+++ b/src/main/java/org/folio/search/service/SearchTenantService.java
@@ -92,6 +92,8 @@ public class SearchTenantService extends TenantService {
       log.info("Removing elasticsearch index [resourceName={}, tenant={}]", name, tenantId);
       indexService.dropIndex(name, tenantId);
     });
+
+    kafkaAdminService.deleteTopics(tenantId);
   }
 
   private void createIndexesAndReindex(TenantAttributes tenantAttributes) {

--- a/src/test/java/org/folio/search/controller/RecordsIndexingIT.java
+++ b/src/test/java/org/folio/search/controller/RecordsIndexingIT.java
@@ -260,7 +260,10 @@ class RecordsIndexingIT extends BaseIntegrationTest {
   }
 
   private static void await(ThrowingRunnable runnable) {
-    Awaitility.await().atMost(ONE_MINUTE).pollInterval(ONE_HUNDRED_MILLISECONDS).untilAsserted(runnable);
+    Awaitility.await()
+      .atMost(ONE_MINUTE)
+      .pollInterval(ONE_HUNDRED_MILLISECONDS)
+      .untilAsserted(runnable);
   }
 
   private static List<String> getRandomIds(int count) {

--- a/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
+++ b/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
@@ -138,6 +138,7 @@ class SearchTenantServiceTest {
     searchTenantService.afterTenantDeletion(tenantAttributes());
 
     verify(indexService).dropIndex(RESOURCE_NAME, TENANT_ID);
+    verify(kafkaAdminService).deleteTopics(TENANT_ID);
     verifyNoMoreInteractions(indexService);
   }
 

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -2,8 +2,8 @@ package org.folio.search.support.base;
 
 import static java.util.Arrays.asList;
 import static org.awaitility.Awaitility.await;
-import static org.awaitility.Durations.ONE_MINUTE;
 import static org.awaitility.Durations.TWO_HUNDRED_MILLISECONDS;
+import static org.awaitility.Durations.TWO_MINUTES;
 import static org.folio.search.support.base.ApiEndpoints.authoritySearchPath;
 import static org.folio.search.support.base.ApiEndpoints.instanceSearchPath;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
@@ -377,7 +377,7 @@ public abstract class BaseIntegrationTest {
   }
 
   protected static void checkThatEventsFromKafkaAreIndexed(String tenantId, String path, int size) {
-    await().atMost(ONE_MINUTE).pollInterval(TWO_HUNDRED_MILLISECONDS).untilAsserted(() ->
+    await().atMost(TWO_MINUTES).pollInterval(TWO_HUNDRED_MILLISECONDS).untilAsserted(() ->
       doSearch(path, tenantId, "cql.allRecords=1", 1, null, null).andExpect(jsonPath("$.totalRecords", is(size))));
   }
 

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -2,8 +2,8 @@ package org.folio.search.support.base;
 
 import static java.util.Arrays.asList;
 import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.ONE_MINUTE;
 import static org.awaitility.Durations.TWO_HUNDRED_MILLISECONDS;
-import static org.awaitility.Durations.TWO_MINUTES;
 import static org.folio.search.support.base.ApiEndpoints.authoritySearchPath;
 import static org.folio.search.support.base.ApiEndpoints.instanceSearchPath;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
@@ -377,7 +377,7 @@ public abstract class BaseIntegrationTest {
   }
 
   protected static void checkThatEventsFromKafkaAreIndexed(String tenantId, String path, int size) {
-    await().atMost(TWO_MINUTES).pollInterval(TWO_HUNDRED_MILLISECONDS).untilAsserted(() ->
+    await().atMost(ONE_MINUTE).pollInterval(TWO_HUNDRED_MILLISECONDS).untilAsserted(() ->
       doSearch(path, tenantId, "cql.allRecords=1", 1, null, null).andExpect(jsonPath("$.totalRecords", is(size))));
   }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -71,27 +71,28 @@ folio:
     core-max-size: ${STREAM_ID_MAX_POOL_SIZE:2}
     core-queue-capacity: ${STREAM_ID_QUEUE_CAPACITY:500}
   kafka:
+    bootstrap-servers: ${spring.embedded.kafka.brokers}
     topics:
       - name: inventory.instance
-        numPartitions: 10
+        numPartitions: 1
         replicationFactor: 1
       - name: inventory.item
-        numPartitions: 10
+        numPartitions: 1
         replicationFactor: 1
       - name: inventory.holdings-record
-        numPartitions: 10
+        numPartitions: 1
         replicationFactor: 1
       - name: inventory.bound-with
-        numPartitions: 10
+        numPartitions: 1
         replicationFactor: 1
       - name: inventory.authority
-        numPartitions: 10
+        numPartitions: 1
         replicationFactor: 1
       - name: search.instance-contributor
-        numPartitions: 10
+        numPartitions: 1
         replicationFactor: 1
       - name: search.instance-subject
-        numPartitions: 10
+        numPartitions: 1
         replicationFactor: 1
     listener:
       events:


### PR DESCRIPTION
## Purpose
Delete tenant related topic when tenant is disabled

## Approach
Added topic deletion part of the method together with test.

### Learning
[MSEARCH-541](https://issues.folio.org/browse/MSEARCH-541)
