### PR TITLE
fix(cn-browse): Call number browse:"Previous" pagination button is disabled.

### DIFF
--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -71,7 +71,7 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
 
     return new BrowseResult<CallNumberBrowseItem>()
       .totalRecords(precedingResult.getTotalRecords() + succeedingResult.getTotalRecords())
-      .prev(getPrevBrowsingValue(precedingResult.getRecords(), context, false))
+      .prev(getPrevBrowsingAroundValue(precedingResult.getRecords(), succeedingResult.getRecords(), context))
       .next(getNextBrowsingValue(succeedingResult.getRecords(), context, true))
       .records(mergeSafelyToList(
         trim(precedingResult.getRecords(), context, false),
@@ -105,6 +105,14 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
       precedingResult = callNumberBrowseResultConverter.convert(searchResponse, context, false);
     }
     return precedingResult;
+  }
+
+  private String getPrevBrowsingAroundValue(List<CallNumberBrowseItem> precedingResult,
+                                            List<CallNumberBrowseItem> succeedingResult, BrowseContext ctx) {
+    if (isEmpty(precedingResult)) {
+      return getPrevBrowsingValue(succeedingResult, ctx, true);
+    }
+    return getPrevBrowsingValue(precedingResult, ctx, false);
   }
 
   private static void highlightMatchingCallNumber(BrowseContext ctx,

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
@@ -89,13 +89,29 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         .param("precedingRecordsCount", "5");
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
-        .totalRecords(32).prev(null).next("CE 216 B6713 X 541993").items(List.of(
+        .totalRecords(32).prev("AB 214 C72 NO 3220").next("CE 216 B6713 X 541993").items(List.of(
             cnBrowseItem(instance("instance #31"), "AB 14 C72 NO 220", true),
             cnBrowseItem(instance("instance #25"), "AC 11 A4 VOL 235"),
             cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
             cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
             cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993")
         )));
+  }
+
+  @Test
+  void browseByCallNumber_browsingAroundWithPrecedingRecordsCountLessThenExistingPrecedingResult() {
+    var request = get(instanceCallNumberBrowsePath())
+      .param("query", prepareQuery("callNumber < {value} or callNumber >= {value}", "\"CE 16 B6713 X 41993\""))
+      .param("limit", "3")
+      .param("expandAll", "true")
+      .param("precedingRecordsCount", "2");
+    var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
+    assertThat(actual).isEqualTo(new CallNumberBrowseResult()
+      .totalRecords(37).prev("AC 211 A67 X 542000").next("CE 216 B6713 X 541993").items(List.of(
+        cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
+        cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
+        cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993", true)
+      )));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Call number browse:"Previous" pagination button is disabled.

## Approach
 fix returning of previous pagination button for an empty preceding result.

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
