### PR TITLE
feat(consortium): add shared, tenantId flags to mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ and [Cross-cluster replication](https://docs.aws.amazon.com/opensearch-service/l
 | STREAM_ID_RETRY_INTERVAL_MS                 | 1000                      | Specifies time to wait before reattempting query.                                                                                                                                     |
 | STREAM_ID_RETRY_ATTEMPTS                    | 3                         | Specifies how many queries attempt to perform after the first one failed.                                                                                                             |
 | CN_BROWSE_OPTIMIZATION_ENABLED              | true                      | Defines if call-number browse optimization is enabled or not                                                                                                                          |
+| CONSORTIUM_ENABLED                          | false                     | Defines if module have to work in consortium mode                                                                                                                                     |
 
 The module uses system user to communicate with other modules from Kafka consumers.
 For production deployments you MUST specify the password for this system user via env variable:
@@ -345,6 +346,12 @@ CQL operators could have modifiers that change search behaviour
 | Operator | Modifier | Usage                            | Description                      |
 |:---------|:---------|:---------------------------------|:---------------------------------|
 | `==`     | `string` | `title ==/string "semantic web"` | Exact match for full text fields |
+
+#### Consortium support
+Consortium feature is disabled by default. To enable it pass to mod-search service following ENV variable:
+```
+CONSORTIUM_ENABLED=true
+```
 
 ### Search API
 

--- a/src/main/java/org/folio/search/service/converter/SearchDocumentConverter.java
+++ b/src/main/java/org/folio/search/service/converter/SearchDocumentConverter.java
@@ -78,6 +78,8 @@ public class SearchDocumentConverter {
     var resourceEvent = context.getResourceEvent();
     var resourceDescriptionFields = context.getResourceDescription().getFields();
     var baseFields = convertMapUsingResourceFields(getNewAsMap(resourceEvent), resourceDescriptionFields, context);
+    // added for testing purposes. tenantId have to be populated only with consortium indexing
+    baseFields.put("tenantId", context.getResourceEvent().getTenant());
     var searchFields = searchFieldsProcessor.getSearchFields(context);
     var resultDocument = mergeSafely(baseFields, searchFields);
     return SearchDocumentBody.of(searchDocumentBodyConverter.apply(resultDocument),

--- a/src/main/java/org/folio/search/service/converter/SearchFieldsProcessor.java
+++ b/src/main/java/org/folio/search/service/converter/SearchFieldsProcessor.java
@@ -49,9 +49,9 @@ public class SearchFieldsProcessor {
 
     var resultMap = new LinkedHashMap<String, Object>();
     searchFields.forEach((name, fieldDescriptor) -> {
-      var value = fieldDescriptor.isRawProcessing() ? data : resourceObject;
+      var resource = fieldDescriptor.isRawProcessing() ? data : resourceObject;
       if (isSearchProcessorEnabled(fieldDescriptor)) {
-        resultMap.putAll(getSearchFieldValue(value, ctx.getLanguages(), name, fieldDescriptor));
+        resultMap.putAll(getSearchFieldValue(resource, ctx.getLanguages(), name, fieldDescriptor));
       } else {
         log.debug("Search processor has been ignored [processor: {}]", fieldDescriptor.getProcessor());
       }

--- a/src/main/java/org/folio/search/service/setter/AbstractSharedFieldProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/AbstractSharedFieldProcessor.java
@@ -1,0 +1,14 @@
+package org.folio.search.service.setter;
+
+public abstract class AbstractSharedFieldProcessor<T> implements FieldProcessor<T, Boolean> {
+
+  public static final String CONSORTIUM_PREFIX = "CONSORTIUM-";
+
+  @Override
+  public Boolean getFieldValue(T eventBody) {
+    String source = getSource(eventBody);
+    return source != null && source.toUpperCase().startsWith(CONSORTIUM_PREFIX);
+  }
+
+  protected abstract String getSource(T eventBody);
+}

--- a/src/main/java/org/folio/search/service/setter/authority/AuthoritySharedFieldProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/authority/AuthoritySharedFieldProcessor.java
@@ -1,0 +1,14 @@
+package org.folio.search.service.setter.authority;
+
+import org.folio.search.domain.dto.Authority;
+import org.folio.search.service.setter.AbstractSharedFieldProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthoritySharedFieldProcessor extends AbstractSharedFieldProcessor<Authority> {
+
+  @Override
+  protected String getSource(Authority eventBody) {
+    return eventBody.getSource();
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/instance/InstanceSharedFieldProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/InstanceSharedFieldProcessor.java
@@ -1,0 +1,14 @@
+package org.folio.search.service.setter.instance;
+
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.service.setter.AbstractSharedFieldProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InstanceSharedFieldProcessor extends AbstractSharedFieldProcessor<Instance> {
+
+  @Override
+  protected String getSource(Instance eventBody) {
+    return eventBody.getSource();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,7 @@ folio:
       search-all-fields: ${SEARCH_BY_ALL_FIELDS_ENABLED:false}
       browse-cn-intermediate-values: ${BROWSE_CN_INTERMEDIATE_VALUES_ENABLED:true}
       browse-cn-intermediate-remove-duplicates: ${BROWSE_CN_INTERMEDIATE_REMOVE_DUPLICATES:true}
+      consortium: ${CONSORTIUM_ENABLED:true}
     indexing:
       instance-subjects:
         retry-attempts: ${INSTANCE_SUBJECTS_INDEXING_RETRY_ATTEMPTS:3}

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -10,6 +10,11 @@
       "index": "keyword",
       "showInResponse": [ "search", "browse" ]
     },
+    "tenantId": {
+      "index": "keyword",
+      "searchTypes": [ "facet", "filter" ],
+      "showInResponse": [ "search", "browse" ]
+    },
     "personalName": {
       "type": "authority",
       "index": "standard",
@@ -371,6 +376,14 @@
       "type": "search",
       "index": "keyword",
       "processor": "lccnProcessor"
+    },
+    "shared": {
+      "searchTypes": [ "facet", "filter" ],
+      "type": "search",
+      "index": "bool",
+      "showInResponse": [ "search", "browse" ],
+      "processor": "authoritySharedFieldProcessor",
+      "dependsOnFeature": "consortium"
     }
   },
   "mappingsSource": {

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -24,6 +24,11 @@
       "index": "keyword",
       "showInResponse": [ "search", "call-number-browse" ]
     },
+    "tenantId": {
+      "index": "keyword",
+      "searchTypes": [ "facet", "filter" ],
+      "showInResponse": [ "search" ]
+    },
     "hrid": {
       "index": "keyword"
     },
@@ -258,6 +263,9 @@
         "id": {
           "index": "keyword"
         },
+        "tenantId": {
+          "index": "keyword"
+        },
         "hrid": {
           "index": "keyword"
         },
@@ -418,6 +426,9 @@
       "type": "object",
       "properties": {
         "id": {
+          "index": "keyword"
+        },
+        "tenantId": {
           "index": "keyword"
         },
         "sourceId": {
@@ -650,6 +661,14 @@
       "index": "keyword",
       "searchAliases": [ "items.effectiveShelvingOrder" ],
       "processor": "itemEffectiveShelvingOrderProcessor"
+    },
+    "shared": {
+      "searchTypes": [ "facet", "filter" ],
+      "type": "search",
+      "index": "bool",
+      "showInResponse": [ "search" ],
+      "dependsOnFeature": "consortium",
+      "processor": "instanceSharedFieldProcessor"
     },
     "allInstances": {
       "type": "search",

--- a/src/main/resources/swagger.api/schemas/authority.json
+++ b/src/main/resources/swagger.api/schemas/authority.json
@@ -7,6 +7,18 @@
       "type": "string",
       "description": "Authority UUID"
     },
+    "tenantId": {
+      "description": "Tenant ID",
+      "type": "string"
+    },
+    "shared": {
+      "description": "Indicate if it shared record",
+      "type": "boolean"
+    },
+    "source": {
+      "type": "string",
+      "description": "The metadata source and its format of the underlying record to the authority record"
+    },
     "personalName": {
       "type": "string",
       "description": "Heading personal name"

--- a/src/main/resources/swagger.api/schemas/holding.json
+++ b/src/main/resources/swagger.api/schemas/holding.json
@@ -7,6 +7,10 @@
       "type": "string",
       "description": "Unique ID of the holding record"
     },
+    "tenantId": {
+      "description": "Tenant ID",
+      "type": "string"
+    },
     "permanentLocationId": {
       "type": "string",
       "description": "The permanent shelving location in which an item resides."

--- a/src/main/resources/swagger.api/schemas/instance.json
+++ b/src/main/resources/swagger.api/schemas/instance.json
@@ -7,6 +7,14 @@
       "description": "The unique ID of the instance record; a UUID",
       "type": "string"
     },
+    "tenantId": {
+      "description": "Tenant ID",
+      "type": "string"
+    },
+    "shared": {
+      "description": "Indicate if it shared record",
+      "type": "boolean"
+    },
     "hrid": {
       "type": "string",
       "description": "The human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"

--- a/src/main/resources/swagger.api/schemas/item.json
+++ b/src/main/resources/swagger.api/schemas/item.json
@@ -7,6 +7,10 @@
       "type": "string",
       "description": "Unique ID of the item record"
     },
+    "tenantId": {
+      "description": "Tenant ID",
+      "type": "string"
+    },
     "hrid": {
       "type": "string",
       "description": "The human readable ID, also called eye readable ID. A system-assigned sequential alternate ID"

--- a/src/main/resources/swagger.api/schemas/tenantConfiguredFeature.json
+++ b/src/main/resources/swagger.api/schemas/tenantConfiguredFeature.json
@@ -5,6 +5,7 @@
   "enum": [
     "search.all.fields",
     "browse.cn.intermediate.values",
-    "browse.cn.intermediate.remove.duplicates"
+    "browse.cn.intermediate.remove.duplicates",
+    "consortium"
   ]
 }

--- a/src/test/java/org/folio/search/controller/BrowseAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseAuthorityIT.java
@@ -3,6 +3,7 @@ package org.folio.search.controller;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.support.base.ApiEndpoints.authorityBrowsePath;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.parseResponse;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -54,6 +55,8 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
     var request = get(authorityBrowsePath())
       .param("query", prepareQuery("(headingRef>={value} or headingRef<{value}) "
         + "and isTitleHeadingRef==false "
+        + "and tenantId==" + TENANT_ID + " "
+        + "and shared==false "
         + "and headingType==(\"Personal Name\")", "\"James Rollins\""))
       .param("limit", "7")
       .param("precedingRecordsCount", "2");
@@ -339,18 +342,20 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
         authority(20).sftGenreTerm(List.of("Poetry")),
         authority(21).saftGenreTerm(List.of("Prose", "Romance")),
         authority(22).personalName("Brian K. Vaughan"),
-      };
+        };
   }
 
   private static Authority authority(int index) {
     return new Authority().id(getId(index))
       .subjectHeadings(String.format("Authority #%02d", index))
+      .source("MARC")
       .sourceFileId("5de462a2-7a90-4467-b77f-b2057d6d69b6").naturalId("nbc123435");
   }
 
   private static Authority authority(int index, String headingRef, String headingType, String authRefType,
                                      Integer numberOfTitles) {
     return new Authority().id(getId(index)).headingRef(headingRef)
+      .tenantId(TENANT_ID).shared(false)
       .authRefType(authRefType).headingType(headingType)
       .sourceFileId("5de462a2-7a90-4467-b77f-b2057d6d69b6").naturalId("nbc123435").numberOfTitles(numberOfTitles);
   }

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
@@ -6,6 +6,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.domain.dto.TenantConfiguredFeature.BROWSE_CN_INTERMEDIATE_VALUES;
 import static org.folio.search.support.base.ApiEndpoints.instanceCallNumberBrowsePath;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.cnBrowseItem;
 import static org.folio.search.utils.TestUtils.getShelfKeyFromCallNumber;
 import static org.folio.search.utils.TestUtils.parseResponse;
@@ -379,6 +380,8 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       .staffSuppress(false)
       .discoverySuppress(false)
       .isBoundWith(false)
+      .shared(false)
+      .tenantId(TENANT_ID)
       .items(items)
       .holdings(emptyList());
   }

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberOtherIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberOtherIT.java
@@ -6,6 +6,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.domain.dto.TenantConfiguredFeature.BROWSE_CN_INTERMEDIATE_VALUES;
 import static org.folio.search.support.base.ApiEndpoints.instanceCallNumberBrowsePath;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.cnBrowseItem;
 import static org.folio.search.utils.TestUtils.cnBrowseResult;
 import static org.folio.search.utils.TestUtils.getShelfKeyFromCallNumber;
@@ -115,6 +116,8 @@ class BrowseCallNumberOtherIT extends BaseIntegrationTest {
       .staffSuppress(false)
       .discoverySuppress(false)
       .isBoundWith(false)
+      .shared(false)
+      .tenantId(TENANT_ID)
       .items(items)
       .holdings(emptyList());
   }

--- a/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIT.java
@@ -10,6 +10,7 @@ import static org.folio.search.model.types.CallNumberType.NLM;
 import static org.folio.search.model.types.CallNumberType.OTHER;
 import static org.folio.search.model.types.CallNumberType.SUDOC;
 import static org.folio.search.support.base.ApiEndpoints.instanceCallNumberBrowsePath;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.cnBrowseItem;
 import static org.folio.search.utils.TestUtils.getShelfKeyFromCallNumber;
 import static org.folio.search.utils.TestUtils.parseResponse;
@@ -181,6 +182,8 @@ class BrowseTypedCallNumberIT extends BaseIntegrationTest {
       .staffSuppress(false)
       .discoverySuppress(false)
       .isBoundWith(false)
+      .shared(false)
+      .tenantId(TENANT_ID)
       .items(items)
       .holdings(emptyList());
   }

--- a/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/SearchAuthorityIT.java
@@ -263,6 +263,8 @@ class SearchAuthorityIT extends BaseIntegrationTest {
                                      Integer numberOfTitles) {
     return new Authority()
       .id(getAuthoritySampleId())
+      .tenantId(TENANT_ID)
+      .shared(false)
       .sourceFileId(getAuthoritySourceFileId())
       .naturalId(getAuthorityNaturalId())
       .headingType(headingType)

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -4,6 +4,7 @@ import static org.folio.search.sample.SampleInstances.getSemanticWeb;
 import static org.folio.search.sample.SampleInstances.getSemanticWebAsMap;
 import static org.folio.search.sample.SampleInstances.getSemanticWebId;
 import static org.folio.search.support.base.ApiEndpoints.instanceIdsPath;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.parseResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -108,7 +109,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
     var response = doSearchByInstances(prepareQuery("id=={value}", getSemanticWebId()))
       .andExpect(jsonPath("totalRecords", is(1)))
       // make sure that no unexpected properties are present
-      .andExpect(jsonPath("instances[0].length()", is(11)));
+      .andExpect(jsonPath("instances[0].length()", is(13)));
 
     var actual = parseResponse(response, new TypeReference<ResultList<Instance>>() { }).getResult().get(0);
     assertThat(actual.getId(), is(expected.getId()));
@@ -148,7 +149,7 @@ class SearchInstanceIT extends BaseIntegrationTest {
       .map(SearchInstanceIT::removeUnexpectedProperties)
       .map(Matchers::is).collect(Collectors.toList())));
 
-    assertThat(actual.holdings(null).items(null),
+    assertThat(actual.tenantId(null).shared(null).holdings(null).items(null),
       is(removeUnexpectedProperties(expected)));
   }
 
@@ -164,6 +165,8 @@ class SearchInstanceIT extends BaseIntegrationTest {
 
   private static Instance removeUnexpectedProperties(Instance instance) {
     instance.getElectronicAccess().forEach(e -> e.setMaterialsSpecification(null));
+    instance.setTenantId(null);
+    instance.setShared(null);
     return instance.staffSuppress(false).discoverySuppress(false).items(null).holdings(null);
   }
 
@@ -180,6 +183,10 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("id = {value}", getSemanticWebId()),
       arguments("id = {value}", "5bf370e0*a0a39"),
       arguments("id == {value}", getSemanticWebId()),
+
+      arguments("tenantId = {value}", TENANT_ID),
+
+      arguments("shared == {value}", "false"),
 
       arguments("title <> {value}", "unknown value"),
       arguments("indexTitle <> {value}", "unknown value"),

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -46,6 +46,7 @@ folio:
       search-all-fields: false
       browse-cn-intermediate-values: true
       browse-cn-intermediate-remove-duplicates: true
+      consortium: true
     indexing:
       instance-subjects:
         retry-attempts: 3

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -10,8 +10,8 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss} [$${folio:requestid:-}] [$${folio:tenantid:-}] [$${folio:userid:-}] [$${folio:moduleid:-}] %-5p %-20.20C{1} %m%n
 
-rootLogger.level = debug
-rootLogger.appenderRefs = debug
+rootLogger.level = info
+rootLogger.appenderRefs = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 
 


### PR DESCRIPTION
## Purpose
TenantId and shared fields are present in the search/browse responses
TenantId and shared fields are searchable via CQL

## Approach
* update mappings
* populate tenantId from Kafka message body
* populate shared from source field by CONSORTIUM- prefix

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
https://issues.folio.org/browse/MSEARCH-532
