### PR TITLE
fix(cn-browse): Improve preceding records searching

### DIFF
--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -1,6 +1,7 @@
 package org.folio.search.service.browse;
 
 import static java.lang.Boolean.TRUE;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 import static org.folio.search.utils.CollectionUtils.mergeSafelyToList;
@@ -66,9 +67,12 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
         .stream().distinct().toList());
     }
 
-    if (precedingResult.isEmpty() && precedingResult.getTotalRecords() > 0) {
-      log.debug("browseAround:: preceding result is empty: Do additional requests");
-      precedingResult = additionalPrecedingRequests(request, context, precedingQuery);
+    if (precedingResult.getRecords().size() < request.getPrecedingRecordsCount()
+        && precedingResult.getTotalRecords() > 0) {
+      log.debug("getPrecedingResult:: preceding result are empty: Do additional requests");
+      var additionalPrecedingRequestsResult = additionalPrecedingRequests(request, context, precedingQuery);
+      precedingResult.setRecords(mergeSafelyToList(additionalPrecedingRequestsResult, precedingResult.getRecords())
+        .stream().distinct().toList());
     }
 
     if (TRUE.equals(request.getHighlightMatch())) {
@@ -91,14 +95,15 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
     return browseItem.getShelfKey();
   }
 
-  private BrowseResult<CallNumberBrowseItem> additionalPrecedingRequests(BrowseRequest request,
+  private List<CallNumberBrowseItem> additionalPrecedingRequests(BrowseRequest request,
                                                                          BrowseContext context,
                                                                          SearchSourceBuilder precedingQuery) {
-    BrowseResult<CallNumberBrowseItem> precedingResult = BrowseResult.empty();
+    List<CallNumberBrowseItem> additionalPrecedingRecords = emptyList();
     int offset = precedingQuery.from() + precedingQuery.size();
     precedingQuery.size(ADDITIONAL_REQUEST_SIZE);
 
-    while (precedingResult.getRecords().isEmpty() && precedingQuery.from() <= ADDITIONAL_REQUEST_SIZE_MAX) {
+    while (additionalPrecedingRecords.size() < request.getPrecedingRecordsCount()
+           && precedingQuery.from() <= ADDITIONAL_REQUEST_SIZE_MAX) {
       int size = precedingQuery.size() * 2;
       log.debug("additionalPrecedingRequests:: request offset {}, size {}", offset, size);
       precedingQuery.from(offset).size(size);
@@ -109,10 +114,12 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
         log.debug("additionalPrecedingRequests:: response have no records");
         break;
       }
-      precedingResult = callNumberBrowseResultConverter.convert(searchResponse, context, false);
+      var precedingResult = callNumberBrowseResultConverter.convert(searchResponse, context, false);
+      additionalPrecedingRecords = mergeSafelyToList(additionalPrecedingRecords, precedingResult.getRecords());
       offset = precedingQuery.from() + precedingQuery.size();
+      log.debug("additionalPrecedingRequests:: response have new {} records", precedingResult.getRecords().size());
     }
-    return precedingResult;
+    return additionalPrecedingRecords;
   }
 
   private static void highlightMatchingCallNumber(BrowseContext ctx,

--- a/src/test/java/org/folio/search/controller/BrowseAroundCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseAroundCallNumberIT.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 @IntegrationTest
-class BrowseCallNumberPrecedingIT extends BaseIntegrationTest {
+class BrowseAroundCallNumberIT extends BaseIntegrationTest {
 
   private static final Instance[] INSTANCES = instances();
   private static final Map<String, Instance> INSTANCE_MAP =
@@ -46,13 +46,17 @@ class BrowseCallNumberPrecedingIT extends BaseIntegrationTest {
   void browseByCallNumber_browsingAroundPrecedingRecordsWithSame10FirstSymbols() {
     var request = get(instanceCallNumberBrowsePath())
       .param("query", prepareQuery("callNumber < {value} or callNumber >= {value}", "\"E 3184 S75 1234\""))
-      .param("limit", "15")
+      .param("limit", "19")
       .param("expandAll", "true")
       .param("highlightMatch", "true")
-      .param("precedingRecordsCount", "5");
+      .param("precedingRecordsCount", "9");
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
-      .totalRecords(60).prev("E 43184 S74 45673").next("E 43184 S75 41243").items(List.of(
+      .totalRecords(64).prev("C 223 3987").next("E 43184 S75 41243").items(List.of(
+        cnBrowseItem(instance("instance #34"), "C23 987"),
+        cnBrowseItem(instance("instance #33"), "D15.H63 A3 2002"),
+        cnBrowseItem(instance("instance #27"), "E 3184 S74 5671"),
+        cnBrowseItem(instance("instance #28"), "E 3184 S74 5672"),
         cnBrowseItem(instance("instance #29"), "E 3184 S74 5673"),
         cnBrowseItem(instance("instance #30"), "E 3184 S74 5674"),
         cnBrowseItem(instance("instance #02"), "E 3184 S75 1231"),
@@ -71,9 +75,47 @@ class BrowseCallNumberPrecedingIT extends BaseIntegrationTest {
       )));
   }
 
+  @Test
+  void browseByCallNumber_browsingAroundSucceedingRecordsWithSame10FirstSymbols() {
+    var request = get(instanceCallNumberBrowsePath())
+      .param("query", prepareQuery("callNumber < {value} or callNumber >= {value}", "\"E 3184 S75 1234\""))
+      .param("limit", "24")
+      .param("expandAll", "true")
+      .param("highlightMatch", "true")
+      .param("precedingRecordsCount", "1");
+    var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
+    assertThat(actual).isEqualTo(new CallNumberBrowseResult()
+      .totalRecords(64).prev("E 43184 S75 41233").next("G 275 41255").items(List.of(
+        cnBrowseItem(instance("instance #03"), "E 3184 S75 1233"),
+        cnBrowseItem(instance("instance #04"), "E 3184 S75 1234", true),
+        cnBrowseItem(instance("instance #05"), "E 3184 S75 1235"),
+        cnBrowseItem(instance("instance #06"), "E 3184 S75 1236"),
+        cnBrowseItem(instance("instance #07"), "E 3184 S75 1237"),
+        cnBrowseItem(instance("instance #08"), "E 3184 S75 1238"),
+        cnBrowseItem(instance("instance #09"), "E 3184 S75 1239"),
+        cnBrowseItem(instance("instance #10"), "E 3184 S75 1240"),
+        cnBrowseItem(instance("instance #11"), "E 3184 S75 1241"),
+        cnBrowseItem(instance("instance #12"), "E 3184 S75 1242"),
+        cnBrowseItem(instance("instance #13"), "E 3184 S75 1243"),
+        cnBrowseItem(instance("instance #14"), "E 3184 S75 1244"),
+        cnBrowseItem(instance("instance #15"), "E 3184 S75 1245"),
+        cnBrowseItem(instance("instance #16"), "E 3184 S75 1246"),
+        cnBrowseItem(instance("instance #18"), "E 3184 S75 1248"),
+        cnBrowseItem(instance("instance #19"), "E 3184 S75 1249"),
+        cnBrowseItem(instance("instance #20"), "E 3184 S75 1250"),
+        cnBrowseItem(instance("instance #21"), "E 3184 S75 1251"),
+        cnBrowseItem(instance("instance #22"), "E 3184 S75 1252"),
+        cnBrowseItem(instance("instance #23"), "E 3184 S75 1253"),
+        cnBrowseItem(instance("instance #24"), "E 3184 S75 1254"),
+        cnBrowseItem(instance("instance #17"), "E 3184 S76 1247"),
+        cnBrowseItem(instance("instance #38"), "FA 42010 3546 256"),
+        cnBrowseItem(instance("instance #35"), "G75 1255")
+      )));
+  }
+
   private static Instance[] instances() {
     return callNumberBrowseInstanceData().stream()
-      .map(BrowseCallNumberPrecedingIT::instance)
+      .map(BrowseAroundCallNumberIT::instance)
       .toArray(Instance[]::new);
   }
 
@@ -111,6 +153,8 @@ class BrowseCallNumberPrecedingIT extends BaseIntegrationTest {
       List.of("instance #30", List.of("E 3184 S74 5674")),
       List.of("instance #31", List.of("A 3184 S74 ")),
       List.of("instance #32", List.of("A 3184 S75 1235")),
+      List.of("instance #33", List.of("D15.H63 A3 2002")),
+      List.of("instance #34", List.of("C23 987")),
       List.of("instance #02", List.of("E 3184 S75 1231")),
       List.of("instance #01", List.of("E 3184 S75 1232")),
       List.of("instance #03", List.of("E 3184 S75 1233")),
@@ -127,7 +171,7 @@ class BrowseCallNumberPrecedingIT extends BaseIntegrationTest {
       List.of("instance #14", List.of("E 3184 S75 1244")),
       List.of("instance #15", List.of("E 3184 S75 1245")),
       List.of("instance #16", List.of("E 3184 S75 1246")),
-      List.of("instance #17", List.of("E 3184 S75 1247")),
+      List.of("instance #17", List.of("E 3184 S76 1247")),
       List.of("instance #18", List.of("E 3184 S75 1248")),
       List.of("instance #19", List.of("E 3184 S75 1249")),
       List.of("instance #20", List.of("E 3184 S75 1250")),
@@ -135,7 +179,10 @@ class BrowseCallNumberPrecedingIT extends BaseIntegrationTest {
       List.of("instance #22", List.of("E 3184 S75 1252")),
       List.of("instance #23", List.of("E 3184 S75 1253")),
       List.of("instance #24", List.of("E 3184 S75 1254")),
-      List.of("instance #25", List.of("E 3184 S75 1255"))
+      List.of("instance #35", List.of("G75 1255")),
+      List.of("instance #36", List.of("PR 213 E5 41999")),
+      List.of("instance #37", List.of("GA 16 D64 41548A")),
+      List.of("instance #38", List.of("FA 42010 3546 256"))
     );
   }
 }

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
@@ -101,13 +101,14 @@ class CallNumberBrowseServiceTest {
       .thenReturn(new CQLTermNode(null, null, "B"));
     prepareMockForBrowsingAround(request,
       contextAroundIncluding(),
-      BrowseResult.of(1, browseItems("A 11")),
+      BrowseResult.of(1, browseItems("A 11", "A 12")),
       BrowseResult.of(2, browseItems("B", "C 11")));
 
     var actual = callNumberBrowseService.browse(request);
 
     assertThat(actual).isEqualTo(BrowseResult.of(3, List.of(
       cnBrowseItem(instance("A 11"), "A 11"),
+      cnBrowseItem(instance("A 12"), "A 12"),
       cnBrowseItem(instance("B"), "B", true),
       cnBrowseItem(instance("C 11"), "C 11"))));
   }
@@ -139,12 +140,13 @@ class CallNumberBrowseServiceTest {
     when(cqlSearchQueryConverter.convertToTermNode(anyString(), anyString()))
       .thenReturn(new CQLTermNode(null, null, "B"));
     prepareMockForBrowsingAround(request,
-      contextAroundIncluding(), BrowseResult.of(1, browseItems("A 11")), BrowseResult.empty());
+      contextAroundIncluding(), BrowseResult.of(1, browseItems("A 11", "A 12")), BrowseResult.empty());
 
     var actual = callNumberBrowseService.browse(request);
 
     assertThat(actual).isEqualTo(BrowseResult.of(1, List.of(
       cnBrowseItem(instance("A 11"), "A 11"),
+      cnBrowseItem(instance("A 12"), "A 12"),
       cnBrowseItem(0, "B", true))));
   }
 
@@ -154,13 +156,14 @@ class CallNumberBrowseServiceTest {
 
     prepareMockForBrowsingAround(request,
       contextAroundIncluding(),
-      BrowseResult.of(1, browseItems("A 11")),
+      BrowseResult.of(1, browseItems("A 11", "A 12")),
       BrowseResult.of(1, browseItems("C 11")));
 
     var actual = callNumberBrowseService.browse(request);
 
     assertThat(actual).isEqualTo(BrowseResult.of(2, List.of(
       cnBrowseItem(instance("A 11"), "A 11"),
+      cnBrowseItem(instance("A 12"), "A 12"),
       cnBrowseItem(instance("C 11"), "C 11"))));
   }
 


### PR DESCRIPTION
## Purpose
Optimize result building to use already queried data before querying new
Improve preceding records searching 

Closes: MSEARCH-552, MSEARCH-544

## Approach
- Change condition for additionalPrecedingRequests to check the size of records
- Avoid additionalPrecedingRequests if backwardSucceedingResult contains required records
- Improve test case for "preceding" records and add new for "succeeding" records

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
