### PR TITLE
feat(consortium): Implement consortium index management

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ It is possible to define specific tenant parameters during module's initializati
 | Tenant parameter | Default value | Description                                                                       |
 |:-----------------|:-------------:|:----------------------------------------------------------------------------------|
 | runReindex       |     false     | Start reindex procedure automatically after module will be enabled for the tenant |
+| centralTenantId  |     null      | Central tenant Id when module is in consortia mode                                |
 
 ## Data Indexing
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,12 +9,14 @@
         {
           "methods": [ "POST" ],
           "pathPattern": "/search/index/indices",
-          "permissionsRequired": [ "search.index.indices.item.post" ]
+          "permissionsRequired": [ "search.index.indices.item.post" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         },
         {
           "methods": [ "POST" ],
           "pathPattern": "/search/index/mappings",
-          "permissionsRequired": [ "search.index.mappings.item.post" ]
+          "permissionsRequired": [ "search.index.mappings.item.post" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         },
         {
           "methods": [ "POST" ],
@@ -23,7 +25,8 @@
           "modulePermissions": [
             "inventory-storage.inventory-view.instances.collection.get",
             "inventory-storage.identifier-types.collection.get",
-            "inventory-storage.alternative-title-types.collection.get"
+            "inventory-storage.alternative-title-types.collection.get",
+            "user-tenants.collection.get"
           ]
         },
         {
@@ -32,13 +35,15 @@
           "permissionsRequired": [ "search.index.inventory.reindex.post" ],
           "modulePermissions": [
             "inventory-storage.instance.reindex.post",
-            "authority-storage.authority.reindex.post"
+            "authority-storage.authority.reindex.post",
+            "user-tenants.collection.get"
           ]
         },
         {
           "methods": [ "PUT" ],
           "pathPattern": "/search/index/settings",
-          "permissionsRequired": [ "search.index.settings.item.put" ]
+          "permissionsRequired": [ "search.index.settings.item.put" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         }
       ]
     },
@@ -49,27 +54,32 @@
         {
           "methods": [ "GET" ],
           "pathPattern": "/search/instances",
-          "permissionsRequired": [ "search.instances.collection.get" ]
+          "permissionsRequired": [ "search.instances.collection.get" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         },
         {
           "methods": [ "GET" ],
           "pathPattern": "/search/authorities",
-          "permissionsRequired": [ "search.authorities.collection.get" ]
+          "permissionsRequired": [ "search.authorities.collection.get" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         },
         {
           "methods": [ "GET" ],
           "pathPattern": "/search/{recordType}/facets",
-          "permissionsRequired": [ "search.facets.collection.get" ]
+          "permissionsRequired": [ "search.facets.collection.get" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         },
         {
           "methods": [ "GET" ],
           "pathPattern": "/search/instances/ids",
-          "permissionsRequired": [ "search.instances.ids.collection.get" ]
+          "permissionsRequired": [ "search.instances.ids.collection.get" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         },
         {
           "methods": [ "GET" ],
           "pathPattern": "/search/holdings/ids",
-          "permissionsRequired": [ "search.holdings.ids.collection.get" ]
+          "permissionsRequired": [ "search.holdings.ids.collection.get" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         }
       ]
     },
@@ -90,7 +100,8 @@
         {
           "methods": [ "POST" ],
           "pathPattern": "/search/resources/jobs",
-          "permissionsRequired": [ "search.resources.ids.jobs.post" ]
+          "permissionsRequired": [ "search.resources.ids.jobs.post" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         }
       ]
     },
@@ -101,22 +112,26 @@
         {
           "methods": [ "GET" ],
           "pathPattern": "/browse/call-numbers/instances",
-          "permissionsRequired": [ "browse.call-numbers.instances.collection.get" ]
+          "permissionsRequired": [ "browse.call-numbers.instances.collection.get" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         },
         {
           "methods": [ "GET" ],
           "pathPattern": "/browse/subjects/instances",
-          "permissionsRequired": [ "browse.subjects.instances.collection.get" ]
+          "permissionsRequired": [ "browse.subjects.instances.collection.get" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         },
         {
           "methods": [ "GET" ],
           "pathPattern": "/browse/contributors/instances",
-          "permissionsRequired": [ "browse.contributors.instances.collection.get" ]
+          "permissionsRequired": [ "browse.contributors.instances.collection.get" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         },
         {
           "methods": [ "GET" ],
           "pathPattern": "/browse/authorities",
-          "permissionsRequired": [ "browse.authorities.collection.get" ]
+          "permissionsRequired": [ "browse.authorities.collection.get" ],
+          "modulePermissions": ["user-tenants.collection.get"]
         }
       ]
     },
@@ -195,6 +210,12 @@
           "pathPattern": "/_/tenant/{id}"
         }
       ]
+    }
+  ],
+  "optional":[
+    {
+      "id": "user-tenants",
+      "version": "1.0"
     }
   ],
   "requires": [

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       src/main/java/org/folio/search/configuration/properties/**
     </sonar.exclusions>
 
-    <folio-spring-base.version>7.1.0</folio-spring-base.version>
+    <folio-spring-base.version>7.1.2</folio-spring-base.version>
     <folio-service-tools.version>3.1.0-SNAPSHOT</folio-service-tools.version>
     <folio-isbn-utils.version>1.5.0</folio-isbn-utils.version>
     <folio-cql2pgjson.version>35.0.6</folio-cql2pgjson.version>

--- a/src/main/java/org/folio/search/client/UserTenantsClient.java
+++ b/src/main/java/org/folio/search/client/UserTenantsClient.java
@@ -1,0 +1,19 @@
+package org.folio.search.client;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient("user-tenants")
+public interface UserTenantsClient {
+
+  @GetMapping(produces = APPLICATION_JSON_VALUE)
+  UserTenants getUserTenants(@RequestParam("tenantId") String tenantId);
+
+  record UserTenants(List<UserTenant> userTenants) { }
+
+  record UserTenant(String centralTenantId) { }
+}

--- a/src/main/java/org/folio/search/configuration/ConsortiaConfig.java
+++ b/src/main/java/org/folio/search/configuration/ConsortiaConfig.java
@@ -1,0 +1,23 @@
+package org.folio.search.configuration;
+
+import org.folio.search.configuration.properties.SearchConfigurationProperties;
+import org.folio.search.service.consortia.ConsortiaService;
+import org.folio.search.service.consortia.ConsortiaTenantProvider;
+import org.folio.search.service.consortia.TenantProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ConsortiaConfig {
+
+  @Bean
+  public TenantProvider getTenantProvider(SearchConfigurationProperties searchConfigurationProperties,
+                                          ConsortiaService consortiaService) {
+
+    if (searchConfigurationProperties.inConsortiaMode()) {
+      return new ConsortiaTenantProvider(consortiaService);
+    } else {
+      return tenantId -> tenantId;
+    }
+  }
+}

--- a/src/main/java/org/folio/search/configuration/SearchCacheNames.java
+++ b/src/main/java/org/folio/search/configuration/SearchCacheNames.java
@@ -12,4 +12,5 @@ public class SearchCacheNames {
   public static final String RESOURCE_LANGUAGE_CACHE = "tenant-languages";
   public static final String TENANT_FEATURES_CACHE = "tenant-features";
   public static final String SEARCH_PREFERENCE_CACHE = "search-preference";
+  public static final String USER_TENANTS_CACHE = "user-tenants";
 }

--- a/src/main/java/org/folio/search/configuration/properties/SearchConfigurationProperties.java
+++ b/src/main/java/org/folio/search/configuration/properties/SearchConfigurationProperties.java
@@ -46,6 +46,10 @@ public class SearchConfigurationProperties {
    */
   private IndexingSettings indexing;
 
+  public boolean inConsortiaMode() {
+    return searchFeatures.getOrDefault(TenantConfiguredFeature.CONSORTIUM, false);
+  }
+
   @Data
   @Validated
   public static class IndexingSettings {

--- a/src/main/java/org/folio/search/controller/BrowseController.java
+++ b/src/main/java/org/folio/search/controller/BrowseController.java
@@ -26,6 +26,7 @@ import org.folio.search.service.browse.AuthorityBrowseService;
 import org.folio.search.service.browse.CallNumberBrowseService;
 import org.folio.search.service.browse.ContributorBrowseService;
 import org.folio.search.service.browse.SubjectBrowseService;
+import org.folio.search.service.consortia.TenantProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,6 +42,7 @@ public class BrowseController implements BrowseApi {
   private final AuthorityBrowseService authorityBrowseService;
   private final CallNumberBrowseService callNumberBrowseService;
   private final ContributorBrowseService contributorBrowseService;
+  private final TenantProvider tenantProvider;
 
   @Override
   public ResponseEntity<AuthorityBrowseResult> browseAuthorities(String query, String tenant,
@@ -108,7 +110,7 @@ public class BrowseController implements BrowseApi {
       .next(browseResult.getNext()));
   }
 
-  private static BrowseRequestBuilder getBrowseRequestBuilder(String query, String tenant, Integer limit,
+  private BrowseRequestBuilder getBrowseRequestBuilder(String query, String tenant, Integer limit,
                                                               Boolean expandAll, Boolean highlightMatch,
                                                               Integer precedingRecordsCount) {
     if (precedingRecordsCount != null && precedingRecordsCount >= limit) {
@@ -119,7 +121,7 @@ public class BrowseController implements BrowseApi {
     return BrowseRequest.builder()
       .limit(limit)
       .query(query)
-      .tenantId(tenant)
+      .tenantId(tenantProvider.getTenant(tenant))
       .expandAll(expandAll)
       .highlightMatch(highlightMatch)
       .precedingRecordsCount(defaultIfNull(precedingRecordsCount, limit / 2));

--- a/src/main/java/org/folio/search/controller/ConfigController.java
+++ b/src/main/java/org/folio/search/controller/ConfigController.java
@@ -12,8 +12,8 @@ import org.folio.search.domain.dto.LanguageConfig;
 import org.folio.search.domain.dto.LanguageConfigs;
 import org.folio.search.domain.dto.TenantConfiguredFeature;
 import org.folio.search.rest.resource.ConfigApi;
-import org.folio.search.service.FeatureConfigService;
-import org.folio.search.service.LanguageConfigService;
+import org.folio.search.service.consortia.FeatureConfigServiceDecorator;
+import org.folio.search.service.consortia.LanguageConfigServiceDecorator;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,8 +26,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/")
 public class ConfigController implements ConfigApi {
 
-  private final LanguageConfigService languageConfigService;
-  private final FeatureConfigService featureConfigService;
+  private final LanguageConfigServiceDecorator languageConfigService;
+  private final FeatureConfigServiceDecorator featureConfigService;
 
   @Override
   public ResponseEntity<LanguageConfig> createLanguageConfig(@Valid LanguageConfig languageConfig) {

--- a/src/main/java/org/folio/search/controller/FacetsController.java
+++ b/src/main/java/org/folio/search/controller/FacetsController.java
@@ -12,6 +12,7 @@ import org.folio.search.domain.dto.RecordType;
 import org.folio.search.model.service.CqlFacetRequest;
 import org.folio.search.rest.resource.FacetsApi;
 import org.folio.search.service.FacetService;
+import org.folio.search.service.consortia.TenantProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,11 +31,13 @@ public class FacetsController implements FacetsApi {
   );
 
   private final FacetService facetService;
+  private final TenantProvider tenantProvider;
 
   @Override
   public ResponseEntity<FacetResult> getFacets(RecordType recordType, String query,
                                                List<String> facet, String tenantId) {
-    String recordResource = RECORD_TYPE_TO_RESOURCE_MAP.getOrDefault(recordType, recordType.getValue());
+    var recordResource = RECORD_TYPE_TO_RESOURCE_MAP.getOrDefault(recordType, recordType.getValue());
+    tenantId = tenantProvider.getTenant(tenantId);
     var facetRequest = CqlFacetRequest.of(recordResource, tenantId, query, facet);
     return ResponseEntity.ok(facetService.getFacets(facetRequest));
   }

--- a/src/main/java/org/folio/search/controller/ResourcesIdsController.java
+++ b/src/main/java/org/folio/search/controller/ResourcesIdsController.java
@@ -8,8 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.folio.search.domain.dto.ResourceIdsJob;
 import org.folio.search.model.service.CqlResourceIdsRequest;
 import org.folio.search.rest.resource.SearchResourcesIdsApi;
-import org.folio.search.service.ResourceIdsJobService;
 import org.folio.search.service.ResourceIdsStreamHelper;
+import org.folio.search.service.consortia.ResourceIdsJobServiceDecorator;
+import org.folio.search.service.consortia.TenantProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,10 +23,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ResourcesIdsController implements SearchResourcesIdsApi {
 
   private final ResourceIdsStreamHelper resourceIdsStreamHelper;
-  private final ResourceIdsJobService resourceIdsJobService;
+  private final ResourceIdsJobServiceDecorator resourceIdsJobService;
+  private final TenantProvider tenantProvider;
 
   @Override
   public ResponseEntity<Void> getHoldingIds(String query, String tenantId, String contentType) {
+    tenantId = tenantProvider.getTenant(tenantId);
     var bulkRequest = CqlResourceIdsRequest.of(INSTANCE_RESOURCE, tenantId, query, HOLDINGS_ID_PATH);
     return resourceIdsStreamHelper.streamResourceIds(bulkRequest, contentType);
   }
@@ -37,6 +40,7 @@ public class ResourcesIdsController implements SearchResourcesIdsApi {
 
   @Override
   public ResponseEntity<Void> getInstanceIds(String query, String tenantId, String contentType) {
+    tenantId = tenantProvider.getTenant(tenantId);
     var request = CqlResourceIdsRequest.of(INSTANCE_RESOURCE, tenantId, query, INSTANCE_ID_PATH);
     return resourceIdsStreamHelper.streamResourceIds(request, contentType);
   }
@@ -48,6 +52,7 @@ public class ResourcesIdsController implements SearchResourcesIdsApi {
 
   @Override
   public ResponseEntity<ResourceIdsJob> submitIdsJob(String tenantId, ResourceIdsJob resourceIdsJob) {
+    tenantId = tenantProvider.getTenant(tenantId);
     resourceIdsJob.setEntityType(ResourceIdsJob.EntityTypeEnum.valueOf(resourceIdsJob.getEntityType().name()));
     return ResponseEntity.ok(resourceIdsJobService.createStreamJob(resourceIdsJob, tenantId));
   }

--- a/src/main/java/org/folio/search/controller/SearchController.java
+++ b/src/main/java/org/folio/search/controller/SearchController.java
@@ -8,6 +8,7 @@ import org.folio.search.domain.dto.InstanceSearchResult;
 import org.folio.search.model.service.CqlSearchRequest;
 import org.folio.search.rest.resource.SearchApi;
 import org.folio.search.service.SearchService;
+import org.folio.search.service.consortia.TenantProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,10 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class SearchController implements SearchApi {
 
   private final SearchService searchService;
+  private final TenantProvider tenantProvider;
 
   @Override
   public ResponseEntity<InstanceSearchResult> searchInstances(String tenantId, String query, Integer limit,
                                                               Integer offset, Boolean expandAll) {
+    tenantId = tenantProvider.getTenant(tenantId);
     var searchRequest = CqlSearchRequest.of(Instance.class, tenantId, query, limit, offset, expandAll);
     var result = searchService.search(searchRequest);
     return ResponseEntity.ok(new InstanceSearchResult()
@@ -34,6 +37,8 @@ public class SearchController implements SearchApi {
   @Override
   public ResponseEntity<AuthoritySearchResult> searchAuthorities(
     String tenant, String query, Integer limit, Integer offset, Boolean expandAll, Boolean includeNumberOfTitles) {
+
+    tenant = tenantProvider.getTenant(tenant);
     var searchRequest = CqlSearchRequest.of(
       Authority.class, tenant, query, limit, offset, expandAll, includeNumberOfTitles);
     var result = searchService.search(searchRequest);

--- a/src/main/java/org/folio/search/integration/KafkaMessageListener.java
+++ b/src/main/java/org/folio/search/integration/KafkaMessageListener.java
@@ -108,7 +108,7 @@ public class KafkaMessageListener {
     log.info("Processing subjects events from Kafka [number of events: {}]", consumerRecords.size());
     var batch = consumerRecords.stream()
       .map(ConsumerRecord::value)
-      .map(contributor -> contributor.resourceName(INSTANCE_SUBJECT_RESOURCE).id(getResourceEventId(contributor)))
+      .map(subject -> subject.resourceName(INSTANCE_SUBJECT_RESOURCE).id(getResourceEventId(subject)))
       .toList();
 
     folioMessageBatchProcessor.consumeBatchWithFallback(batch, KAFKA_RETRY_TEMPLATE_NAME,

--- a/src/main/java/org/folio/search/service/ResourceIdsJobService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdsJobService.java
@@ -9,6 +9,7 @@ import org.folio.search.converter.ResourceIdsJobMapper;
 import org.folio.search.domain.dto.ResourceIdsJob;
 import org.folio.search.model.types.StreamJobStatus;
 import org.folio.search.repository.ResourceIdsJobRepository;
+import org.folio.search.service.consortia.ResourceIdServiceDecorator;
 import org.springframework.stereotype.Service;
 
 @Log4j2
@@ -19,7 +20,7 @@ public class ResourceIdsJobService {
   private final TenantScopedExecutionService tenantExecutionService;
   private final ResourceIdsJobRepository jobRepository;
   private final ResourceIdsJobMapper resourceIdsJobMapper;
-  private final ResourceIdService resourceIdService;
+  private final ResourceIdServiceDecorator resourceIdService;
 
   public ResourceIdsJob getJobById(String id) {
     return resourceIdsJobMapper.convert(jobRepository.getReferenceById(id));

--- a/src/main/java/org/folio/search/service/ResourceIdsStreamHelper.java
+++ b/src/main/java/org/folio/search/service/ResourceIdsStreamHelper.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.search.exception.SearchServiceException;
 import org.folio.search.model.service.CqlResourceIdsRequest;
+import org.folio.search.service.consortia.ResourceIdServiceDecorator;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
@@ -20,7 +21,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @RequiredArgsConstructor
 public class ResourceIdsStreamHelper {
 
-  private final ResourceIdService resourceIdService;
+  private final ResourceIdServiceDecorator resourceIdService;
 
   /**
    * Provides ability to stream resource ids using given request object.

--- a/src/main/java/org/folio/search/service/SearchService.java
+++ b/src/main/java/org/folio/search/service/SearchService.java
@@ -43,7 +43,7 @@ public class SearchService {
    * @param request cql search request as {@link CqlSearchRequest} object
    * @return search result.
    */
-  public <T> SearchResult<T> search(CqlSearchRequest<T> request) {
+  public <T> SearchResult<T>  search(CqlSearchRequest<T> request) {
     log.debug("search:: by [query: {}, resource: {}]", request.getQuery(), request.getResource());
 
     if (request.getOffset() + request.getLimit() > 10_000L) {

--- a/src/main/java/org/folio/search/service/SearchTenantService.java
+++ b/src/main/java/org/folio/search/service/SearchTenantService.java
@@ -3,18 +3,21 @@ package org.folio.search.service;
 import static java.lang.Boolean.parseBoolean;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.extern.log4j.Log4j2;
 import org.folio.search.configuration.properties.SearchConfigurationProperties;
 import org.folio.search.domain.dto.LanguageConfig;
 import org.folio.search.domain.dto.ReindexRequest;
 import org.folio.search.service.browse.CallNumberBrowseRangeService;
+import org.folio.search.service.consortia.LanguageConfigServiceDecorator;
 import org.folio.search.service.metadata.ResourceDescriptionService;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.liquibase.FolioSpringLiquibase;
 import org.folio.spring.service.TenantService;
 import org.folio.spring.tools.kafka.KafkaAdminService;
 import org.folio.spring.tools.systemuser.PrepareSystemUserService;
+import org.folio.tenant.domain.dto.Parameter;
 import org.folio.tenant.domain.dto.TenantAttributes;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -26,12 +29,13 @@ import org.springframework.stereotype.Service;
 public class SearchTenantService extends TenantService {
 
   private static final String REINDEX_PARAM_NAME = "runReindex";
+  private static final String CENTRAL_TENANT_ID_PARAM_NAME = "centralTenantId";
 
   private final IndexService indexService;
   private final ScriptService scriptService;
   private final KafkaAdminService kafkaAdminService;
   private final PrepareSystemUserService prepareSystemUserService;
-  private final LanguageConfigService languageConfigService;
+  private final LanguageConfigServiceDecorator languageConfigService;
   private final ResourceDescriptionService resourceDescriptionService;
   private final CallNumberBrowseRangeService callNumberBrowseRangeService;
   private final SearchConfigurationProperties searchConfigurationProperties;
@@ -40,7 +44,7 @@ public class SearchTenantService extends TenantService {
                              FolioSpringLiquibase folioSpringLiquibase, KafkaAdminService kafkaAdminService,
                              IndexService indexService, ScriptService scriptService,
                              PrepareSystemUserService prepareSystemUserService,
-                             LanguageConfigService languageConfigService,
+                             LanguageConfigServiceDecorator languageConfigService,
                              CallNumberBrowseRangeService callNumberBrowseRangeService,
                              ResourceDescriptionService resourceDescriptionService,
                              SearchConfigurationProperties searchConfigurationProperties) {
@@ -62,6 +66,44 @@ public class SearchTenantService extends TenantService {
    * <ul>
    *   <li>Creates Kafka topics</li>
    *   <li>Creates a system user to perform record indexing</li>
+   * </ul>
+   *
+   * <p>This method additionally if it's not a consortium member tenant:</p>
+   * <ul>
+   *   <li>Creates database schemas</li>
+   *   <li>Add default languages to the tenant configuration</li>
+   *   <li>Creates Elasticsearch indexes and corresponding mappings for supported record types</li>
+   *   <li>Starts reindexing process for inventory (if it's specified)</li>
+   * </ul>
+   *
+   * @param tenantAttributes - tenant attributes comes from {@code POST /_/tenant} request.
+   */
+  @Override
+  public synchronized void createOrUpdateTenant(TenantAttributes tenantAttributes) {
+    var tenantId = context.getTenantId();
+    var centralTenant = centralTenant(tenantId, tenantAttributes);
+    if (tenantId.equals(centralTenant)) {
+      super.createOrUpdateTenant(tenantAttributes);
+    } else {
+      log.info("Not executing full tenant init for not central tenant {}.", tenantId);
+      baseAfterTenantUpdate();
+    }
+  }
+
+  private void baseAfterTenantUpdate() {
+    kafkaAdminService.createTopics(context.getTenantId());
+    kafkaAdminService.restartEventListeners();
+    prepareSystemUserService.setupSystemUser();
+    log.info("Tenant base init has been completed");
+  }
+
+  /**
+   * Initializes tenant using given {@link TenantAttributes}.
+   *
+   * <p>This method:</p>
+   * <ul>
+   *   <li>Creates Kafka topics</li>
+   *   <li>Creates a system user to perform record indexing</li>
    *   <li>Add default languages to the tenant configuration</li>
    *   <li>Creates Elasticsearch indexes and corresponding mappings for supported record types</li>
    *   <li>Starts reindexing process for inventory (if it's specified)</li>
@@ -71,16 +113,39 @@ public class SearchTenantService extends TenantService {
    */
   @Override
   protected void afterTenantUpdate(TenantAttributes tenantAttributes) {
-    kafkaAdminService.createTopics(context.getTenantId());
-    kafkaAdminService.restartEventListeners();
-    prepareSystemUserService.setupSystemUser();
+    baseAfterTenantUpdate();
     createLanguages();
     createIndexesAndReindex(tenantAttributes);
     log.info("Tenant init has been completed");
   }
 
   /**
-   * Removes elasticsearch indices for all supported record types and cleaning related caches.
+   * Removes database schemas.
+   * Removes elasticsearch indices for all supported record types and cleaning related caches
+   * if it's not a consortium member tenant.
+   * Deletes kafka topics.
+   *
+   * @param tenantAttributes - tenant attributes comes from {@code POST /_/tenant} request.
+   */
+  @Override
+  public void deleteTenant(TenantAttributes tenantAttributes) {
+    var tenantId = context.getTenantId();
+    var centralTenant = centralTenant(tenantId, tenantAttributes);
+    if (tenantId.equals(centralTenant)) {
+      super.deleteTenant(tenantAttributes);
+    } else {
+      log.info("Not executing full tenant destroy for not central tenant {}.", tenantId);
+      baseAfterTenantDeletion(tenantId);
+    }
+  }
+
+  private void baseAfterTenantDeletion(String tenantId) {
+    kafkaAdminService.deleteTopics(tenantId);
+  }
+
+  /**
+   * Removes elasticsearch indices for all supported record types and cleaning related caches
+   * if it's not a consortium member tenant.
    *
    * @param tenantAttributes - tenant attributes comes from {@code POST /_/tenant} request.
    */
@@ -93,7 +158,7 @@ public class SearchTenantService extends TenantService {
       indexService.dropIndex(name, tenantId);
     });
 
-    kafkaAdminService.deleteTopics(tenantId);
+    baseAfterTenantDeletion(tenantId);
   }
 
   private void createIndexesAndReindex(TenantAttributes tenantAttributes) {
@@ -121,6 +186,15 @@ public class SearchTenantService extends TenantService {
       .filter(code -> !existingLanguages.contains(code))
       .map(code -> new LanguageConfig().code(code))
       .forEach(languageConfigService::create);
+  }
+
+  private String centralTenant(String contextTenantId, TenantAttributes tenantAttributes) {
+    return Optional.ofNullable(tenantAttributes.getParameters())
+      .flatMap(parameters -> parameters.stream()
+        .filter(parameter -> parameter.getKey().equals(CENTRAL_TENANT_ID_PARAM_NAME))
+        .findFirst()
+        .map(Parameter::getValue))
+      .orElse(contextTenantId);
   }
 
 }

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseResultConverter.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseResultConverter.java
@@ -30,7 +30,7 @@ import org.folio.search.domain.dto.Item;
 import org.folio.search.model.BrowseResult;
 import org.folio.search.model.SearchResult;
 import org.folio.search.model.service.BrowseContext;
-import org.folio.search.service.FeatureConfigService;
+import org.folio.search.service.consortia.FeatureConfigServiceDecorator;
 import org.folio.search.service.converter.ElasticsearchDocumentConverter;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.search.SearchHit;
@@ -42,7 +42,7 @@ import org.springframework.stereotype.Component;
 public class CallNumberBrowseResultConverter {
 
   private final ElasticsearchDocumentConverter documentConverter;
-  private final FeatureConfigService featureConfigService;
+  private final FeatureConfigServiceDecorator featureConfigService;
 
   /**
    * Converts received {@link SearchResponse} from Elasticsearch to browsing {@link SearchResult} object.

--- a/src/main/java/org/folio/search/service/consortia/ConsortiaService.java
+++ b/src/main/java/org/folio/search/service/consortia/ConsortiaService.java
@@ -1,0 +1,27 @@
+package org.folio.search.service.consortia;
+
+import static org.folio.search.configuration.SearchCacheNames.USER_TENANTS_CACHE;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.folio.search.client.UserTenantsClient;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ConsortiaService {
+
+  private final UserTenantsClient userTenantsClient;
+
+  @Cacheable(USER_TENANTS_CACHE)
+  public Optional<String> getCentralTenant(String tenantId) {
+    var userTenants = userTenantsClient.getUserTenants(tenantId);
+
+    return Optional.ofNullable(userTenants)
+      .flatMap(tenants -> tenants.userTenants().stream()
+        .findFirst()
+        .map(UserTenantsClient.UserTenant::centralTenantId));
+  }
+
+}

--- a/src/main/java/org/folio/search/service/consortia/ConsortiaTenantExecutor.java
+++ b/src/main/java/org/folio/search/service/consortia/ConsortiaTenantExecutor.java
@@ -1,0 +1,34 @@
+package org.folio.search.service.consortia;
+
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.tools.systemuser.SystemUserScopedExecutionService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ConsortiaTenantExecutor {
+
+  private final FolioExecutionContext folioExecutionContext;
+  private final TenantProvider tenantProvider;
+  private final SystemUserScopedExecutionService scopedExecutionService;
+
+  public <T> T execute(Supplier<T> operation) {
+    var contextTenantId = folioExecutionContext.getTenantId();
+    var tenantId = tenantProvider.getTenant(contextTenantId);
+    if (contextTenantId.equals(tenantId)) {
+      return operation.get();
+    } else {
+      return scopedExecutionService.executeSystemUserScoped(tenantId, operation::get);
+    }
+  }
+
+  public void run(Runnable operation) {
+    execute(() -> {
+      operation.run();
+      return null;
+    });
+  }
+
+}

--- a/src/main/java/org/folio/search/service/consortia/ConsortiaTenantProvider.java
+++ b/src/main/java/org/folio/search/service/consortia/ConsortiaTenantProvider.java
@@ -1,0 +1,15 @@
+package org.folio.search.service.consortia;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ConsortiaTenantProvider implements TenantProvider {
+
+  private final ConsortiaService consortiaService;
+
+  @Override
+  public String getTenant(String tenantId) {
+    return consortiaService.getCentralTenant(tenantId)
+      .orElse(tenantId);
+  }
+}

--- a/src/main/java/org/folio/search/service/consortia/FeatureConfigServiceDecorator.java
+++ b/src/main/java/org/folio/search/service/consortia/FeatureConfigServiceDecorator.java
@@ -1,0 +1,37 @@
+package org.folio.search.service.consortia;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.search.domain.dto.FeatureConfig;
+import org.folio.search.domain.dto.FeatureConfigs;
+import org.folio.search.domain.dto.TenantConfiguredFeature;
+import org.folio.search.service.FeatureConfigService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FeatureConfigServiceDecorator {
+
+  private final ConsortiaTenantExecutor consortiaTenantExecutor;
+  private final FeatureConfigService featureConfigService;
+
+  public boolean isEnabled(TenantConfiguredFeature feature) {
+    return consortiaTenantExecutor.execute(() -> featureConfigService.isEnabled(feature));
+  }
+
+  public FeatureConfigs getAll() {
+    return consortiaTenantExecutor.execute(featureConfigService::getAll);
+  }
+
+  public FeatureConfig create(FeatureConfig featureConfig) {
+    return consortiaTenantExecutor.execute(() -> featureConfigService.create(featureConfig));
+  }
+
+  public FeatureConfig update(TenantConfiguredFeature feature, FeatureConfig featureConfig) {
+    return consortiaTenantExecutor.execute(() -> featureConfigService.update(feature, featureConfig));
+  }
+
+  public void delete(TenantConfiguredFeature feature) {
+    consortiaTenantExecutor.run(() -> featureConfigService.delete(feature));
+  }
+
+}

--- a/src/main/java/org/folio/search/service/consortia/LanguageConfigServiceDecorator.java
+++ b/src/main/java/org/folio/search/service/consortia/LanguageConfigServiceDecorator.java
@@ -1,0 +1,41 @@
+package org.folio.search.service.consortia;
+
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.folio.search.domain.dto.LanguageConfig;
+import org.folio.search.domain.dto.LanguageConfigs;
+import org.folio.search.service.LanguageConfigService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LanguageConfigServiceDecorator {
+
+  private final ConsortiaTenantExecutor consortiaTenantExecutor;
+  private final LanguageConfigService languageConfigService;
+
+  public LanguageConfig create(LanguageConfig languageConfig) {
+    return consortiaTenantExecutor.execute(() -> languageConfigService.create(languageConfig));
+  }
+
+  public LanguageConfig update(String code, LanguageConfig languageConfig) {
+    return consortiaTenantExecutor.execute(() -> languageConfigService.update(code, languageConfig));
+  }
+
+  public void delete(String code) {
+    consortiaTenantExecutor.run(() -> languageConfigService.delete(code));
+  }
+
+  public LanguageConfigs getAll() {
+    return consortiaTenantExecutor.execute(languageConfigService::getAll);
+  }
+
+  public Set<String> getAllLanguageCodes() {
+    return consortiaTenantExecutor.execute(languageConfigService::getAllLanguageCodes);
+  }
+
+  public Set<String> getAllLanguagesForTenant(String tenant) {
+    return languageConfigService.getAllLanguagesForTenant(tenant);
+  }
+
+}

--- a/src/main/java/org/folio/search/service/consortia/ResourceIdServiceDecorator.java
+++ b/src/main/java/org/folio/search/service/consortia/ResourceIdServiceDecorator.java
@@ -1,0 +1,33 @@
+package org.folio.search.service.consortia;
+
+import java.io.OutputStream;
+import lombok.RequiredArgsConstructor;
+import org.folio.search.model.service.CqlResourceIdsRequest;
+import org.folio.search.model.streamids.ResourceIdsJobEntity;
+import org.folio.search.service.ResourceIdService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ResourceIdServiceDecorator {
+
+  private final ConsortiaTenantExecutor consortiaTenantExecutor;
+  private final ResourceIdService resourceIdService;
+
+  public void streamResourceIdsAsText(CqlResourceIdsRequest request, OutputStream outputStream) {
+    resourceIdService.streamResourceIdsAsText(request, outputStream);
+  }
+
+  public void streamIdsFromDatabaseAsJson(String jobId, OutputStream outputStream) {
+    consortiaTenantExecutor.run(() -> resourceIdService.streamIdsFromDatabaseAsJson(jobId, outputStream));
+  }
+
+  public void streamResourceIdsForJob(ResourceIdsJobEntity job, String tenantId) {
+    consortiaTenantExecutor.run(() -> resourceIdService.streamResourceIdsForJob(job, tenantId));
+  }
+
+  public void streamResourceIdsAsJson(CqlResourceIdsRequest request, OutputStream outputStream) {
+    resourceIdService.streamResourceIdsAsJson(request, outputStream);
+  }
+
+}

--- a/src/main/java/org/folio/search/service/consortia/ResourceIdsJobServiceDecorator.java
+++ b/src/main/java/org/folio/search/service/consortia/ResourceIdsJobServiceDecorator.java
@@ -1,0 +1,23 @@
+package org.folio.search.service.consortia;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.search.domain.dto.ResourceIdsJob;
+import org.folio.search.service.ResourceIdsJobService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ResourceIdsJobServiceDecorator {
+
+  private final ConsortiaTenantExecutor consortiaTenantExecutor;
+  private final ResourceIdsJobService resourceIdsJobService;
+
+  public ResourceIdsJob getJobById(String id) {
+    return consortiaTenantExecutor.execute(() -> resourceIdsJobService.getJobById(id));
+  }
+
+  public ResourceIdsJob createStreamJob(ResourceIdsJob job, String tenantId) {
+    return consortiaTenantExecutor.execute(() -> resourceIdsJobService.createStreamJob(job, tenantId));
+  }
+
+}

--- a/src/main/java/org/folio/search/service/consortia/TenantProvider.java
+++ b/src/main/java/org/folio/search/service/consortia/TenantProvider.java
@@ -1,0 +1,5 @@
+package org.folio.search.service.consortia;
+
+public interface TenantProvider {
+  String getTenant(String tenantId);
+}

--- a/src/main/java/org/folio/search/service/converter/SearchDocumentConverter.java
+++ b/src/main/java/org/folio/search/service/converter/SearchDocumentConverter.java
@@ -26,7 +26,7 @@ import org.folio.search.model.metadata.FieldDescription;
 import org.folio.search.model.metadata.ObjectFieldDescription;
 import org.folio.search.model.metadata.PlainFieldDescription;
 import org.folio.search.model.types.IndexingDataFormat;
-import org.folio.search.service.LanguageConfigService;
+import org.folio.search.service.consortia.LanguageConfigServiceDecorator;
 import org.folio.search.service.metadata.ResourceDescriptionService;
 import org.folio.search.utils.SearchConverterUtils;
 import org.folio.search.utils.SearchUtils;
@@ -38,13 +38,13 @@ import org.springframework.stereotype.Component;
 public class SearchDocumentConverter {
 
   private final SearchFieldsProcessor searchFieldsProcessor;
-  private final LanguageConfigService languageConfigService;
+  private final LanguageConfigServiceDecorator languageConfigService;
   private final ResourceDescriptionService descriptionService;
   private final IndexingDataFormat indexingDataFormat;
   private final Function<Map<String, Object>, BytesReference> searchDocumentBodyConverter;
 
   public SearchDocumentConverter(SearchFieldsProcessor searchFieldsProcessor,
-                                 LanguageConfigService languageConfigService,
+                                 LanguageConfigServiceDecorator languageConfigService,
                                  ResourceDescriptionService descriptionService,
                                  SearchConfigurationProperties searchConfigurationProperties,
                                  Function<Map<String, Object>, BytesReference> searchDocumentBodyConverter) {
@@ -78,8 +78,6 @@ public class SearchDocumentConverter {
     var resourceEvent = context.getResourceEvent();
     var resourceDescriptionFields = context.getResourceDescription().getFields();
     var baseFields = convertMapUsingResourceFields(getNewAsMap(resourceEvent), resourceDescriptionFields, context);
-    // added for testing purposes. tenantId have to be populated only with consortium indexing
-    baseFields.put("tenantId", context.getResourceEvent().getTenant());
     var searchFields = searchFieldsProcessor.getSearchFields(context);
     var resultDocument = mergeSafely(baseFields, searchFields);
     return SearchDocumentBody.of(searchDocumentBodyConverter.apply(resultDocument),

--- a/src/main/java/org/folio/search/service/converter/SearchFieldsProcessor.java
+++ b/src/main/java/org/folio/search/service/converter/SearchFieldsProcessor.java
@@ -13,7 +13,7 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.folio.search.model.converter.ConversionContext;
 import org.folio.search.model.metadata.SearchFieldDescriptor;
-import org.folio.search.service.FeatureConfigService;
+import org.folio.search.service.consortia.FeatureConfigServiceDecorator;
 import org.folio.search.service.setter.FieldProcessor;
 import org.folio.search.utils.JsonConverter;
 import org.folio.search.utils.SearchUtils;
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 public class SearchFieldsProcessor {
 
   private final JsonConverter jsonConverter;
-  private final FeatureConfigService featureConfigService;
+  private final FeatureConfigServiceDecorator featureConfigService;
   private final Map<String, FieldProcessor<?, ?>> fieldProcessors;
 
   /**

--- a/src/main/java/org/folio/search/service/es/SearchMappingsHelper.java
+++ b/src/main/java/org/folio/search/service/es/SearchMappingsHelper.java
@@ -20,7 +20,7 @@ import org.folio.search.exception.ResourceDescriptionException;
 import org.folio.search.model.metadata.FieldDescription;
 import org.folio.search.model.metadata.ObjectFieldDescription;
 import org.folio.search.model.metadata.PlainFieldDescription;
-import org.folio.search.service.LanguageConfigService;
+import org.folio.search.service.consortia.LanguageConfigServiceDecorator;
 import org.folio.search.service.metadata.ResourceDescriptionService;
 import org.folio.search.service.metadata.SearchFieldProvider;
 import org.folio.search.utils.JsonConverter;
@@ -35,7 +35,7 @@ public class SearchMappingsHelper {
 
   private final JsonConverter jsonConverter;
   private final SearchFieldProvider searchFieldProvider;
-  private final LanguageConfigService languageConfigService;
+  private final LanguageConfigServiceDecorator languageConfigService;
   private final ResourceDescriptionService resourceDescriptionService;
 
   /**
@@ -88,8 +88,8 @@ public class SearchMappingsHelper {
   }
 
   private Map<String, JsonNode> getMappingForField(String name, FieldDescription fieldDescription) {
-    if (fieldDescription instanceof PlainFieldDescription) {
-      return getMappingsForPlainField(name, (PlainFieldDescription) fieldDescription);
+    if (fieldDescription instanceof PlainFieldDescription plainFieldDescription) {
+      return getMappingsForPlainField(name, plainFieldDescription);
     }
     return getMappingForObjectField(name, (ObjectFieldDescription) fieldDescription);
   }

--- a/src/main/java/org/folio/search/service/setter/authority/AuthoritySearchResponsePostProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/authority/AuthoritySearchResponsePostProcessor.java
@@ -14,6 +14,7 @@ import org.folio.search.domain.dto.Authority;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.model.SimpleResourceRequest;
 import org.folio.search.repository.SearchRepository;
+import org.folio.search.service.consortia.TenantProvider;
 import org.folio.search.service.metadata.SearchFieldProvider;
 import org.folio.search.service.setter.SearchResponsePostProcessor;
 import org.folio.search.utils.SearchUtils;
@@ -29,6 +30,7 @@ public final class AuthoritySearchResponsePostProcessor implements SearchRespons
   private final SearchRepository searchRepository;
   private final SearchFieldProvider searchFieldProvider;
   private final FolioExecutionContext context;
+  private final TenantProvider tenantProvider;
 
   @Override
   public Class<Authority> getGeneric() {
@@ -56,7 +58,8 @@ public final class AuthoritySearchResponsePostProcessor implements SearchRespons
     var instanceResourceName = SearchUtils.getResourceName(Instance.class);
     var queries = buildQueries(authorities, instanceResourceName);
 
-    var resourceRequest = SimpleResourceRequest.of(instanceResourceName, context.getTenantId());
+    var resourceRequest = SimpleResourceRequest.of(instanceResourceName,
+      tenantProvider.getTenant(context.getTenantId()));
     var responses = searchRepository.msearch(resourceRequest, queries).getResponses();
 
     for (int i = 0; i < responses.length; i++) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,7 @@ spring:
       - tenant-languages
       - tenant-features
       - search-preference
+      - user-tenants
     caffeine:
       spec: maximumSize=500,expireAfterWrite=3600s
   main:

--- a/src/test/java/org/folio/search/controller/BrowseAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseAuthorityIT.java
@@ -346,7 +346,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
   }
 
   private static Authority authority(int index) {
-    return new Authority().id(getId(index))
+    return new Authority().id(getId(index)).tenantId(TENANT_ID)
       .subjectHeadings(String.format("Authority #%02d", index))
       .source("MARC")
       .sourceFileId("5de462a2-7a90-4467-b77f-b2057d6d69b6").naturalId("nbc123435");

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberPrecedingIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberPrecedingIT.java
@@ -24,6 +24,7 @@ import org.folio.spring.test.type.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @IntegrationTest
 class BrowseCallNumberPrecedingIT extends BaseIntegrationTest {
@@ -31,6 +32,9 @@ class BrowseCallNumberPrecedingIT extends BaseIntegrationTest {
   private static final Instance[] INSTANCES = instances();
   private static final Map<String, Instance> INSTANCE_MAP =
     Arrays.stream(INSTANCES).collect(toMap(Instance::getTitle, identity()));
+
+  @Autowired
+  private Boolean inConsortiumMode;
 
   @BeforeAll
   static void prepare() {
@@ -99,8 +103,14 @@ class BrowseCallNumberPrecedingIT extends BaseIntegrationTest {
       .holdings(emptyList());
   }
 
-  private static Instance instance(String title) {
-    return INSTANCE_MAP.get(title);
+  private Instance instance(String title) {
+    var instance = INSTANCE_MAP.get(title);
+
+    if (!inConsortiumMode) {
+      instance.setShared(null);
+    }
+
+    return instance;
   }
 
   private static List<List<Object>> callNumberBrowseInstanceData() {

--- a/src/test/java/org/folio/search/controller/BrowseContributorIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorIT.java
@@ -71,7 +71,7 @@ class BrowseContributorIT extends BaseIntegrationTest {
     await().atMost(ONE_MINUTE).pollInterval(ONE_SECOND).untilAsserted(() -> {
       var searchRequest = new SearchRequest()
         .source(searchSource().query(matchAllQuery()).trackTotalHits(true).from(0).size(0))
-        .indices(getIndexName(SearchUtils.CONTRIBUTOR_RESOURCE, TENANT_ID));
+        .indices(getIndexName(SearchUtils.CONTRIBUTOR_RESOURCE, centralTenant));
       var searchResponse = restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
       assertThat(searchResponse.getHits().getTotalHits().value).isEqualTo(12);
     });

--- a/src/test/java/org/folio/search/controller/BrowseControllerTest.java
+++ b/src/test/java/org/folio/search/controller/BrowseControllerTest.java
@@ -30,7 +30,9 @@ import org.folio.search.service.browse.AuthorityBrowseService;
 import org.folio.search.service.browse.CallNumberBrowseService;
 import org.folio.search.service.browse.ContributorBrowseService;
 import org.folio.search.service.browse.SubjectBrowseService;
+import org.folio.search.service.consortia.TenantProvider;
 import org.folio.search.service.setter.SearchResponsePostProcessor;
+import org.folio.search.support.base.TenantConfig;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.test.type.UnitTest;
 import org.junit.jupiter.api.Test;
@@ -43,11 +45,15 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @UnitTest
 @WebMvcTest(BrowseController.class)
-@Import({ApiExceptionHandler.class})
+@Import({ApiExceptionHandler.class, TenantConfig.class})
 class BrowseControllerTest {
 
   @Autowired
   private MockMvc mockMvc;
+  @Autowired
+  private String centralTenant;
+  @Autowired
+  private TenantProvider tenantProvider;
   @MockBean
   private SubjectBrowseService subjectBrowseService;
   @MockBean
@@ -79,7 +85,7 @@ class BrowseControllerTest {
   @Test
   void browseInstancesByCallNumber_positive_allFields() throws Exception {
     var query = "callNumber > B";
-    var request = BrowseRequest.of(INSTANCE_RESOURCE, TENANT_ID,
+    var request = BrowseRequest.of(INSTANCE_RESOURCE, centralTenant,
       query, 20, SHELVING_ORDER_BROWSING_FIELD, CALL_NUMBER_BROWSING_FIELD, true, true, 5);
     when(callNumberBrowseService.browse(request)).thenReturn(BrowseResult.empty());
 
@@ -101,7 +107,7 @@ class BrowseControllerTest {
   @Test
   void browseInstancesBySubject_positive() throws Exception {
     var query = "value > water";
-    var request = BrowseRequest.of(INSTANCE_SUBJECT_RESOURCE, TENANT_ID, query, 25, "value", null, null, true, 12);
+    var request = BrowseRequest.of(INSTANCE_SUBJECT_RESOURCE, centralTenant, query, 25, "value", null, null, true, 12);
     var browseResult = BrowseResult.of(1, List.of(subjectBrowseItem(10, "water treatment")));
     when(subjectBrowseService.browse(request)).thenReturn(browseResult);
     var requestBuilder = get(instanceSubjectBrowsePath())
@@ -120,7 +126,7 @@ class BrowseControllerTest {
   @Test
   void browseAuthoritiesByHeadingRef_positive() throws Exception {
     var query = "headingRef > mark";
-    var request = BrowseRequest.of(AUTHORITY_RESOURCE, TENANT_ID, query, 25, "headingRef", null, false, true, 12);
+    var request = BrowseRequest.of(AUTHORITY_RESOURCE, centralTenant, query, 25, "headingRef", null, false, true, 12);
     var authority = new Authority().id(RESOURCE_ID).headingRef("mark twain");
     var browseResult = BrowseResult.of(1, List.of(authorityBrowseItem("mark twain", authority)));
     when(authorityBrowseService.browse(request)).thenReturn(browseResult);
@@ -191,8 +197,8 @@ class BrowseControllerTest {
         "browseInstancesByCallNumber.precedingRecordsCount must be greater than or equal to 1")));
   }
 
-  public static BrowseRequest browseRequest(String query, int limit) {
-    return BrowseRequest.of(INSTANCE_RESOURCE, TENANT_ID, query, limit,
+  private BrowseRequest browseRequest(String query, int limit) {
+    return BrowseRequest.of(INSTANCE_RESOURCE, centralTenant, query, limit,
       SHELVING_ORDER_BROWSING_FIELD, CALL_NUMBER_BROWSING_FIELD, false, true, limit / 2);
   }
 }

--- a/src/test/java/org/folio/search/controller/BrowseSubjectIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseSubjectIT.java
@@ -8,7 +8,6 @@ import static org.awaitility.Durations.ONE_SECOND;
 import static org.folio.search.model.Pair.pair;
 import static org.folio.search.support.base.ApiEndpoints.instanceSubjectBrowsePath;
 import static org.folio.search.utils.SearchUtils.getIndexName;
-import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.parseResponse;
 import static org.folio.search.utils.TestUtils.randomId;
 import static org.folio.search.utils.TestUtils.subjectBrowseItem;
@@ -53,7 +52,7 @@ class BrowseSubjectIT extends BaseIntegrationTest {
     await().atMost(ONE_MINUTE).pollInterval(ONE_SECOND).untilAsserted(() -> {
       var searchRequest = new SearchRequest()
         .source(searchSource().query(matchAllQuery()).trackTotalHits(true).from(0).size(0))
-        .indices(getIndexName(SearchUtils.INSTANCE_SUBJECT_RESOURCE, TENANT_ID));
+        .indices(getIndexName(SearchUtils.INSTANCE_SUBJECT_RESOURCE, centralTenant));
       var searchResponse = restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
       assertThat(searchResponse.getHits().getTotalHits().value).isEqualTo(23);
     });

--- a/src/test/java/org/folio/search/controller/ConfigControllerTest.java
+++ b/src/test/java/org/folio/search/controller/ConfigControllerTest.java
@@ -24,8 +24,8 @@ import org.folio.search.domain.dto.FeatureConfigs;
 import org.folio.search.domain.dto.LanguageConfigs;
 import org.folio.search.exception.RequestValidationException;
 import org.folio.search.exception.ValidationException;
-import org.folio.search.service.FeatureConfigService;
-import org.folio.search.service.LanguageConfigService;
+import org.folio.search.service.consortia.FeatureConfigServiceDecorator;
+import org.folio.search.service.consortia.LanguageConfigServiceDecorator;
 import org.folio.search.support.base.ApiEndpoints;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.test.type.UnitTest;
@@ -44,9 +44,9 @@ class ConfigControllerTest {
   @Autowired
   private MockMvc mockMvc;
   @MockBean
-  private LanguageConfigService languageConfigService;
+  private LanguageConfigServiceDecorator languageConfigService;
   @MockBean
-  private FeatureConfigService featureConfigService;
+  private FeatureConfigServiceDecorator featureConfigService;
 
   @Test
   void createLanguageConfig_positive() throws Exception {

--- a/src/test/java/org/folio/search/controller/FacetsControllerTest.java
+++ b/src/test/java/org/folio/search/controller/FacetsControllerTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.folio.search.exception.RequestValidationException;
 import org.folio.search.service.FacetService;
+import org.folio.search.support.base.TenantConfig;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.test.type.UnitTest;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 @UnitTest
-@Import({ApiExceptionHandler.class})
+@Import({ApiExceptionHandler.class, TenantConfig.class})
 @WebMvcTest(FacetsController.class)
 class FacetsControllerTest {
 
@@ -42,6 +43,8 @@ class FacetsControllerTest {
   private FacetService facetService;
   @Autowired
   private MockMvc mockMvc;
+  @Autowired
+  private String centralTenant;
 
   public static Stream<Arguments> facetsTestSource() {
     return Stream.of(
@@ -55,7 +58,7 @@ class FacetsControllerTest {
   @ParameterizedTest
   void getFacets_positive(String recordType, String resource) throws Exception {
     var cqlQuery = "source all \"test-query\"";
-    var expectedFacetRequest = facetServiceRequest(resource, cqlQuery, "source:5");
+    var expectedFacetRequest = facetServiceRequest(centralTenant, resource, cqlQuery, "source:5");
     when(facetService.getFacets(expectedFacetRequest)).thenReturn(
       facetResult(mapOf("source", facet(List.of(facetItem("MARC", 20), facetItem("FOLIO", 10))))));
 
@@ -78,7 +81,7 @@ class FacetsControllerTest {
   @Test
   void getFacets_negative_unknownFacet() throws Exception {
     var cqlQuery = "title all \"test-query\"";
-    var expectedFacetRequest = facetServiceRequest(INSTANCE_RESOURCE, cqlQuery, "source:5");
+    var expectedFacetRequest = facetServiceRequest(centralTenant, INSTANCE_RESOURCE, cqlQuery, "source:5");
     when(facetService.getFacets(expectedFacetRequest)).thenThrow(
       new RequestValidationException("Invalid facet value", "facet", "source"));
 

--- a/src/test/java/org/folio/search/controller/RecordsIndexingIT.java
+++ b/src/test/java/org/folio/search/controller/RecordsIndexingIT.java
@@ -90,20 +90,20 @@ class RecordsIndexingIT extends BaseIntegrationTest {
 
     inventoryApi.createInstance(TENANT_ID, instance);
     assertCountByQuery(instanceSearchPath(), "subjects=={value}", "(s1 and s2)", 1);
-    assertSubjectExistenceById(sha1Hex(TENANT_ID + "|s1|null"), true);
-    assertSubjectExistenceById(sha1Hex(TENANT_ID + "|s2|null"), true);
+    assertSubjectExistenceById(sha1Hex(centralTenant + "|s1|null"), true);
+    assertSubjectExistenceById(sha1Hex(centralTenant + "|s2|null"), true);
 
     var instanceToUpdate = new Instance().id(instanceId).title("test-resource").subjects(
       List.of(new Subject().value("s2"), new Subject().value("s3")));
     inventoryApi.updateInstance(TENANT_ID, instanceToUpdate);
     assertCountByQuery(instanceSearchPath(), "subjects=={value}", "(s2 and s3)", 1);
-    assertSubjectExistenceById(sha1Hex(TENANT_ID + "|s1|null"), false);
-    assertSubjectExistenceById(sha1Hex(TENANT_ID + "|s3|null"), true);
+    assertSubjectExistenceById(sha1Hex(centralTenant + "|s1|null"), false);
+    assertSubjectExistenceById(sha1Hex(centralTenant + "|s3|null"), true);
 
     inventoryApi.deleteInstance(TENANT_ID, instanceId);
     assertCountByQuery(instanceSearchPath(), "id=={value}", instanceId, 0);
-    assertSubjectExistenceById(sha1Hex(TENANT_ID + "|s2|null"), false);
-    assertSubjectExistenceById(sha1Hex(TENANT_ID + "|s3|null"), false);
+    assertSubjectExistenceById(sha1Hex(centralTenant + "|s2|null"), false);
+    assertSubjectExistenceById(sha1Hex(centralTenant + "|s3|null"), false);
   }
 
   @Test
@@ -271,7 +271,7 @@ class RecordsIndexingIT extends BaseIntegrationTest {
   }
 
   private static String getSubjectId(String instanceId) {
-    return sha1Hex(TENANT_ID + "|subject-" + sha1Hex(instanceId) + "|null");
+    return sha1Hex(centralTenant + "|subject-" + sha1Hex(instanceId) + "|null");
   }
 
   private void createInstances() {
@@ -294,7 +294,7 @@ class RecordsIndexingIT extends BaseIntegrationTest {
   }
 
   private boolean isInstanceSubjectExistsById(String subjectId) throws IOException {
-    var indexName = getIndexName(INSTANCE_SUBJECT_RESOURCE, TENANT_ID);
+    var indexName = getIndexName(INSTANCE_SUBJECT_RESOURCE, centralTenant);
     var request = new GetRequest(indexName, subjectId);
     var documentById = restHighLevelClient.get(request, RequestOptions.DEFAULT);
     return documentById.isExists() && !documentById.isSourceEmpty();

--- a/src/test/java/org/folio/search/controller/ResourcesIdsControllerTest.java
+++ b/src/test/java/org/folio/search/controller/ResourcesIdsControllerTest.java
@@ -26,9 +26,10 @@ import java.util.List;
 import org.folio.search.domain.dto.ResourceId;
 import org.folio.search.domain.dto.ResourceIds;
 import org.folio.search.model.service.CqlResourceIdsRequest;
-import org.folio.search.service.ResourceIdService;
-import org.folio.search.service.ResourceIdsJobService;
 import org.folio.search.service.ResourceIdsStreamHelper;
+import org.folio.search.service.consortia.ResourceIdServiceDecorator;
+import org.folio.search.service.consortia.ResourceIdsJobServiceDecorator;
+import org.folio.search.support.base.TenantConfig;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.test.type.UnitTest;
 import org.junit.jupiter.api.Test;
@@ -40,22 +41,24 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @UnitTest
 @WebMvcTest(ResourcesIdsController.class)
-@Import({ApiExceptionHandler.class, ResourceIdsStreamHelper.class, ResourceIdsJobService.class,
-         ResourceIdService.class})
+@Import({ApiExceptionHandler.class, ResourceIdsStreamHelper.class, ResourceIdsJobServiceDecorator.class,
+  ResourceIdServiceDecorator.class, TenantConfig.class})
 class ResourcesIdsControllerTest {
 
   @Autowired
+  private String centralTenant;
+  @Autowired
   private MockMvc mockMvc;
   @MockBean
-  private ResourceIdService resourceIdService;
+  private ResourceIdServiceDecorator resourceIdService;
   @MockBean
-  private ResourceIdsJobService resourceIdsJobService;
+  private ResourceIdsJobServiceDecorator resourceIdsJobService;
 
   @Test
   void getHoldingsIds_positive() throws Exception {
     var cqlQuery = "id=*";
     var holdingId = randomId();
-    var request = CqlResourceIdsRequest.of(INSTANCE_RESOURCE, TENANT_ID, cqlQuery, HOLDINGS_ID_PATH);
+    var request = CqlResourceIdsRequest.of(INSTANCE_RESOURCE, centralTenant, cqlQuery, HOLDINGS_ID_PATH);
 
     doAnswer(inv -> {
       var out = (OutputStream) inv.getArgument(1);
@@ -80,7 +83,7 @@ class ResourcesIdsControllerTest {
   void getHoldingsIdsTextType_positive() throws Exception {
     var cqlQuery = "id=*";
     var holdingId = randomId();
-    var request = CqlResourceIdsRequest.of(INSTANCE_RESOURCE, TENANT_ID, cqlQuery, HOLDINGS_ID_PATH);
+    var request = CqlResourceIdsRequest.of(INSTANCE_RESOURCE, centralTenant, cqlQuery, HOLDINGS_ID_PATH);
 
     doAnswer(inv -> {
       var out = (OutputStream) inv.getArgument(1);
@@ -103,7 +106,7 @@ class ResourcesIdsControllerTest {
   void getInstanceIds_positive() throws Exception {
     var cqlQuery = "id=*";
     var instanceId = randomId();
-    var request = CqlResourceIdsRequest.of(INSTANCE_RESOURCE, TENANT_ID, cqlQuery, INSTANCE_ID_PATH);
+    var request = CqlResourceIdsRequest.of(INSTANCE_RESOURCE, centralTenant, cqlQuery, INSTANCE_ID_PATH);
 
     doAnswer(inv -> {
       var out = (OutputStream) inv.getArgument(1);
@@ -128,7 +131,7 @@ class ResourcesIdsControllerTest {
   void getInstanceIdsTextType_positive() throws Exception {
     var cqlQuery = "id=*";
     var instanceId = randomId();
-    var request = CqlResourceIdsRequest.of(INSTANCE_RESOURCE, TENANT_ID, cqlQuery, INSTANCE_ID_PATH);
+    var request = CqlResourceIdsRequest.of(INSTANCE_RESOURCE, centralTenant, cqlQuery, INSTANCE_ID_PATH);
 
     doAnswer(inv -> {
       var out = (OutputStream) inv.getArgument(1);

--- a/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
@@ -464,6 +464,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       .toArray(Instance[]::new);
 
     instances[0]
+      .tenantId(TENANT_ID)
       .source("MARC")
       .languages(List.of("eng", "ita"))
       .instanceTypeId(TYPES[1])
@@ -488,6 +489,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
           .permanentLocationId(PERMANENT_LOCATIONS[0]).tags(tags("htag1", "htag2"))));
 
     instances[1]
+      .tenantId(TENANT_ID)
       .source("MARC")
       .languages(List.of("eng", "ger", "fra"))
       .instanceTypeId(TYPES[0])
@@ -511,6 +513,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
         .permanentLocationId(PERMANENT_LOCATIONS[1]).tags(tags("htag2", "htag3"))));
 
     instances[2]
+      .tenantId(TENANT_ID)
       .source("FOLIO")
       .languages(List.of("rus", "ukr"))
       .instanceTypeId(TYPES[0])
@@ -527,6 +530,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
           .tags(tags("itag1", "itag2", "itag3"))));
 
     instances[3]
+      .tenantId(TENANT_ID)
       .source("CONSORTIUM-MARC")
       .languages(List.of("ita"))
       .staffSuppress(false)
@@ -551,6 +555,7 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
         new Holding().id(randomId()).permanentLocationId(PERMANENT_LOCATIONS[2]).tags(tags("htag3"))));
 
     instances[4]
+      .tenantId(TENANT_ID)
       .source("CONSORTIUM-FOLIO")
       .languages(List.of("eng", "fra"))
       .instanceTypeId(TYPES[1])

--- a/src/test/java/org/folio/search/service/FacetServiceTest.java
+++ b/src/test/java/org/folio/search/service/FacetServiceTest.java
@@ -2,7 +2,7 @@ package org.folio.search.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
-import static org.folio.search.utils.TestUtils.facetServiceRequest;
+import static org.folio.search.utils.TestUtils.defaultFacetServiceRequest;
 import static org.mockito.Mockito.when;
 import static org.opensearch.index.query.QueryBuilders.boolQuery;
 import static org.opensearch.index.query.QueryBuilders.matchQuery;
@@ -86,6 +86,6 @@ class FacetServiceTest {
   }
 
   private static CqlFacetRequest facetRequest(String... facetNames) {
-    return facetServiceRequest(RESOURCE_NAME, QUERY, facetNames);
+    return defaultFacetServiceRequest(RESOURCE_NAME, QUERY, facetNames);
   }
 }

--- a/src/test/java/org/folio/search/service/ResourceIdsStreamHelperTest.java
+++ b/src/test/java/org/folio/search/service/ResourceIdsStreamHelperTest.java
@@ -15,6 +15,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.folio.search.exception.SearchServiceException;
 import org.folio.search.model.service.CqlResourceIdsRequest;
+import org.folio.search.service.consortia.ResourceIdServiceDecorator;
 import org.folio.spring.test.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,7 +33,7 @@ class ResourceIdsStreamHelperTest {
   @InjectMocks
   private ResourceIdsStreamHelper resourceIdsStreamHelper;
   @Mock
-  private ResourceIdService resourceIdService;
+  private ResourceIdServiceDecorator resourceIdService;
 
   @Test
   void streamResourceIds_positive() throws IOException {

--- a/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
+++ b/src/test/java/org/folio/search/service/SearchTenantServiceTest.java
@@ -1,12 +1,16 @@
 package org.folio.search.service;
 
+import static org.folio.search.utils.TestConstants.CONSORTIUM_TENANT_ID;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.resourceDescription;
 import static org.folio.search.utils.TestUtils.secondaryResourceDescription;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -16,8 +20,11 @@ import org.folio.search.configuration.properties.SearchConfigurationProperties;
 import org.folio.search.domain.dto.LanguageConfig;
 import org.folio.search.domain.dto.ReindexRequest;
 import org.folio.search.service.browse.CallNumberBrowseRangeService;
+import org.folio.search.service.consortia.LanguageConfigServiceDecorator;
 import org.folio.search.service.metadata.ResourceDescriptionService;
 import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.liquibase.FolioSpringLiquibase;
 import org.folio.spring.test.type.UnitTest;
 import org.folio.spring.tools.kafka.KafkaAdminService;
 import org.folio.spring.tools.systemuser.PrepareSystemUserService;
@@ -28,6 +35,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.ResultSetExtractor;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -44,7 +53,7 @@ class SearchTenantServiceTest {
   @Mock
   private PrepareSystemUserService prepareSystemUserService;
   @Mock
-  private LanguageConfigService languageConfigService;
+  private LanguageConfigServiceDecorator languageConfigService;
   @Mock
   private CallNumberBrowseRangeService callNumberBrowseRangeService;
   @Mock
@@ -53,6 +62,59 @@ class SearchTenantServiceTest {
   private SearchConfigurationProperties searchConfigurationProperties;
   @Mock
   private KafkaAdminService kafkaAdminService;
+  @Mock
+  private FolioSpringLiquibase folioSpringLiquibase;
+  @Mock
+  private JdbcTemplate jdbcTemplate;
+
+  private final FolioModuleMetadata metadata = new FolioModuleMetadata() {
+    @Override
+    public String getModuleName() {
+      return null;
+    }
+
+    @Override
+    public String getDBSchemaName(String tenantId) {
+      return null;
+    }
+  };
+
+  @Test
+  void createOrUpdateTenant_positive() {
+    when(searchConfigurationProperties.getInitialLanguages()).thenReturn(Set.of("eng"));
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(context.getFolioModuleMetadata()).thenReturn(metadata);
+    when(resourceDescriptionService.getResourceNames()).thenReturn(List.of(RESOURCE_NAME));
+    doNothing().when(prepareSystemUserService).setupSystemUser();
+    doNothing().when(kafkaAdminService).createTopics(TENANT_ID);
+    doNothing().when(kafkaAdminService).restartEventListeners();
+
+    searchTenantService.createOrUpdateTenant(tenantAttributes());
+
+    verify(languageConfigService).create(new LanguageConfig().code("eng"));
+    verify(indexService).createIndexIfNotExist(RESOURCE_NAME, TENANT_ID);
+    verify(scriptService).saveScripts();
+    verify(indexService, never()).reindexInventory(TENANT_ID, null);
+    verify(kafkaAdminService).createTopics(TENANT_ID);
+    verify(kafkaAdminService).restartEventListeners();
+  }
+
+  @Test
+  void createOrUpdateTenant_positive_onlyKafkaAndSystemUserWhenConsortiumMemberTenant() {
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    doNothing().when(prepareSystemUserService).setupSystemUser();
+    doNothing().when(kafkaAdminService).createTopics(TENANT_ID);
+    doNothing().when(kafkaAdminService).restartEventListeners();
+
+    searchTenantService.createOrUpdateTenant(tenantAttributes().addParametersItem(centralTenantParameter()));
+
+    verifyNoInteractions(languageConfigService);
+    verifyNoInteractions(indexService);
+    verifyNoInteractions(scriptService);
+    verify(kafkaAdminService).createTopics(TENANT_ID);
+    verify(kafkaAdminService).restartEventListeners();
+    verify(prepareSystemUserService).setupSystemUser();
+  }
 
   @Test
   void initializeTenant_positive() {
@@ -130,6 +192,33 @@ class SearchTenantServiceTest {
   }
 
   @Test
+  void deleteTenant_positive() {
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(resourceDescriptionService.getResourceNames()).thenReturn(List.of(RESOURCE_NAME));
+    when(context.getFolioModuleMetadata()).thenReturn(metadata);
+    when(jdbcTemplate.query(anyString(), any(ResultSetExtractor.class), any())).thenReturn(true);
+
+    searchTenantService.deleteTenant(tenantAttributes());
+
+    verify(jdbcTemplate).execute(anyString());
+    verify(callNumberBrowseRangeService).evictRangeCache(TENANT_ID);
+    verify(indexService).dropIndex(RESOURCE_NAME, TENANT_ID);
+    verify(kafkaAdminService).deleteTopics(TENANT_ID);
+  }
+
+  @Test
+  void deleteTenant_positive_onlyDeleteKafkaTopicsWhenConsortiumMemberTenant() {
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+
+    searchTenantService.deleteTenant(tenantAttributes().addParametersItem(centralTenantParameter()));
+
+    verify(kafkaAdminService).deleteTopics(TENANT_ID);
+    verifyNoInteractions(jdbcTemplate);
+    verifyNoInteractions(callNumberBrowseRangeService);
+    verifyNoInteractions(indexService);
+  }
+
+  @Test
   void disableTenant_positive() {
     when(context.getTenantId()).thenReturn(TENANT_ID);
     when(resourceDescriptionService.getResourceNames()).thenReturn(List.of(RESOURCE_NAME));
@@ -144,5 +233,9 @@ class SearchTenantServiceTest {
 
   private TenantAttributes tenantAttributes() {
     return new TenantAttributes().moduleTo("mod-search");
+  }
+
+  private Parameter centralTenantParameter() {
+    return new Parameter("centralTenantId").value(CONSORTIUM_TENANT_ID);
   }
 }

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseResultConverterTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseResultConverterTest.java
@@ -27,7 +27,7 @@ import org.folio.search.domain.dto.Item;
 import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
 import org.folio.search.model.BrowseResult;
 import org.folio.search.model.service.BrowseContext;
-import org.folio.search.service.FeatureConfigService;
+import org.folio.search.service.consortia.FeatureConfigServiceDecorator;
 import org.folio.search.service.converter.ElasticsearchDocumentConverter;
 import org.folio.spring.test.type.UnitTest;
 import org.junit.jupiter.api.DisplayName;
@@ -58,7 +58,7 @@ class CallNumberBrowseResultConverterTest {
   @Mock
   private SearchResponse searchResponse;
   @Mock
-  private FeatureConfigService featureConfigService;
+  private FeatureConfigServiceDecorator featureConfigService;
 
   @MethodSource("testDataProvider")
   @DisplayName("convert_positive_parameterized")

--- a/src/test/java/org/folio/search/service/converter/FacetQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/service/converter/FacetQueryBuilderTest.java
@@ -242,6 +242,6 @@ class FacetQueryBuilderTest {
   }
 
   private static CqlFacetRequest facetRequest(String... facets) {
-    return TestUtils.facetServiceRequest(RESOURCE_NAME, TENANT_ID, facets);
+    return TestUtils.defaultFacetServiceRequest(RESOURCE_NAME, TENANT_ID, facets);
   }
 }

--- a/src/test/java/org/folio/search/service/converter/SearchDocumentConverterTest.java
+++ b/src/test/java/org/folio/search/service/converter/SearchDocumentConverterTest.java
@@ -41,7 +41,7 @@ import org.folio.search.model.converter.ConversionContext;
 import org.folio.search.model.index.SearchDocumentBody;
 import org.folio.search.model.metadata.FieldDescription;
 import org.folio.search.model.types.IndexingDataFormat;
-import org.folio.search.service.LanguageConfigService;
+import org.folio.search.service.consortia.LanguageConfigServiceDecorator;
 import org.folio.search.service.metadata.ResourceDescriptionService;
 import org.folio.search.utils.JsonConverter;
 import org.folio.search.utils.SmileConverter;
@@ -68,7 +68,7 @@ class SearchDocumentConverterTest {
   @InjectMocks
   private SearchDocumentConverter documentMapper;
   @Mock
-  private LanguageConfigService languageConfigService;
+  private LanguageConfigServiceDecorator languageConfigService;
   @Mock
   private SearchFieldsProcessor searchFieldsProcessor;
   @Mock
@@ -121,8 +121,8 @@ class SearchDocumentConverterTest {
   @Test
   void convert_negative_pathNotFound() {
     when(descriptionService.get(RESOURCE_NAME)).thenReturn(resourceDescription(
-      mapOf("id", plainField("keyword"), "title", plainField("keyword"))));
-    var resourceEvent = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID));
+      mapOf("id", plainField("keyword"), "tenantId", keywordField(), "title", plainField("keyword"))));
+    var resourceEvent = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "tenantId", TENANT_ID));
     var actual = documentMapper.convert(resourceEvent);
     assertThat(actual).isEqualTo(
       expectedSearchDocument(resourceEvent, jsonObject("id", RESOURCE_ID, "tenantId", TENANT_ID)));
@@ -131,10 +131,12 @@ class SearchDocumentConverterTest {
   @Test
   void convert_negative_emptyTitle() {
     when(descriptionService.get(RESOURCE_NAME)).thenReturn(resourceDescription(
-      mapOf("id", plainField("keyword"), "title", plainField("keyword"))));
-    var resourceEvent = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "title", ""));
+      mapOf("id", plainField("keyword"), "tenantId", keywordField(),
+        "title", plainField("keyword"))));
+    var resourceEvent = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "tenantId", TENANT_ID,
+      "title", ""));
     var actual = documentMapper.convert(resourceEvent);
-    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID, "title", "", "tenantId", TENANT_ID);
+    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID, "tenantId", TENANT_ID, "title", "");
     assertThat(actual).isEqualTo(expectedSearchDocument(resourceEvent, expectedJson));
   }
 
@@ -142,11 +144,12 @@ class SearchDocumentConverterTest {
   void convert_positive_multilangResource() {
     when(languageConfigService.getAllLanguageCodes()).thenReturn(Set.of("eng"));
     when(descriptionService.get(RESOURCE_NAME)).thenReturn(resourceDescription(
-      mapOf("id", plainField("keyword"), "title", multilangField()),
+      mapOf("id", plainField("keyword"), "tenantId", keywordField(), "title", multilangField()),
       List.of("$.lang1", "$.lang2", "$.lang3", "$.lang4", "$.lang5")));
 
     var resourceEvent = resourceEvent(RESOURCE_NAME, mapOf(
       "id", RESOURCE_ID,
+      "tenantId", TENANT_ID,
       "title", "val",
       "lang1", List.of("eng"),
       "lang2", mapOf("value", "eng"),
@@ -157,8 +160,8 @@ class SearchDocumentConverterTest {
     var actual = documentMapper.convert(resourceEvent);
 
     ObjectNode expectedJson =
-      jsonObject("id", RESOURCE_ID, "title", jsonObject("eng", "val", "src", "val"), "plain_title", "val",
-        "tenantId", TENANT_ID);
+      jsonObject("id", RESOURCE_ID, "tenantId", TENANT_ID,
+        "title", jsonObject("eng", "val", "src", "val"), "plain_title", "val");
     assertThat(actual).isEqualTo(expectedSearchDocument(resourceEvent,
       expectedJson));
   }
@@ -166,34 +169,36 @@ class SearchDocumentConverterTest {
   @Test
   void convert_positive_repeatableObjectField() {
     when(descriptionService.get(RESOURCE_NAME)).thenReturn(resourceDescription(mapOf(
-      "id", keywordField(), "identifiers", objectField(mapOf("value", keywordField())))));
-    var resourceEvent = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "identifiers", List.of(
-      mapOf("type", "isbn", "value", "test-isbn"),
-      mapOf("type", "issn", "value", "test-issn"),
-      mapOf("type", "isbn"), "test-isbn-2")));
+      "id", keywordField(), "tenantId", keywordField(),
+      "identifiers", objectField(mapOf("value", keywordField())))));
+    var resourceEvent = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID,
+      "tenantId", TENANT_ID,
+      "identifiers", List.of(
+        mapOf("type", "isbn", "value", "test-isbn"),
+        mapOf("type", "issn", "value", "test-issn"),
+        mapOf("type", "isbn"), "test-isbn-2")));
 
     var actual = documentMapper.convert(resourceEvent);
 
-    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID,
-      "identifiers", jsonArray(jsonObject("value", "test-isbn"), jsonObject("value", "test-issn")),
-      "tenantId", TENANT_ID);
+    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID, "tenantId", TENANT_ID,
+      "identifiers", jsonArray(jsonObject("value", "test-isbn"), jsonObject("value", "test-issn")));
     assertThat(actual).isEqualTo(expectedSearchDocument(resourceEvent, expectedJson));
   }
 
   @Test
   void convert_positive_multiLanguageValue() {
     var resourceDescription = resourceDescription(mapOf(
-      "id", keywordField(), "alternativeTitle", objectField(mapOf("value", multilangField()))));
-    var resourceEvent = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID,
+      "id", keywordField(), "tenantId", keywordField(),
+      "alternativeTitle", objectField(mapOf("value", multilangField()))));
+    var resourceEvent = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "tenantId", TENANT_ID,
       "alternativeTitle", List.of(mapOf("value", "title1"), mapOf("value", null), emptyMap(), "title3")));
 
     when(descriptionService.get(RESOURCE_NAME)).thenReturn(resourceDescription);
 
     var actual = documentMapper.convert(resourceEvent);
 
-    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID,
-      "alternativeTitle", jsonArray(jsonObject("value", jsonObject("src", "title1"), "plain_value", "title1")),
-      "tenantId", TENANT_ID);
+    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID, "tenantId", TENANT_ID,
+      "alternativeTitle", jsonArray(jsonObject("value", jsonObject("src", "title1"), "plain_value", "title1")));
     assertThat(actual).isEqualTo(expectedSearchDocument(resourceEvent, expectedJson));
   }
 
@@ -206,8 +211,10 @@ class SearchDocumentConverterTest {
 
   @Test
   void convert_positive_extendedFields() {
-    var desc = resourceDescription(mapOf("id", keywordField(), "base", keywordField()));
-    var resourceEvent = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "base", "base val"));
+    var desc = resourceDescription(mapOf("id", keywordField(), "tenantId", keywordField(),
+      "base", keywordField()));
+    var resourceEvent = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "tenantId", TENANT_ID,
+      "base", "base val"));
     var expectedContext = ConversionContext.of(resourceEvent, desc, emptyList());
 
     when(descriptionService.get(RESOURCE_NAME)).thenReturn(desc);
@@ -216,47 +223,51 @@ class SearchDocumentConverterTest {
     var actual = documentMapper.convert(resourceEvent);
 
     ObjectNode expectedJson = jsonObject(
-      "id", RESOURCE_ID, "base", "base val", "tenantId", TENANT_ID, "generated", "generated value");
+      "id", RESOURCE_ID, "tenantId", TENANT_ID, "base", "base val", "generated", "generated value");
     assertThat(actual).isEqualTo(expectedSearchDocument(resourceEvent, expectedJson));
   }
 
   @Test
   void convert_positive_useDefaultValueFromFieldDescription() {
     when(descriptionService.get(RESOURCE_NAME)).thenReturn(resourceDescription(mapOf(
-      "id", keywordField(), "value", keywordFieldWithDefaultValue("default"))));
-    var event = resourceEvent(RESOURCE_NAME, Map.of("id", RESOURCE_ID, "value", "aValue"));
+      "id", keywordField(), "tenantId", keywordField(),
+      "value", keywordFieldWithDefaultValue("default"))));
+    var event = resourceEvent(RESOURCE_NAME, Map.of("id", RESOURCE_ID, "tenantId", TENANT_ID, "value", "aValue"));
     var actual = documentMapper.convert(event);
-    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID, "value", "aValue", "tenantId", TENANT_ID);
+    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID, "tenantId", TENANT_ID, "value", "aValue");
     assertThat(actual).isEqualTo(expectedSearchDocument(event, expectedJson));
   }
 
   @Test
   void convert_positive_useDefaultValueWhenNoValuePresent() {
     var resourceDescription = resourceDescription(mapOf("id", keywordField(),
+      "tenantId", keywordField(),
       "value", keywordFieldWithDefaultValue("default")));
 
     when(descriptionService.get(RESOURCE_NAME)).thenReturn(resourceDescription);
 
-    var event = resourceEvent(RESOURCE_NAME, Map.of("id", RESOURCE_ID));
+    var event = resourceEvent(RESOURCE_NAME, Map.of("id", RESOURCE_ID, "tenantId", TENANT_ID));
     var actual = documentMapper.convert(event);
 
-    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID, "value", "default", "tenantId", TENANT_ID);
+    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID, "tenantId", TENANT_ID, "value", "default");
     assertThat(actual).isEqualTo(expectedSearchDocument(event, expectedJson));
   }
 
   @Test
   void convert_positive_useDefaultWhenValueIsNull() {
     when(descriptionService.get(RESOURCE_NAME)).thenReturn(resourceDescription(mapOf(
-      "id", keywordField(), "value", keywordFieldWithDefaultValue("default"))));
-    var event = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "value", null));
+      "id", keywordField(), "tenantId", keywordField(),
+      "value", keywordFieldWithDefaultValue("default"))));
+    var event = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "tenantId", TENANT_ID, "value", null));
     var actual = documentMapper.convert(event);
-    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID, "value", "default", "tenantId", TENANT_ID);
+    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID, "tenantId", TENANT_ID, "value", "default");
     assertThat(actual).isEqualTo(expectedSearchDocument(event, expectedJson));
   }
 
   @Test
   void convert_positive_languageIsNotSpecified() {
-    var event = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "language", "rus", "multilang_value", "value"));
+    var event = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "tenantId", TENANT_ID,
+      "language", "rus", "multilang_value", "value"));
 
     when(languageConfigService.getAllLanguageCodes()).thenReturn(Set.of("eng", "fra"));
     when(descriptionService.get(RESOURCE_NAME)).thenReturn(
@@ -264,14 +275,14 @@ class SearchDocumentConverterTest {
 
     var actual = documentMapper.convert(event);
 
-    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID, "language", "rus",
-      "multilang_value", jsonObject("src", "value"), "plain_multilang_value", "value", "tenantId", TENANT_ID);
+    ObjectNode expectedJson = jsonObject("id", RESOURCE_ID, "tenantId", TENANT_ID, "language", "rus",
+      "multilang_value", jsonObject("src", "value"), "plain_multilang_value", "value");
     assertThat(actual).isEqualTo(expectedSearchDocument(event, expectedJson));
   }
 
   @Test
   void convert_positive_instanceWithItems() {
-    var event = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "items", List.of(
+    var event = resourceEvent(RESOURCE_NAME, mapOf("id", RESOURCE_ID, "tenantId", TENANT_ID, "items", List.of(
       mapOf("id", "item#1"),
       mapOf("id", "item#2", "effectiveShelvingOrder", "F10"),
       mapOf("id", "item#3", "effectiveShelvingOrder", "C5"),
@@ -279,25 +290,26 @@ class SearchDocumentConverterTest {
 
     when(languageConfigService.getAllLanguageCodes()).thenReturn(emptySet());
     when(descriptionService.get(RESOURCE_NAME)).thenReturn(
-      resourceDescription(mapOf("id", keywordField(), "items", objectField(
-        mapOf("id", keywordField(), "effectiveShelvingOrder", keywordField())))));
+      resourceDescription(mapOf("id", keywordField(), "tenantId", keywordField(),
+        "items", objectField(mapOf("id", keywordField(), "effectiveShelvingOrder", keywordField())))));
 
     var actual = documentMapper.convert(event);
 
     ObjectNode expectedJson = jsonObject(
       "id", RESOURCE_ID,
+      "tenantId", TENANT_ID,
       "items", jsonArray(
         jsonObject("id", "item#1"),
         jsonObject("id", "item#2", "effectiveShelvingOrder", "F10"),
         jsonObject("id", "item#3", "effectiveShelvingOrder", "C5"),
-        jsonObject("id", "item#4")),
-      "tenantId", TENANT_ID);
+        jsonObject("id", "item#4")));
     assertThat(actual).isEqualTo(expectedSearchDocument(event, expectedJson));
   }
 
   private static Map<String, FieldDescription> resourceDescriptionFields() {
     return mapOf(
       "id", keywordField(),
+      "tenantId", keywordField(),
       "title", keywordField(),
       "language", keywordField(),
       "multilang_value", multilangField(),
@@ -312,6 +324,7 @@ class SearchDocumentConverterTest {
   private static Map<String, Object> testResourceBody() {
     return mapOf(
       "id", RESOURCE_ID,
+      "tenantId", TENANT_ID,
       "title", List.of("instance title"),
       "language", "eng",
       "multilang_value", "some value",
@@ -326,6 +339,7 @@ class SearchDocumentConverterTest {
   private static ObjectNode expectedSearchDocumentBody() {
     return jsonObject(
       "id", RESOURCE_ID,
+      "tenantId", TENANT_ID,
       "title", jsonArray("instance title"),
       "language", "eng",
       "multilang_value", jsonObject("eng", "some value", "src", "some value"),
@@ -333,8 +347,7 @@ class SearchDocumentConverterTest {
       "bool", true,
       "number", 123,
       "numbers", jsonArray(1, 2, 3, 4),
-      "metadata", jsonObject("createdAt", "12-01-01T12:03:12Z"),
-      "tenantId", TENANT_ID);
+      "metadata", jsonObject("createdAt", "12-01-01T12:03:12Z"));
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/search/service/converter/SearchFieldsProcessorTest.java
+++ b/src/test/java/org/folio/search/service/converter/SearchFieldsProcessorTest.java
@@ -21,7 +21,7 @@ import org.folio.search.domain.dto.Instance;
 import org.folio.search.model.converter.ConversionContext;
 import org.folio.search.model.metadata.ResourceDescription;
 import org.folio.search.model.metadata.SearchFieldDescriptor;
-import org.folio.search.service.FeatureConfigService;
+import org.folio.search.service.consortia.FeatureConfigServiceDecorator;
 import org.folio.search.service.converter.SearchFieldsProcessorTest.TestContextConfiguration;
 import org.folio.search.service.setter.FieldProcessor;
 import org.folio.search.utils.JsonConverter;
@@ -46,7 +46,7 @@ class SearchFieldsProcessorTest {
   @Autowired
   private SearchFieldsProcessor searchFieldsProcessor;
   @MockBean
-  private FeatureConfigService featureConfigService;
+  private FeatureConfigServiceDecorator featureConfigService;
 
   @Test
   void getSearchFields_positive_emptySearchFields() {

--- a/src/test/java/org/folio/search/service/es/SearchMappingsHelperTest.java
+++ b/src/test/java/org/folio/search/service/es/SearchMappingsHelperTest.java
@@ -32,7 +32,7 @@ import org.folio.search.domain.dto.LanguageConfigs;
 import org.folio.search.exception.ResourceDescriptionException;
 import org.folio.search.model.metadata.ResourceDescription;
 import org.folio.search.model.metadata.SearchFieldType;
-import org.folio.search.service.LanguageConfigService;
+import org.folio.search.service.consortia.LanguageConfigServiceDecorator;
 import org.folio.search.service.metadata.ResourceDescriptionService;
 import org.folio.search.service.metadata.SearchFieldProvider;
 import org.folio.search.utils.JsonConverter;
@@ -54,7 +54,7 @@ class SearchMappingsHelperTest {
   @Mock
   private SearchFieldProvider searchFieldProvider;
   @Mock
-  private LanguageConfigService languageConfigService;
+  private LanguageConfigServiceDecorator languageConfigService;
   @Mock
   private ResourceDescriptionService resourceDescriptionService;
   @Spy

--- a/src/test/java/org/folio/search/service/setter/authority/AuthoritySearchResponsePostProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/authority/AuthoritySearchResponsePostProcessorTest.java
@@ -15,26 +15,32 @@ import org.folio.search.model.SimpleResourceRequest;
 import org.folio.search.model.index.AuthRefType;
 import org.folio.search.repository.SearchRepository;
 import org.folio.search.service.metadata.SearchFieldProvider;
+import org.folio.search.support.base.TenantConfig;
 import org.folio.spring.FolioExecutionContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.search.SearchHits;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 
 @ExtendWith(MockitoExtension.class)
+@SpringBootTest(classes = TenantConfig.class)
 class AuthoritySearchResponsePostProcessorTest {
 
-  private @Mock SearchRepository searchRepository;
-  private @Mock SearchFieldProvider searchFieldProvider;
-  private @Mock FolioExecutionContext context;
-  private @Mock MultiSearchResponse multiSearchResponse;
+  private @MockBean SearchRepository searchRepository;
+  private @MockBean SearchFieldProvider searchFieldProvider;
+  private @MockBean FolioExecutionContext context;
+  private @MockBean MultiSearchResponse multiSearchResponse;
+  private @SpyBean AuthoritySearchResponsePostProcessor processor;
 
-  private @InjectMocks AuthoritySearchResponsePostProcessor processor;
+  @Autowired
+  private String centralTenant;
 
   @BeforeEach
   void setUp() {
@@ -87,7 +93,7 @@ class AuthoritySearchResponsePostProcessorTest {
 
   private void mockSearchResponse(Integer... counts) {
     var searchResponse = mock(SearchResponse.class);
-    when(searchRepository.msearch(eq(SimpleResourceRequest.of("instance", TENANT_ID)), any()))
+    when(searchRepository.msearch(eq(SimpleResourceRequest.of("instance", centralTenant)), any()))
       .thenReturn(multiSearchResponse);
     var hitsOngoingStubbing = when(searchResponse.getHits());
     var responses = new MultiSearchResponse.Item[counts.length];

--- a/src/test/java/org/folio/search/support/base/TenantConfig.java
+++ b/src/test/java/org/folio/search/support/base/TenantConfig.java
@@ -1,0 +1,37 @@
+package org.folio.search.support.base;
+
+import static org.folio.search.utils.TestConstants.CONSORTIUM_TENANT_ID;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
+
+import org.folio.search.service.consortia.TenantProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Needed to run tests in both modes (consortia on/off).
+ * Provides central tenant (regular tenant if consortia off).
+ * Provides TenantProvider that returns central tenant
+ * */
+@Configuration
+public class TenantConfig {
+
+  @Bean
+  public Boolean inConsortiumMode(
+    @Value("${folio.search-config.search-features.consortium}") Boolean inConsortiumMode) {
+    return inConsortiumMode;
+  }
+
+  @Bean
+  public String centralTenant(Boolean inConsortiumMode) {
+    if (inConsortiumMode) {
+      return CONSORTIUM_TENANT_ID;
+    }
+    return TENANT_ID;
+  }
+
+  @Bean
+  public TenantProvider tenantProvider(String centralTenant) {
+    return tenantId -> centralTenant;
+  }
+}

--- a/src/test/java/org/folio/search/utils/TestConstants.java
+++ b/src/test/java/org/folio/search/utils/TestConstants.java
@@ -15,12 +15,13 @@ public class TestConstants {
 
   public static final String ENV = "folio";
   public static final String TENANT_ID = "test_tenant";
+  public static final String CONSORTIUM_TENANT_ID = "consortium";
   public static final String RESOURCE_ID = "d148dd82-56b0-4ddb-a638-83ca1ee97e0a";
   public static final String RESOURCE_ID_SECOND = "d148dd82-56b0-4ddb-a638-83ca1ee97e0b";
   public static final String EMPTY_OBJECT = "{}";
   public static final JsonNode EMPTY_JSON_OBJECT = JsonNodeFactory.instance.objectNode();
   public static final String RESOURCE_NAME = getResourceName(TestResource.class);
-  public static final String INDEX_NAME = String.join("_", ENV, RESOURCE_NAME, TENANT_ID);
+  public static final String INDEX_NAME = indexName(TENANT_ID);
 
   public static final String AUTHORITY_TOPIC = "inventory.authority";
   public static final String CONTRIBUTOR_TOPIC = "search.instance-contributor";
@@ -85,6 +86,10 @@ public class TestConstants {
 
   public static String inventoryBoundWithTopic(String tenantId) {
     return getTopicName(tenantId, INVENTORY_BOUND_WITH_TOPIC);
+  }
+
+  public static String indexName(String tenantId) {
+    return String.join("_", ENV, RESOURCE_NAME, tenantId);
   }
 
   private static String getTopicName(String tenantId, String topic) {

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -143,12 +143,25 @@ public class TestUtils {
     return searchServiceRequest(resourceClass, query, false);
   }
 
-  public static <T> CqlSearchRequest<T> searchServiceRequest(Class<T> resourceClass, String query, boolean expandAll) {
-    return CqlSearchRequest.of(resourceClass, TENANT_ID, query, 100, 0, expandAll);
+  public static <T> CqlSearchRequest<T> searchServiceRequest(Class<T> resourceClass, String tenantId, String query) {
+    return searchServiceRequest(resourceClass, tenantId, query, false);
   }
 
-  public static CqlFacetRequest facetServiceRequest(String resource, String query, String... facets) {
-    return CqlFacetRequest.of(resource, TENANT_ID, query, asList(facets));
+  public static <T> CqlSearchRequest<T> searchServiceRequest(Class<T> resourceClass, String query, boolean expandAll) {
+    return searchServiceRequest(resourceClass, TENANT_ID, query, expandAll);
+  }
+
+  public static <T> CqlSearchRequest<T> searchServiceRequest(Class<T> resourceClass, String tenantId, String query,
+                                                             boolean expandAll) {
+    return CqlSearchRequest.of(resourceClass, tenantId, query, 100, 0, expandAll);
+  }
+
+  public static CqlFacetRequest defaultFacetServiceRequest(String resource, String query, String... facets) {
+    return facetServiceRequest(TENANT_ID, resource, query, facets);
+  }
+
+  public static CqlFacetRequest facetServiceRequest(String tenantId, String resource, String query, String... facets) {
+    return CqlFacetRequest.of(resource, tenantId, query, asList(facets));
   }
 
   public static CallNumberBrowseResult cnBrowseResult(int total, List<CallNumberBrowseItem> items) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -33,6 +33,7 @@ spring:
       - tenant-languages
       - tenant-features
       - search-preference
+      - user-tenants
     caffeine:
       spec: maximumSize=500,expireAfterWrite=3600s
 

--- a/src/test/resources/mappings/user-tenants.json
+++ b/src/test/resources/mappings/user-tenants.json
@@ -1,0 +1,23 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/user-tenants"
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "userTenants": [
+            {
+              "centralTenantId": "consortium"
+            }
+          ]
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+  ]
+}

--- a/src/test/resources/samples/authority-sample/authority.json
+++ b/src/test/resources/samples/authority-sample/authority.json
@@ -1,5 +1,6 @@
 {
   "id": "55294032-fcf6-45cc-b6da-4420a61ef72c",
+  "tenantId": "test_tenant",
   "personalName": "Gary A. Wills",
   "sftPersonalName": [ "a sft personal name" ],
   "saftPersonalName": [ "a saft personal name" ],

--- a/src/test/resources/samples/semantic-web-primer/instance.json
+++ b/src/test/resources/samples/semantic-web-primer/instance.json
@@ -1,5 +1,6 @@
 {
   "id": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",
+  "tenantId": "test_tenant",
   "hrid": "inst000000000022",
   "source": "FOLIO",
   "title": "A semantic web primer :0747-0850 & wolves",


### PR DESCRIPTION
## Purpose
The objective of this story is to enhance the indexing logic to accommodate consortia mode and central tenant management.

## Approach
- Add Tenant providers based on mode consortia on/off
- Add tenant api parameter to decide which tenants should have indices/db schema created for
- Add decorators wrapping service calls that have database access, for consortia mode

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
