### PR TITLE
feat(consortium): Add tenantId/shared fields to contributors/subjects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Add shared, tenantId flags to mapping for consortium ([MSEARCH-532](https://issues.folio.org/browse/MSEARCH-532))
 * Implement indexing for consortium tenants  ([MSEARCH-554](https://issues.folio.org/browse/MSEARCH-554))
 * Implement Active Affiliation Context for Search in Consortia Mode  ([MSEARCH-533](https://issues.folio.org/browse/MSEARCH-533))
+* Add tenantId/shared fields to contributors/subjects  ([MSEARCH-551](https://issues.folio.org/browse/MSEARCH-551))
 
 ### Bug fixes
 * Fix bug when number of titles response is greater than real ([MSEARCH-526](https://issues.folio.org/browse/MSEARCH-526))

--- a/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
@@ -64,7 +64,7 @@ public class CqlSearchQueryConverter {
     return queryBuilder.query(enhancedQuery);
   }
 
-  //todo(MSEARCH-551): may be reworked after implemented for browse/streamIds.
+  //todo(MSEARCH-576): may be reworked after implemented for browse/streamIds.
   // Implemented separately because it crashes 'browse/streamIds' functionality.
   /**
    * Converts given CQL search query value to the elasticsearch {@link SearchSourceBuilder} object.
@@ -156,15 +156,13 @@ public class CqlSearchQueryConverter {
   private QueryBuilder filterForActiveAffiliation(QueryBuilder query) {
     var contextTenantId = folioExecutionContext.getTenantId();
     var centralTenantId = consortiumTenantService.getCentralTenant(contextTenantId);
-    if (centralTenantId.isEmpty()) {
+    if (centralTenantId.isEmpty() || contextTenantId.equals(centralTenantId.get())) {
       return query;
     }
 
     var affiliationShouldClauses = new LinkedList<QueryBuilder>();
     affiliationShouldClauses.add(termQuery("tenantId", contextTenantId));
-    if (!contextTenantId.equals(centralTenantId.get())) {
-      affiliationShouldClauses.add(termQuery("shared", true));
-    }
+    affiliationShouldClauses.add(termQuery("shared", true));
 
     BoolQueryBuilder boolQuery;
     if (query instanceof MatchAllQueryBuilder) {

--- a/src/main/java/org/folio/search/integration/KafkaMessageProducer.java
+++ b/src/main/java/org/folio/search/integration/KafkaMessageProducer.java
@@ -171,7 +171,7 @@ public class KafkaMessageProducer {
   }
 
   private String getContributorId(Contributor contributor) {
-    return sha1Hex(contributor.getContributorNameTypeId()
+    return sha1Hex(contributor.getContributorNameTypeId() //NOSONAR
       + "|" + toRootLowerCase(contributor.getName())
       + "|" + contributor.getAuthorityId());
   }

--- a/src/main/java/org/folio/search/model/index/ContributorResource.java
+++ b/src/main/java/org/folio/search/model/index/ContributorResource.java
@@ -1,9 +1,11 @@
 package org.folio.search.model.index;
 
 import java.util.Set;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class ContributorResource {
 
   private String id;
@@ -16,5 +18,5 @@ public class ContributorResource {
 
   private String authorityId;
 
-  private Set<String> instances;
+  private Set<InstanceSubResource> instances;
 }

--- a/src/main/java/org/folio/search/model/index/ContributorResource.java
+++ b/src/main/java/org/folio/search/model/index/ContributorResource.java
@@ -12,8 +12,6 @@ public class ContributorResource {
 
   private String name;
 
-  private Set<String> contributorTypeId;
-
   private String contributorNameTypeId;
 
   private String authorityId;

--- a/src/main/java/org/folio/search/model/index/InstanceSubResource.java
+++ b/src/main/java/org/folio/search/model/index/InstanceSubResource.java
@@ -7,6 +7,7 @@ import lombok.Data;
 @Builder
 public class InstanceSubResource {
   private String instanceId;
+  private String typeId;
   private String tenantId;
   private Boolean shared;
 }

--- a/src/main/java/org/folio/search/model/index/InstanceSubResource.java
+++ b/src/main/java/org/folio/search/model/index/InstanceSubResource.java
@@ -1,0 +1,12 @@
+package org.folio.search.model.index;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class InstanceSubResource {
+  private String instanceId;
+  private String tenantId;
+  private Boolean shared;
+}

--- a/src/main/java/org/folio/search/model/index/SubjectResource.java
+++ b/src/main/java/org/folio/search/model/index/SubjectResource.java
@@ -12,5 +12,5 @@ public class SubjectResource {
 
   private String authorityId;
 
-  private Set<String> instances;
+  private Set<InstanceSubResource> instances;
 }

--- a/src/main/java/org/folio/search/repository/InstanceSubjectRepository.java
+++ b/src/main/java/org/folio/search/repository/InstanceSubjectRepository.java
@@ -11,6 +11,7 @@ import static org.folio.search.utils.SearchUtils.INSTANCE_SUBJECT_UPSERT_SCRIPT_
 import static org.opensearch.script.ScriptType.STORED;
 
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +24,7 @@ import org.folio.search.configuration.properties.SearchConfigurationProperties;
 import org.folio.search.domain.dto.FolioIndexOperationResponse;
 import org.folio.search.model.index.SearchDocumentBody;
 import org.folio.search.model.types.IndexActionType;
+import org.folio.search.service.consortium.ConsortiumTenantService;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.script.Script;
@@ -33,7 +35,10 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class InstanceSubjectRepository extends AbstractResourceRepository {
 
+  private static final String INSTANCE_ID = "instanceId";
+
   private final SearchConfigurationProperties properties;
+  private final ConsortiumTenantService consortiumTenantService;
 
   @Override
   public FolioIndexOperationResponse indexResources(List<SearchDocumentBody> documentBodies) {
@@ -42,9 +47,9 @@ public class InstanceSubjectRepository extends AbstractResourceRepository {
     var docsById = documentBodies.stream().collect(groupingBy(SearchDocumentBody::getId));
     for (var entry : docsById.entrySet()) {
       var documents = entry.getValue();
-      var instanceIds = prepareInstanceIds(documents);
-      if (!IterableUtils.matchesAll(instanceIds.values(), Set::isEmpty)) {
-        var upsertRequest = prepareUpsertRequest(documents.iterator().next(), instanceIds);
+      var instances = prepareInstances(documents);
+      if (!IterableUtils.matchesAll(instances.values(), Set::isEmpty)) {
+        var upsertRequest = prepareUpsertRequest(documents.iterator().next(), instances);
         bulkRequest.add(upsertRequest);
       }
     }
@@ -56,46 +61,53 @@ public class InstanceSubjectRepository extends AbstractResourceRepository {
            : getSuccessIndexOperationResponse();
   }
 
-  private EnumMap<IndexActionType, Set<String>> prepareInstanceIds(List<SearchDocumentBody> documents) {
-    var instanceIds = prepareInstanceIdMap();
+  private EnumMap<IndexActionType, Set<Map<String, Object>>> prepareInstances(List<SearchDocumentBody> documents) {
+    var instances = prepareInstanceMap();
     for (var document : documents) {
       var payload = getPayload(document);
-      var instanceId = String.valueOf(payload.get("instanceId"));
+      var instanceId = String.valueOf(payload.get(INSTANCE_ID));
       if (StringUtils.isNotBlank(instanceId)) {
-        instanceIds.getOrDefault(document.getAction(), instanceIds.get(DELETE)).add(instanceId);
+        var tenantId = document.getTenant();
+        var instance = new HashMap<String, Object>();
+        instance.put(INSTANCE_ID, instanceId);
+        instance.put("tenantId", tenantId);
+        consortiumTenantService.getCentralTenant(tenantId).ifPresent(centralTenant ->
+          instance.put("shared", centralTenant.equals(tenantId)));
+
+        instances.getOrDefault(document.getAction(), instances.get(DELETE)).add(instance);
       } else {
         log.warn("InstanceId is blank in subject event. [payload: {}]", payload);
       }
     }
-    return instanceIds;
+    return instances;
   }
 
-  private EnumMap<IndexActionType, Set<String>> prepareInstanceIdMap() {
-    var instanceIds = new EnumMap<IndexActionType, Set<String>>(IndexActionType.class);
+  private EnumMap<IndexActionType, Set<Map<String, Object>>> prepareInstanceMap() {
+    var instanceIds = new EnumMap<IndexActionType, Set<Map<String, Object>>>(IndexActionType.class);
     instanceIds.put(INDEX, new HashSet<>());
     instanceIds.put(DELETE, new HashSet<>());
     return instanceIds;
   }
 
   private UpdateRequest prepareUpsertRequest(SearchDocumentBody doc,
-                                             EnumMap<IndexActionType, Set<String>> instanceIds) {
+                                             EnumMap<IndexActionType, Set<Map<String, Object>>> instances) {
     return new UpdateRequest()
       .id(doc.getId())
       .scriptedUpsert(true)
       .retryOnConflict(properties.getIndexing().getInstanceSubjects().getRetryAttempts())
       .index(indexName(doc))
-      .script(new Script(STORED, null, INSTANCE_SUBJECT_UPSERT_SCRIPT_ID, prepareScriptParams(instanceIds)))
-      .upsert(prepareDocumentBody(getPayload(doc), instanceIds), doc.getDataFormat().getXcontentType());
+      .script(new Script(STORED, null, INSTANCE_SUBJECT_UPSERT_SCRIPT_ID, prepareScriptParams(instances)))
+      .upsert(prepareDocumentBody(getPayload(doc), instances), doc.getDataFormat().getXcontentType());
   }
 
-  private Map<String, Object> prepareScriptParams(EnumMap<IndexActionType, Set<String>> instanceIds) {
+  private Map<String, Object> prepareScriptParams(EnumMap<IndexActionType, Set<Map<String, Object>>> instanceIds) {
     return Map.of("ins", instanceIds.get(INDEX), "del", instanceIds.get(DELETE));
   }
 
   private Map<String, Object> prepareDocumentBody(Map<String, Object> payload,
-                                                  Map<IndexActionType, Set<String>> instanceIds) {
-    payload.put("instances", subtract(instanceIds.get(INDEX), instanceIds.get(DELETE)));
-    payload.remove("instanceId");
+                                                  Map<IndexActionType, Set<Map<String, Object>>> instances) {
+    payload.put("instances", subtract(instances.get(INDEX), instances.get(DELETE)));
+    payload.remove(INSTANCE_ID);
     return payload;
   }
 

--- a/src/main/java/org/folio/search/service/browse/AbstractBrowseServiceBySearchAfter.java
+++ b/src/main/java/org/folio/search/service/browse/AbstractBrowseServiceBySearchAfter.java
@@ -30,7 +30,6 @@ import org.springframework.util.Assert;
 @Log4j2
 public abstract class AbstractBrowseServiceBySearchAfter<T, R> extends AbstractBrowseService<T> {
 
-  private static final String TENANT_ID_FILTER_KEY = "instances.tenantId";
   private static final String SHARED_FILTER_KEY = "instances.shared";
 
   protected SearchRepository searchRepository;
@@ -136,19 +135,12 @@ public abstract class AbstractBrowseServiceBySearchAfter<T, R> extends AbstractB
     Function<R, Set<InstanceSubResource>> subResourceExtractor) {
 
     var subResources = subResourceExtractor.apply(resource);
-    var tenantIdFilter = getBrowseFilter(context, TENANT_ID_FILTER_KEY);
     var sharedFilter = getBrowseFilter(context, SHARED_FILTER_KEY);
-    if (tenantIdFilter.isEmpty() && sharedFilter.isEmpty()) {
-      return subResources;
-    }
 
-    return subResources.stream()
-      .filter(subResource ->
-        tenantIdFilter.map(tenantId -> subResource.getTenantId().equals(tenantId))
-          .orElse(true)
-          && sharedFilter.map(shared -> subResource.getShared().equals(Boolean.valueOf(shared)))
-          .orElse(true))
-      .collect(Collectors.toSet());
+    return sharedFilter.map(shared -> subResources.stream()
+        .filter(subResource -> subResource.getShared().equals(Boolean.valueOf(shared)))
+        .collect(Collectors.toSet()))
+      .orElse(subResources);
   }
 
   private Optional<String> getBrowseFilter(BrowseContext context, String filterKey) {

--- a/src/main/java/org/folio/search/service/browse/AuthorityBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/AuthorityBrowseService.java
@@ -39,7 +39,8 @@ public class AuthorityBrowseService extends AbstractBrowseServiceBySearchAfter<A
   private final SearchFieldProvider searchFieldProvider;
 
   @Override
-  protected BrowseResult<AuthorityBrowseItem> mapToBrowseResult(SearchResult<Authority> result, boolean isAnchor) {
+  protected BrowseResult<AuthorityBrowseItem> mapToBrowseResult(BrowseContext context, SearchResult<Authority> result,
+                                                                boolean isAnchor) {
     log.debug("mapToBrowseResult:: by [records.size: {}, isAnchor: {}]",
       result.getTotalRecords(), isAnchor);
 

--- a/src/main/java/org/folio/search/service/browse/BrowseContextProvider.java
+++ b/src/main/java/org/folio/search/service/browse/BrowseContextProvider.java
@@ -38,7 +38,7 @@ public class BrowseContextProvider {
   public BrowseContext get(BrowseRequest request) {
     log.debug("get:: by [query: {}, resource: {}]", request.getQuery(), request.getResource());
 
-    // todo(MSEARCH-551): use 'convertForConsortia' or/and check todo item for 'convertForConsortia'
+    // todo(MSEARCH-580): use 'convertForConsortia' or/and check todo item for 'convertForConsortia'
     var searchSource = cqlSearchQueryConverter.convert(request.getQuery(), request.getResource());
     var cqlQuery = request.getQuery();
     if (isNotEmpty(searchSource.sorts())) {

--- a/src/main/java/org/folio/search/service/browse/ContributorBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/ContributorBrowseService.java
@@ -89,9 +89,9 @@ public class ContributorBrowseService extends
     return browseItem.getName();
   }
 
-  private int calculateTotalRecords(ContributorResource item) {
+  private int calculateTotalRecords(ContributorResource item) { //todo: may count another tenant in total
     return ((Long) item.getInstances().stream()
-      .map(id -> INSTANCES_FIELD_SPLIT_PATTERN.split(id)[0])
+      .map(instance -> INSTANCES_FIELD_SPLIT_PATTERN.split(instance.getInstanceId())[0])
       .distinct()
       .count()
     ).intValue();

--- a/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
@@ -17,7 +17,6 @@ import org.folio.search.model.SearchResult;
 import org.folio.search.model.index.SubjectResource;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.model.service.BrowseRequest;
-import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.springframework.stereotype.Service;
@@ -42,8 +41,9 @@ public class SubjectBrowseService extends AbstractBrowseServiceBySearchAfter<Sub
     if (ctx.getFilters().isEmpty()) {
       query = matchAllQuery();
     } else {
-      query = boolQuery();
-      ctx.getFilters().forEach(filter -> ((BoolQueryBuilder) filter).filter(filter));
+      var boolQuery = boolQuery();
+      ctx.getFilters().forEach(boolQuery::filter);
+      query = boolQuery;
     }
     return searchSource().query(query)
       .searchAfter(new Object[] {ctx.getAnchor().toLowerCase(ROOT)})
@@ -64,7 +64,7 @@ public class SubjectBrowseService extends AbstractBrowseServiceBySearchAfter<Sub
         .value(subjectResource.getValue())
         .authorityId(subjectResource.getAuthorityId())
         .isAnchor(isAnchor ? true : null)
-        .totalRecords(subjectResource.getInstances().size()));
+        .totalRecords(subjectResource.getInstances().size())); //todo: wrong total because of this
   }
 
   @Override

--- a/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
@@ -58,13 +58,14 @@ public class SubjectBrowseService extends AbstractBrowseServiceBySearchAfter<Sub
   }
 
   @Override
-  protected BrowseResult<SubjectBrowseItem> mapToBrowseResult(SearchResult<SubjectResource> res, boolean isAnchor) {
+  protected BrowseResult<SubjectBrowseItem> mapToBrowseResult(BrowseContext context, SearchResult<SubjectResource> res,
+                                                              boolean isAnchor) {
     return BrowseResult.of(res)
       .map(subjectResource -> new SubjectBrowseItem()
         .value(subjectResource.getValue())
         .authorityId(subjectResource.getAuthorityId())
         .isAnchor(isAnchor ? true : null)
-        .totalRecords(subjectResource.getInstances().size())); //todo: wrong total because of this
+        .totalRecords(filterSubResourcesForConsortium(context, subjectResource, SubjectResource::getInstances).size()));
   }
 
   @Override

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -72,7 +72,7 @@ public class SearchUtils {
     {
       "script" : {
         "lang" : "painless",
-        "source" : "def instances=new LinkedHashSet(ctx._source.instances);instances.addAll(params.ins);params.del.forEach(instances::remove);if (instances.isEmpty()) {ctx.op = 'delete'; return;}ctx._source.instances=instances;def typeIds=instances.stream().map(instance -> instance.get('instanceId').splitOnToken('|')[1]).sorted().collect(Collectors.toCollection(LinkedHashSet::new));ctx._source.contributorTypeId=typeIds"
+        "source" : "def instances=new LinkedHashSet(ctx._source.instances);instances.addAll(params.ins);params.del.forEach(instances::remove);if (instances.isEmpty()) {ctx.op = 'delete'; return;}ctx._source.instances=instances;"
       }
     }
     """;

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -63,7 +63,7 @@ public class SearchUtils {
     {
       "script": {
         "lang": "painless",
-        "source": "def instanceIds=new LinkedHashSet(ctx._source.instances);instanceIds.addAll(params.ins);params.del.forEach(instanceIds::remove);if (instanceIds.isEmpty()) {ctx.op = 'delete'; return;}ctx._source.instances=instanceIds;"
+        "source": "def instances=new LinkedHashSet(ctx._source.instances);instances.addAll(params.ins);params.del.forEach(instances::remove);if (instances.isEmpty()) {ctx.op = 'delete'; return;}ctx._source.instances=instances;"
       }
     }
     """;
@@ -72,7 +72,7 @@ public class SearchUtils {
     {
       "script" : {
         "lang" : "painless",
-        "source" : "def instanceIds=new LinkedHashSet(ctx._source.instances);instanceIds.addAll(params.ins);params.del.forEach(instanceIds::remove);if (instanceIds.isEmpty()) {ctx.op = 'delete'; return;}ctx._source.instances=instanceIds;def typeIds=instanceIds.stream().map(id -> id.splitOnToken('|')[1]).sorted().collect(Collectors.toCollection(LinkedHashSet::new));ctx._source.contributorTypeId=typeIds"
+        "source" : "def instances=new LinkedHashSet(ctx._source.instances);instances.addAll(params.ins);params.del.forEach(instances::remove);if (instances.isEmpty()) {ctx.op = 'delete'; return;}ctx._source.instances=instances;def typeIds=instances.stream().map(instance -> instance.get('instanceId').splitOnToken('|')[1]).sorted().collect(Collectors.toCollection(LinkedHashSet::new));ctx._source.contributorTypeId=typeIds"
       }
     }
     """;

--- a/src/main/resources/model/contributor.json
+++ b/src/main/resources/model/contributor.json
@@ -20,7 +20,20 @@
       "showInResponse": [ "browse" ]
     },
     "instances": {
-      "index": "source"
+      "type": "object",
+      "properties": {
+        "instanceId": {
+          "index": "source"
+        },
+        "tenantId": {
+          "index": "keyword",
+          "searchTypes": [ "filter" ]
+        },
+        "shared": {
+          "index": "bool",
+          "searchTypes": [ "filter" ]
+        }
+      }
     },
     "authorityId": {
       "index": "keyword",

--- a/src/main/resources/model/contributor.json
+++ b/src/main/resources/model/contributor.json
@@ -10,10 +10,6 @@
       "index": "keyword_lowercase",
       "showInResponse": [ "browse" ]
     },
-    "contributorTypeId": {
-      "index": "keyword",
-      "showInResponse": [ "browse" ]
-    },
     "contributorNameTypeId": {
       "index": "keyword",
       "searchTypes": [ "facet", "filter" ],
@@ -24,6 +20,10 @@
       "properties": {
         "instanceId": {
           "index": "source"
+        },
+        "contributorTypeId": {
+          "index": "keyword",
+          "showInResponse": [ "browse" ]
         },
         "tenantId": {
           "index": "keyword",

--- a/src/main/resources/model/instance_subject.json
+++ b/src/main/resources/model/instance_subject.json
@@ -14,7 +14,20 @@
       "showInResponse": [ "browse" ]
     },
     "instances": {
-      "index": "source"
+      "type": "object",
+      "properties": {
+        "instanceId": {
+          "index": "source"
+        },
+        "tenantId": {
+          "index": "keyword",
+          "searchTypes": [ "filter" ]
+        },
+        "shared": {
+          "index": "bool",
+          "searchTypes": [ "filter" ]
+        }
+      }
     }
   }
 }

--- a/src/test/java/org/folio/search/controller/BrowseContributorConsortiumIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorConsortiumIT.java
@@ -159,8 +159,7 @@ class BrowseContributorConsortiumIT extends BaseIntegrationTest {
         contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0]),
         contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[2]),
         contributorBrowseItem(1, true, "Bon Jovi", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0]),
-        contributorBrowseItem(2, true, "Bon Jovi",
-          NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
+        contributorBrowseItem(1, true, "Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0]),
         contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1])));
 
     assertThat(actual).isEqualTo(expected);

--- a/src/test/java/org/folio/search/controller/BrowseContributorConsortiumIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorConsortiumIT.java
@@ -38,8 +38,7 @@ import org.folio.tenant.domain.dto.Parameter;
 import org.folio.tenant.domain.dto.TenantAttributes;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
@@ -146,12 +145,11 @@ class BrowseContributorConsortiumIT extends BaseIntegrationTest {
       .authorityId(authorityId);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"tenantId==consortium", "shared==true"})
-  void browseByContributor_withNameAndConsortiumInstanceFilter(String instanceFilterQuery) {
+  @Test
+  void browseByContributor_withNameAndConsortiumInstanceFilter() {
     var request = get(instanceContributorBrowsePath()).param("query",
       "(" + prepareQuery("name >= {value} or name < {value}", '"' + "Bon Jovi" + '"') + ") "
-        + "and instances." + instanceFilterQuery).param("limit", "5");
+        + "and instances.shared==true").param("limit", "5");
 
     var actual = parseResponse(doGet(request), InstanceContributorBrowseResult.class);
     var expected = new InstanceContributorBrowseResult().totalRecords(5).prev(null).next(null).items(

--- a/src/test/java/org/folio/search/controller/BrowseContributorConsortiumIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorConsortiumIT.java
@@ -1,0 +1,203 @@
+package org.folio.search.controller;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.ONE_MINUTE;
+import static org.awaitility.Durations.ONE_SECOND;
+import static org.folio.search.support.base.ApiEndpoints.instanceContributorBrowsePath;
+import static org.folio.search.support.base.ApiEndpoints.instanceSearchPath;
+import static org.folio.search.utils.SearchUtils.getIndexName;
+import static org.folio.search.utils.TestConstants.CONSORTIUM_TENANT_ID;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.folio.search.utils.TestUtils.array;
+import static org.folio.search.utils.TestUtils.asJsonString;
+import static org.folio.search.utils.TestUtils.contributorBrowseItem;
+import static org.folio.search.utils.TestUtils.parseResponse;
+import static org.folio.search.utils.TestUtils.randomId;
+import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
+import static org.opensearch.search.builder.SearchSourceBuilder.searchSource;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.folio.search.domain.dto.Contributor;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.InstanceContributorBrowseResult;
+import org.folio.search.support.base.BaseIntegrationTest;
+import org.folio.search.utils.SearchUtils;
+import org.folio.spring.test.type.IntegrationTest;
+import org.folio.tenant.domain.dto.Parameter;
+import org.folio.tenant.domain.dto.TenantAttributes;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Log4j2
+@IntegrationTest
+class BrowseContributorConsortiumIT extends BaseIntegrationTest {
+
+  private static final String[] NAME_TYPE_IDS =
+    array("e2ef4075-310a-4447-a231-712bf10cc985", "0ad0a89a-741d-4f1a-85a6-ada214751013",
+      "1f857623-89ca-4f0b-ab56-5c30f706df3e");
+  private static final String[] TYPE_IDS =
+    array("2a165833-1673-493f-934b-f3d3c8fcb299", "3ae36e29-e38f-457c-8fcf-1974a6cb63d3",
+      "653ffe66-aa3f-4f1c-a090-c42c4011ef40");
+  private static final String[] AUTHORITY_IDS =
+    array("0a4c6d10-2161-4f64-aace-9e919489b6c9", "7ff32633-cc49-4332-870a-b05e329d2a2d");
+  private static final Instance[] INSTANCES_MEMBER = instancesMember();
+  private static final Instance[] INSTANCES_CENTRAL = instancesCentral();
+
+  @BeforeAll
+  static void prepare(@Autowired RestHighLevelClient restHighLevelClient) throws InterruptedException {
+    setUpTenant(CONSORTIUM_TENANT_ID, INSTANCES_CENTRAL.length, INSTANCES_CENTRAL);
+    setUpTenant(TENANT_ID, INSTANCES_CENTRAL.length + INSTANCES_MEMBER.length, INSTANCES_MEMBER);
+
+    // this is needed to test deleting contributors when all instances are unlinked from a contributor
+    var instanceToUpdate = INSTANCES_CENTRAL[0];
+    instanceToUpdate.setContributors(Collections.emptyList());
+    inventoryApi.updateInstance(CONSORTIUM_TENANT_ID, instanceToUpdate);
+
+    await().atMost(ONE_MINUTE).pollInterval(ONE_SECOND).untilAsserted(() -> {
+      var searchRequest = new SearchRequest()
+        .source(searchSource().query(matchAllQuery()).trackTotalHits(true).from(0).size(0))
+        .indices(getIndexName(SearchUtils.CONTRIBUTOR_RESOURCE, CONSORTIUM_TENANT_ID));
+      var searchResponse = restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
+      assertThat(searchResponse.getHits().getTotalHits().value).isEqualTo(12);
+    });
+  }
+
+  @AfterAll
+  static void cleanUp() {
+    removeTenant();
+  }
+
+  private static Instance[] instancesMember() {
+    return contributorBrowseInstanceData().subList(3, 7).stream()
+      .map(BrowseContributorConsortiumIT::instance).toArray(Instance[]::new);
+  }
+
+  private static Instance[] instancesCentral() {
+    return contributorBrowseInstanceData().subList(0, 3).stream()
+      .map(BrowseContributorConsortiumIT::instance).toArray(Instance[]::new);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Instance instance(List<Object> data) {
+    return new Instance().id(randomId()).title((String) data.get(0)).contributors((List<Contributor>) data.get(1))
+      .staffSuppress(false).discoverySuppress(false).holdings(emptyList());
+  }
+
+  private static List<List<Object>> contributorBrowseInstanceData() {
+    return List.of(
+      List.of("instance #00", List.of(
+        contributor("Darth Vader", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0])
+      )),
+      List.of("instance #01", List.of(
+        contributor("Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0]),
+        contributor("Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0]),
+        contributor("Anthony Kiedis", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0])
+      )),
+      List.of("instance #02", List.of(
+        contributor("Bon Jovi", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0]),
+        contributor("Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[1]),
+        contributor("Anthony Kiedis", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[2])
+      )),
+      List.of("instance #03", List.of(
+        contributor("Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[1]),
+        contributor("Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[2]),
+        contributor("Klaus Meine", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], null)
+      )),
+      List.of("instance #04", List.of(
+        contributor("John Lennon", NAME_TYPE_IDS[2], AUTHORITY_IDS[1], TYPE_IDS[0]),
+        contributor("Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0]),
+        contributor("George Harrison", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], TYPE_IDS[2]),
+        contributor("Ringo Starr", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0])
+      )),
+      List.of("instance #05", List.of(
+        contributor("John Lennon", NAME_TYPE_IDS[2], AUTHORITY_IDS[1], TYPE_IDS[0]),
+        contributor("Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[1]),
+        contributor("George Harrison", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], TYPE_IDS[2]),
+        contributor("Ringo Starr", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[1])
+      )),
+      List.of("instance #06", List.of(
+        contributor("Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[2]),
+        contributor("John Lennon", NAME_TYPE_IDS[2], null, TYPE_IDS[0])
+      )));
+  }
+
+  private static Contributor contributor(String name, String nameTypeId, String authorityId, String typeId) {
+    return new Contributor()
+      .name(name)
+      .contributorNameTypeId(nameTypeId)
+      .contributorTypeId(typeId)
+      .authorityId(authorityId);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"tenantId==consortium", "shared==true"})
+  void browseByContributor_withNameAndConsortiumInstanceFilter(String instanceFilterQuery) {
+    var request = get(instanceContributorBrowsePath()).param("query",
+      "(" + prepareQuery("name >= {value} or name < {value}", '"' + "Bon Jovi" + '"') + ") "
+        + "and instances." + instanceFilterQuery).param("limit", "5");
+
+    var actual = parseResponse(doGet(request), InstanceContributorBrowseResult.class);
+    var expected = new InstanceContributorBrowseResult().totalRecords(5).prev(null).next(null).items(
+      List.of(
+        contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0]),
+        contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[2]),
+        contributorBrowseItem(1, true, "Bon Jovi", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0]),
+        contributorBrowseItem(2, true, "Bon Jovi",
+          NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
+        contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1])));
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  //todo: move 4 methods below to consortium integration test base in a scope of MSEARCH-562
+  @SneakyThrows
+  protected static void setUpTenant(String tenantName, int expectedCount, Instance... instances) {
+    setUpTenant(tenantName, instanceSearchPath(), () -> { }, asList(instances), expectedCount,
+      instance -> inventoryApi.createInstance(tenantName, instance));
+  }
+
+  @SneakyThrows
+  private static <T> void setUpTenant(String tenant, String validationPath, Runnable postInitAction,
+                                      List<T> records, Integer expectedCount, Consumer<T> consumer) {
+    enableTenant(tenant);
+    postInitAction.run();
+    saveRecords(tenant, validationPath, records, expectedCount, consumer);
+  }
+
+  @SneakyThrows
+  protected static void enableTenant(String tenant) {
+    var tenantAttributes = new TenantAttributes().moduleTo("mod-search");
+    tenantAttributes.addParametersItem(new Parameter("centralTenantId").value(CONSORTIUM_TENANT_ID));
+
+    mockMvc.perform(post("/_/tenant", randomId())
+        .content(asJsonString(tenantAttributes))
+        .headers(defaultHeaders(tenant))
+        .contentType(APPLICATION_JSON))
+      .andExpect(status().isNoContent());
+  }
+
+  private static <T> void saveRecords(String tenant, String validationPath, List<T> records, Integer expectedCount,
+                                      Consumer<T> consumer) {
+    records.forEach(consumer);
+    if (records.size() > 0) {
+      checkThatEventsFromKafkaAreIndexed(tenant, validationPath, expectedCount);
+    }
+  }
+}

--- a/src/test/java/org/folio/search/controller/BrowseContributorIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorIT.java
@@ -47,7 +47,6 @@ import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@Disabled("Will be fixed in MSEARCH-562")
 @IntegrationTest
 class BrowseContributorIT extends BaseIntegrationTest {
 
@@ -319,6 +318,7 @@ class BrowseContributorIT extends BaseIntegrationTest {
     assertThat(actual).isEqualTo(expected);
   }
 
+  @Disabled("Will be fixed in MSEARCH-562 (or MSEARCH-534)")
   @MethodSource("facetQueriesProvider")
   @ParameterizedTest(name = "[{index}] query={0}, facets={1}")
   @DisplayName("getFacetsForContributors_parameterized")

--- a/src/test/java/org/folio/search/controller/BrowseSubjectConsortiumIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseSubjectConsortiumIT.java
@@ -130,7 +130,7 @@ class BrowseSubjectConsortiumIT extends BaseIntegrationTest {
     assertThat(actual).isEqualTo(new SubjectBrowseResult()
       .totalRecords(10).prev("Music")
       .items(List.of(
-        subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_2),
+        subjectBrowseItem(1, "Music", MUSIC_AUTHORITY_ID_2), //todo: should be one because of filtering
         subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_1),
         subjectBrowseItem(1, "Rules", true),
         subjectBrowseItem(1, "Text"),

--- a/src/test/java/org/folio/search/controller/BrowseSubjectConsortiumIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseSubjectConsortiumIT.java
@@ -1,0 +1,174 @@
+package org.folio.search.controller;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.ONE_MINUTE;
+import static org.awaitility.Durations.ONE_SECOND;
+import static org.folio.search.model.Pair.pair;
+import static org.folio.search.support.base.ApiEndpoints.instanceSearchPath;
+import static org.folio.search.support.base.ApiEndpoints.instanceSubjectBrowsePath;
+import static org.folio.search.utils.SearchUtils.getIndexName;
+import static org.folio.search.utils.TestConstants.CONSORTIUM_TENANT_ID;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.folio.search.utils.TestUtils.asJsonString;
+import static org.folio.search.utils.TestUtils.parseResponse;
+import static org.folio.search.utils.TestUtils.randomId;
+import static org.folio.search.utils.TestUtils.subjectBrowseItem;
+import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
+import static org.opensearch.search.builder.SearchSourceBuilder.searchSource;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Subject;
+import org.folio.search.domain.dto.SubjectBrowseResult;
+import org.folio.search.model.Pair;
+import org.folio.search.support.base.BaseIntegrationTest;
+import org.folio.search.utils.SearchUtils;
+import org.folio.spring.test.type.IntegrationTest;
+import org.folio.tenant.domain.dto.Parameter;
+import org.folio.tenant.domain.dto.TenantAttributes;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+class BrowseSubjectConsortiumIT extends BaseIntegrationTest {
+
+  private static final String MUSIC_AUTHORITY_ID_1 = "e62bbefe-adf5-4b1e-b3e7-43d877b0c91a";
+  private static final String MUSIC_AUTHORITY_ID_2 = "308c950f-8209-4f2e-9702-0c004a9f21bc";
+  private static final Instance[] INSTANCES_MEMBER = instancesMember();
+  private static final Instance[] INSTANCES_CENTRAL = instancesCentral();
+
+  @BeforeAll
+  static void prepare(@Autowired RestHighLevelClient restHighLevelClient) {
+    setUpTenant(CONSORTIUM_TENANT_ID, INSTANCES_CENTRAL.length, INSTANCES_CENTRAL);
+    setUpTenant(TENANT_ID, INSTANCES_CENTRAL.length + INSTANCES_MEMBER.length, INSTANCES_MEMBER);
+
+    await().atMost(ONE_MINUTE).pollInterval(ONE_SECOND).untilAsserted(() -> {
+      var searchRequest = new SearchRequest()
+        .source(searchSource().query(matchAllQuery()).trackTotalHits(true).from(0).size(0))
+        .indices(getIndexName(SearchUtils.INSTANCE_SUBJECT_RESOURCE, centralTenant));
+      var searchResponse = restHighLevelClient.search(searchRequest, RequestOptions.DEFAULT);
+      assertThat(searchResponse.getHits().getTotalHits().value).isEqualTo(23);
+    });
+  }
+
+  @AfterAll
+  static void cleanUp() {
+    removeTenant();
+  }
+
+  private static Instance[] instancesCentral() {
+    return subjectBrowseInstanceData().subList(0, 5).stream()
+      .map(BrowseSubjectConsortiumIT::instance)
+      .toArray(Instance[]::new);
+  }
+
+  private static Instance[] instancesMember() {
+    return subjectBrowseInstanceData().subList(5, 10).stream()
+      .map(BrowseSubjectConsortiumIT::instance)
+      .toArray(Instance[]::new);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Instance instance(List<Object> data) {
+    return new Instance()
+      .id(randomId())
+      .title((String) data.get(0))
+      .subjects(((List<Object>) data.get(1)).stream()
+        .map(val -> {
+          if (val instanceof Pair<?, ?> pair) {
+            return new Subject().value(String.valueOf(pair.getFirst())).authorityId(String.valueOf(pair.getSecond()));
+          } else {
+            return new Subject().value(String.valueOf(val));
+          }
+        }).collect(Collectors.toList()))
+      .staffSuppress(false)
+      .discoverySuppress(false)
+      .holdings(emptyList());
+  }
+
+  private static List<List<Object>> subjectBrowseInstanceData() {
+    return List.of(
+      List.of("instance #01", List.of("History", pair("Music", MUSIC_AUTHORITY_ID_1), "Biography")),
+      List.of("instance #02", List.of("Fantasy", pair("Music", MUSIC_AUTHORITY_ID_2))),
+      List.of("instance #03", List.of("United States", "History", "Rules")),
+      List.of("instance #04", List.of("Europe", pair("Music", MUSIC_AUTHORITY_ID_1))),
+      List.of("instance #05", List.of("Book", "Text", "Biography")),
+      List.of("instance #06", List.of("Religion", "History", "Philosophy")),
+      List.of("instance #07", List.of("Science", "Science--Methodology", "Science--Philosophy")),
+      List.of("instance #08", List.of("Water", "Water-supply", pair("Music", MUSIC_AUTHORITY_ID_2))),
+      List.of("instance #09", List.of("Water--Analysis", "Water--Purification", "Water--Microbiology")),
+      List.of("instance #10", List.of("Database design", "Database management", "Textbooks"))
+    );
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"tenantId==consortium", "shared==true"})
+  void browseBySubject_browsingAroundWithConsortiumInstanceFilter(String instanceFilterQuery) {
+    var request = get(instanceSubjectBrowsePath())
+      .param("query", "("
+        + prepareQuery("value < {value} or value >= {value}", "\"Rules\"") + ") "
+        + "and instances." + instanceFilterQuery)
+      .param("limit", "5")
+      .param("precedingRecordsCount", "2");
+    var actual = parseResponse(doGet(request), SubjectBrowseResult.class);
+    assertThat(actual).isEqualTo(new SubjectBrowseResult()
+      .totalRecords(10).prev("Music")
+      .items(List.of(
+        subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_2),
+        subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_1),
+        subjectBrowseItem(1, "Rules", true),
+        subjectBrowseItem(1, "Text"),
+        subjectBrowseItem(1, "United States"))));
+  }
+
+  //todo: move 4 methods below to consortium integration test base in a scope of MSEARCH-562
+  @SneakyThrows
+  protected static void setUpTenant(String tenantName, int expectedCount, Instance... instances) {
+    setUpTenant(tenantName, instanceSearchPath(), () -> { }, asList(instances), expectedCount,
+      instance -> inventoryApi.createInstance(tenantName, instance));
+  }
+
+  @SneakyThrows
+  private static <T> void setUpTenant(String tenant, String validationPath, Runnable postInitAction,
+                                      List<T> records, Integer expectedCount, Consumer<T> consumer) {
+    enableTenant(tenant);
+    postInitAction.run();
+    saveRecords(tenant, validationPath, records, expectedCount, consumer);
+  }
+
+  @SneakyThrows
+  protected static void enableTenant(String tenant) {
+    var tenantAttributes = new TenantAttributes().moduleTo("mod-search");
+    tenantAttributes.addParametersItem(new Parameter("centralTenantId").value(CONSORTIUM_TENANT_ID));
+
+    mockMvc.perform(post("/_/tenant", randomId())
+        .content(asJsonString(tenantAttributes))
+        .headers(defaultHeaders(tenant))
+        .contentType(APPLICATION_JSON))
+      .andExpect(status().isNoContent());
+  }
+
+  private static <T> void saveRecords(String tenant, String validationPath, List<T> records, Integer expectedCount,
+                                      Consumer<T> consumer) {
+    records.forEach(consumer);
+    if (records.size() > 0) {
+      checkThatEventsFromKafkaAreIndexed(tenant, validationPath, expectedCount);
+    }
+  }
+}

--- a/src/test/java/org/folio/search/controller/BrowseSubjectConsortiumIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseSubjectConsortiumIT.java
@@ -130,7 +130,7 @@ class BrowseSubjectConsortiumIT extends BaseIntegrationTest {
     assertThat(actual).isEqualTo(new SubjectBrowseResult()
       .totalRecords(10).prev("Music")
       .items(List.of(
-        subjectBrowseItem(1, "Music", MUSIC_AUTHORITY_ID_2), //todo: should be one because of filtering
+        subjectBrowseItem(1, "Music", MUSIC_AUTHORITY_ID_2),
         subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_1),
         subjectBrowseItem(1, "Rules", true),
         subjectBrowseItem(1, "Text"),

--- a/src/test/java/org/folio/search/controller/BrowseSubjectConsortiumIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseSubjectConsortiumIT.java
@@ -38,8 +38,7 @@ import org.folio.tenant.domain.dto.Parameter;
 import org.folio.tenant.domain.dto.TenantAttributes;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
@@ -117,13 +116,12 @@ class BrowseSubjectConsortiumIT extends BaseIntegrationTest {
     );
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"tenantId==consortium", "shared==true"})
-  void browseBySubject_browsingAroundWithConsortiumInstanceFilter(String instanceFilterQuery) {
+  @Test
+  void browseBySubject_browsingAroundWithConsortiumInstanceFilter() {
     var request = get(instanceSubjectBrowsePath())
       .param("query", "("
         + prepareQuery("value < {value} or value >= {value}", "\"Rules\"") + ") "
-        + "and instances." + instanceFilterQuery)
+        + "and instances.shared==true")
       .param("limit", "5")
       .param("precedingRecordsCount", "2");
     var actual = parseResponse(doGet(request), SubjectBrowseResult.class);

--- a/src/test/java/org/folio/search/controller/RecordsIndexingIT.java
+++ b/src/test/java/org/folio/search/controller/RecordsIndexingIT.java
@@ -90,20 +90,20 @@ class RecordsIndexingIT extends BaseIntegrationTest {
 
     inventoryApi.createInstance(TENANT_ID, instance);
     assertCountByQuery(instanceSearchPath(), "subjects=={value}", "(s1 and s2)", 1);
-    assertSubjectExistenceById(sha1Hex(TENANT_ID + "|s1|null"), true);
-    assertSubjectExistenceById(sha1Hex(TENANT_ID + "|s2|null"), true);
+    assertSubjectExistenceById(sha1Hex("s1|null"), true);
+    assertSubjectExistenceById(sha1Hex("s2|null"), true);
 
     var instanceToUpdate = new Instance().id(instanceId).title("test-resource").subjects(
       List.of(new Subject().value("s2"), new Subject().value("s3")));
     inventoryApi.updateInstance(TENANT_ID, instanceToUpdate);
     assertCountByQuery(instanceSearchPath(), "subjects=={value}", "(s2 and s3)", 1);
-    assertSubjectExistenceById(sha1Hex(TENANT_ID + "|s1|null"), false);
-    assertSubjectExistenceById(sha1Hex(TENANT_ID + "|s3|null"), true);
+    assertSubjectExistenceById(sha1Hex("s1|null"), false);
+    assertSubjectExistenceById(sha1Hex("s3|null"), true);
 
     inventoryApi.deleteInstance(TENANT_ID, instanceId);
     assertCountByQuery(instanceSearchPath(), "id=={value}", instanceId, 0);
-    assertSubjectExistenceById(sha1Hex(TENANT_ID + "|s2|null"), false);
-    assertSubjectExistenceById(sha1Hex(TENANT_ID + "|s3|null"), false);
+    assertSubjectExistenceById(sha1Hex("s2|null"), false);
+    assertSubjectExistenceById(sha1Hex("s3|null"), false);
   }
 
   @Test
@@ -271,7 +271,7 @@ class RecordsIndexingIT extends BaseIntegrationTest {
   }
 
   private static String getSubjectId(String instanceId) {
-    return sha1Hex(TENANT_ID + "|subject-" + sha1Hex(instanceId) + "|null");
+    return sha1Hex("subject-" + sha1Hex(instanceId) + "|null");
   }
 
   private void createInstances() {

--- a/src/test/java/org/folio/search/cql/CqlSearchQueryConverterTest.java
+++ b/src/test/java/org/folio/search/cql/CqlSearchQueryConverterTest.java
@@ -376,9 +376,7 @@ class CqlSearchQueryConverterTest {
     var cqlQuery = "f1==value";
     var actual = cqlSearchQueryConverter.convertForConsortia(cqlQuery, RESOURCE_NAME);
     assertThat(actual).isEqualTo(searchSource().query(
-      boolQuery().filter(termQuery("f1", "value"))
-        .should(termQuery("tenantId", CONSORTIUM_TENANT_ID))
-        .minimumShouldMatch(1)));
+      boolQuery().filter(termQuery("f1", "value"))));
   }
 
   @Test

--- a/src/test/java/org/folio/search/repository/InstanceContributorsRepositoryTest.java
+++ b/src/test/java/org/folio/search/repository/InstanceContributorsRepositoryTest.java
@@ -1,13 +1,11 @@
 package org.folio.search.repository;
 
-import static org.apache.commons.codec.digest.DigestUtils.sha256Hex;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.domain.dto.ResourceEventType.CREATE;
-import static org.folio.search.model.types.IndexActionType.DELETE;
 import static org.folio.search.model.types.IndexActionType.INDEX;
 import static org.folio.search.model.types.IndexingDataFormat.SMILE;
 import static org.folio.search.utils.SearchResponseHelper.getSuccessIndexOperationResponse;
-import static org.folio.search.utils.SearchUtils.INSTANCE_SUBJECT_RESOURCE;
+import static org.folio.search.utils.SearchUtils.CONTRIBUTOR_RESOURCE;
 import static org.folio.search.utils.TestConstants.RESOURCE_ID;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.OBJECT_MAPPER;
@@ -29,14 +27,12 @@ import java.util.Set;
 import java.util.function.Function;
 import lombok.SneakyThrows;
 import org.folio.search.configuration.properties.SearchConfigurationProperties;
-import org.folio.search.domain.dto.ResourceEventType;
 import org.folio.search.model.index.SearchDocumentBody;
 import org.folio.search.service.consortium.ConsortiumTenantService;
 import org.folio.search.service.consortium.TenantProvider;
 import org.folio.search.utils.JsonConverter;
 import org.folio.search.utils.SmileConverter;
 import org.folio.spring.test.type.UnitTest;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,10 +53,10 @@ import org.opensearch.script.Script;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-class InstanceSubjectRepositoryTest {
+class InstanceContributorsRepositoryTest {
 
   @InjectMocks
-  private InstanceSubjectRepository repository;
+  private InstanceContributorsRepository repository;
 
   @Spy
   private JsonConverter jsonConverter = new JsonConverter(OBJECT_MAPPER);
@@ -86,8 +82,9 @@ class InstanceSubjectRepositoryTest {
   }
 
   @Test
-  void indexResources_positive_onlyIndexEvents() throws IOException {
-    var document = subjectDocumentBodyToIndex();
+  void indexResources_positive() throws IOException {
+    var typeId = randomId();
+    var document = contributorDocumentBodyToIndex(typeId);
     var bulkResponse = mock(BulkResponse.class);
 
     when(elasticsearchClient.bulk(bulkRequestCaptor.capture(), eq(DEFAULT))).thenReturn(bulkResponse);
@@ -101,14 +98,16 @@ class InstanceSubjectRepositoryTest {
       assertThat(request).isInstanceOf(UpdateRequest.class);
       var updateRequest = (UpdateRequest) request;
       assertThat(getParam(updateRequest.script(), "ins"))
-        .containsExactly(Map.of("instanceId", RESOURCE_ID, "tenantId", TENANT_ID));
+        .containsExactly(Map.of("instanceId", RESOURCE_ID + "|" + typeId,
+          "tenantId", TENANT_ID));
       assertThat(getParam(updateRequest.script(), "del")).isEmpty();
     });
   }
 
   @Test
   void indexResources_positive_shared() throws IOException {
-    var document = subjectDocumentBodyToIndex();
+    var typeId = randomId();
+    var document = contributorDocumentBodyToIndex(typeId);
     var bulkResponse = mock(BulkResponse.class);
 
     when(elasticsearchClient.bulk(bulkRequestCaptor.capture(), eq(DEFAULT))).thenReturn(bulkResponse);
@@ -123,48 +122,11 @@ class InstanceSubjectRepositoryTest {
       assertThat(request).isInstanceOf(UpdateRequest.class);
       var updateRequest = (UpdateRequest) request;
       assertThat(getParam(updateRequest.script(), "ins"))
-        .containsExactly(Map.of("instanceId", RESOURCE_ID, "tenantId", TENANT_ID, "shared", true));
+        .containsExactly(Map.of("instanceId", RESOURCE_ID + "|" + typeId,
+          "tenantId", TENANT_ID,
+          "shared", true));
       assertThat(getParam(updateRequest.script(), "del")).isEmpty();
     });
-  }
-
-  @Test
-  void indexResources_positive_deleteSubjects() throws IOException {
-    var subject1 = "java";
-    var subject2 = "scala";
-
-    var bulkResponse = mock(BulkResponse.class);
-    when(elasticsearchClient.bulk(bulkRequestCaptor.capture(), eq(DEFAULT))).thenReturn(bulkResponse);
-    when(bulkResponse.hasFailures()).thenReturn(false);
-
-    var documents = List.of(subjectDocumentBodyToDelete(subject1), subjectDocumentBodyToDelete(subject2));
-    var actual = repository.indexResources(documents);
-
-    assertThat(actual).isEqualTo(getSuccessIndexOperationResponse());
-    var requests = bulkRequestCaptor.getValue().requests();
-    assertThat(requests).hasSize(2);
-    for (DocWriteRequest<?> request : requests) {
-      var updateRequest = (UpdateRequest) request;
-      assertThat(getParam(updateRequest.script(), "del"))
-        .containsExactly(Map.of("instanceId", RESOURCE_ID, "tenantId", TENANT_ID));
-      assertThat(getParam(updateRequest.script(), "ins")).isEmpty();
-    }
-  }
-
-  @Test
-  void indexResources_positive_skipIfInstanceIdIsBlank() throws IOException {
-    var subject = "scala";
-
-    var bulkResponse = mock(BulkResponse.class);
-    when(elasticsearchClient.bulk(bulkRequestCaptor.capture(), eq(DEFAULT))).thenReturn(bulkResponse);
-    when(bulkResponse.hasFailures()).thenReturn(false);
-
-    var documents = List.of(subjectDocumentBodyToDelete(subject, ""));
-    var actual = repository.indexResources(documents);
-
-    assertThat(actual).isEqualTo(getSuccessIndexOperationResponse());
-    var requests = bulkRequestCaptor.getValue().requests();
-    assertThat(requests).isEmpty();
   }
 
   @SuppressWarnings("unchecked")
@@ -173,36 +135,19 @@ class InstanceSubjectRepositoryTest {
   }
 
   @SneakyThrows
-  private SearchDocumentBody subjectDocumentBodyToIndex() {
-    var subject = "test";
+  private SearchDocumentBody contributorDocumentBodyToIndex(String typeId) {
+    var id = randomId();
     var authorityId = randomId();
-    var body = mapOf("value", subject, "instanceId", RESOURCE_ID, "authorityId", authorityId);
-    var event = resourceEvent(getDocumentId(subject, authorityId), INSTANCE_SUBJECT_RESOURCE, CREATE, body, null);
+    var body = mapOf("id", id, "instanceId", RESOURCE_ID, "name", "test", "nameTypeId", randomId(),
+      "typeId", typeId, "authorityId", authorityId);
+    var event = resourceEvent(id, CONTRIBUTOR_RESOURCE, CREATE, body, null);
     return SearchDocumentBody.of(new BytesArray(SMILE_MAPPER.writeValueAsBytes(body)), SMILE, event, INDEX);
-  }
-
-  @SneakyThrows
-  private SearchDocumentBody subjectDocumentBodyToDelete(String subject) {
-    return subjectDocumentBodyToDelete(subject, RESOURCE_ID);
-  }
-
-  @SneakyThrows
-  private SearchDocumentBody subjectDocumentBodyToDelete(String subject, String instanceId) {
-    var body = mapOf("value", subject, "instanceId", instanceId);
-    var event =
-      resourceEvent(getDocumentId(subject, null), INSTANCE_SUBJECT_RESOURCE, ResourceEventType.DELETE, null, body);
-    return SearchDocumentBody.of(new BytesArray(SMILE_MAPPER.writeValueAsBytes(body)), SMILE, event, DELETE);
-  }
-
-  @NotNull
-  private String getDocumentId(String subject, String authorityId) {
-    return sha256Hex(subject + authorityId);
   }
 
   private SearchConfigurationProperties getSearchConfigurationProperties() {
     var indexSettings = new SearchConfigurationProperties.IndexingSettings();
     indexSettings.setDataFormat(SMILE);
-    indexSettings.setInstanceSubjects(new SearchConfigurationProperties.DocumentIndexingSettings());
+    indexSettings.setInstanceContributors(new SearchConfigurationProperties.DocumentIndexingSettings());
     var searchConfigurationProperties = new SearchConfigurationProperties();
     searchConfigurationProperties.setIndexing(indexSettings);
     return searchConfigurationProperties;

--- a/src/test/java/org/folio/search/repository/InstanceContributorsRepositoryTest.java
+++ b/src/test/java/org/folio/search/repository/InstanceContributorsRepositoryTest.java
@@ -98,8 +98,8 @@ class InstanceContributorsRepositoryTest {
       assertThat(request).isInstanceOf(UpdateRequest.class);
       var updateRequest = (UpdateRequest) request;
       assertThat(getParam(updateRequest.script(), "ins"))
-        .containsExactly(Map.of("instanceId", RESOURCE_ID + "|" + typeId,
-          "tenantId", TENANT_ID));
+        .containsExactly(Map.of("instanceId", RESOURCE_ID,
+          "tenantId", TENANT_ID, "typeId", typeId));
       assertThat(getParam(updateRequest.script(), "del")).isEmpty();
     });
   }
@@ -122,7 +122,8 @@ class InstanceContributorsRepositoryTest {
       assertThat(request).isInstanceOf(UpdateRequest.class);
       var updateRequest = (UpdateRequest) request;
       assertThat(getParam(updateRequest.script(), "ins"))
-        .containsExactly(Map.of("instanceId", RESOURCE_ID + "|" + typeId,
+        .containsExactly(Map.of("instanceId", RESOURCE_ID,
+          "typeId", typeId,
           "tenantId", TENANT_ID,
           "shared", true));
       assertThat(getParam(updateRequest.script(), "del")).isEmpty();

--- a/src/test/java/org/folio/search/service/browse/AbstractBrowseServiceBySearchAfterTest.java
+++ b/src/test/java/org/folio/search/service/browse/AbstractBrowseServiceBySearchAfterTest.java
@@ -39,7 +39,7 @@ class AbstractBrowseServiceBySearchAfterTest {
     }
 
     @Override
-    protected BrowseResult mapToBrowseResult(SearchResult searchResult, boolean isAnchor) {
+    protected BrowseResult mapToBrowseResult(BrowseContext context, SearchResult searchResult, boolean isAnchor) {
       return null;
     }
 

--- a/src/test/java/org/folio/search/service/browse/ContributorBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/ContributorBrowseServiceTest.java
@@ -2,14 +2,22 @@ package org.folio.search.service.browse;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.opensearch.index.query.QueryBuilders.termQuery;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
+import org.folio.search.domain.dto.InstanceContributorBrowseItem;
 import org.folio.search.model.SearchResult;
 import org.folio.search.model.index.ContributorResource;
 import org.folio.search.model.index.InstanceSubResource;
+import org.folio.search.model.service.BrowseContext;
 import org.folio.spring.test.type.UnitTest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
@@ -18,29 +26,53 @@ class ContributorBrowseServiceTest {
 
   private final ContributorBrowseService service = new ContributorBrowseService();
 
-  @Test
-  void mapToBrowseResult_positive_shouldCalculateTotalInstances() {
+  private static Stream<Arguments> consortiumFilterData() {
+    return Stream.of(
+      arguments("instances.tenantId", "tenant1"),
+      arguments("instances.shared", false)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("consortiumFilterData")
+  void mapToBrowseResult_positive_withConsortiumFilter(String parameter, Object value) {
     var contributors = singletonList(ContributorResource.builder()
-      .name("test")
-      .contributorTypeId(Set.of("test1"))
-      .contributorNameTypeId("test2")
-      .authorityId("test3")
+      .name("name")
+      .contributorNameTypeId("nameType")
+      .authorityId("auth")
       .instances(Set.of(
-        contributorInstance("test4|1"),
-        contributorInstance("test5|2"),
-        contributorInstance("test4|3")))
+        contributorInstance("ins1", "type1", false, "tenant1"),
+        contributorInstance("ins2", "type1", true, "tenant2"),
+        contributorInstance("ins1", "type2", false, "tenant1")))
       .build());
     var searchResult = new SearchResult<ContributorResource>();
     searchResult.setTotalRecords(1);
     searchResult.setRecords(contributors);
+    var browseContext = BrowseContext.builder()
+      .filters(singletonList(termQuery(parameter, value)))
+      .build();
 
-    var browseResult = service.mapToBrowseResult(searchResult, false);
+    var expected = new InstanceContributorBrowseItem()
+      .isAnchor(false)
+      .contributorTypeId(List.of("type1", "type2"))
+      .name("name")
+      .contributorNameTypeId("nameType")
+      .authorityId("auth")
+      .totalRecords(1);
 
-    assertThat(browseResult.getRecords().get(0).getTotalRecords())
-      .isEqualTo(2);
+    //todo: test for tenantId/shared filters (separate test without)
+    var browseResult = service.mapToBrowseResult(browseContext, searchResult, false);
+
+    assertThat(browseResult.getRecords().get(0))
+      .isEqualTo(expected);
   }
 
-  private InstanceSubResource contributorInstance(String instanceId) {
-    return InstanceSubResource.builder().instanceId(instanceId).build();
+  private InstanceSubResource contributorInstance(String instanceId, String typeId, Boolean shared, String tenantId) {
+    return InstanceSubResource.builder()
+      .instanceId(instanceId)
+      .typeId(typeId)
+      .shared(shared)
+      .tenantId(tenantId)
+      .build();
   }
 }

--- a/src/test/java/org/folio/search/service/browse/ContributorBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/ContributorBrowseServiceTest.java
@@ -2,22 +2,18 @@ package org.folio.search.service.browse;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.opensearch.index.query.QueryBuilders.termQuery;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 import org.folio.search.domain.dto.InstanceContributorBrowseItem;
 import org.folio.search.model.SearchResult;
 import org.folio.search.model.index.ContributorResource;
 import org.folio.search.model.index.InstanceSubResource;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.spring.test.type.UnitTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
@@ -26,30 +22,14 @@ class ContributorBrowseServiceTest {
 
   private final ContributorBrowseService service = new ContributorBrowseService();
 
-  private static Stream<Arguments> consortiumFilterData() {
-    return Stream.of(
-      arguments("instances.tenantId", "tenant1"),
-      arguments("instances.shared", false)
-    );
-  }
-
-  @ParameterizedTest
-  @MethodSource("consortiumFilterData")
-  void mapToBrowseResult_positive_withConsortiumFilter(String parameter, Object value) {
-    var contributors = singletonList(ContributorResource.builder()
-      .name("name")
-      .contributorNameTypeId("nameType")
-      .authorityId("auth")
-      .instances(Set.of(
-        contributorInstance("ins1", "type1", false, "tenant1"),
-        contributorInstance("ins2", "type1", true, "tenant2"),
-        contributorInstance("ins1", "type2", false, "tenant1")))
-      .build());
+  @Test
+  void mapToBrowseResult_positive_withConsortiumFilter() {
+    var contributors = contributors();
     var searchResult = new SearchResult<ContributorResource>();
     searchResult.setTotalRecords(1);
     searchResult.setRecords(contributors);
     var browseContext = BrowseContext.builder()
-      .filters(singletonList(termQuery(parameter, value)))
+      .filters(singletonList(termQuery("instances.shared", false)))
       .build();
 
     var expected = new InstanceContributorBrowseItem()
@@ -60,11 +40,44 @@ class ContributorBrowseServiceTest {
       .authorityId("auth")
       .totalRecords(1);
 
-    //todo: test for tenantId/shared filters (separate test without)
     var browseResult = service.mapToBrowseResult(browseContext, searchResult, false);
 
     assertThat(browseResult.getRecords().get(0))
       .isEqualTo(expected);
+  }
+
+  @Test
+  void mapToBrowseResult_positive() {
+    var contributors = contributors();
+    var searchResult = new SearchResult<ContributorResource>();
+    searchResult.setTotalRecords(1);
+    searchResult.setRecords(contributors);
+    var browseContext = BrowseContext.builder().build();
+
+    var expected = new InstanceContributorBrowseItem()
+      .isAnchor(false)
+      .contributorTypeId(List.of("type1", "type2"))
+      .name("name")
+      .contributorNameTypeId("nameType")
+      .authorityId("auth")
+      .totalRecords(2);
+
+    var browseResult = service.mapToBrowseResult(browseContext, searchResult, false);
+
+    assertThat(browseResult.getRecords().get(0))
+      .isEqualTo(expected);
+  }
+
+  private List<ContributorResource> contributors() {
+    return singletonList(ContributorResource.builder()
+      .name("name")
+      .contributorNameTypeId("nameType")
+      .authorityId("auth")
+      .instances(Set.of(
+        contributorInstance("ins1", "type1", false, "tenant1"),
+        contributorInstance("ins2", "type1", true, "tenant2"),
+        contributorInstance("ins1", "type2", false, "tenant1")))
+      .build());
   }
 
   private InstanceSubResource contributorInstance(String instanceId, String typeId, Boolean shared, String tenantId) {

--- a/src/test/java/org/folio/search/service/browse/ContributorBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/ContributorBrowseServiceTest.java
@@ -1,0 +1,46 @@
+package org.folio.search.service.browse;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.folio.search.model.SearchResult;
+import org.folio.search.model.index.ContributorResource;
+import org.folio.search.model.index.InstanceSubResource;
+import org.folio.spring.test.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class ContributorBrowseServiceTest {
+
+  private final ContributorBrowseService service = new ContributorBrowseService();
+
+  @Test
+  void mapToBrowseResult_positive_shouldCalculateTotalInstances() {
+    var contributors = singletonList(ContributorResource.builder()
+      .name("test")
+      .contributorTypeId(Set.of("test1"))
+      .contributorNameTypeId("test2")
+      .authorityId("test3")
+      .instances(Set.of(
+        contributorInstance("test4|1"),
+        contributorInstance("test5|2"),
+        contributorInstance("test4|3")))
+      .build());
+    var searchResult = new SearchResult<ContributorResource>();
+    searchResult.setTotalRecords(1);
+    searchResult.setRecords(contributors);
+
+    var browseResult = service.mapToBrowseResult(searchResult, false);
+
+    assertThat(browseResult.getRecords().get(0).getTotalRecords())
+      .isEqualTo(2);
+  }
+
+  private InstanceSubResource contributorInstance(String instanceId) {
+    return InstanceSubResource.builder().instanceId(instanceId).build();
+  }
+}

--- a/src/test/java/org/folio/search/service/browse/SubjectBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/SubjectBrowseServiceTest.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import org.folio.search.model.BrowseResult;
 import org.folio.search.model.ResourceRequest;
 import org.folio.search.model.SearchResult;
+import org.folio.search.model.index.InstanceSubResource;
 import org.folio.search.model.index.SubjectResource;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.model.service.BrowseRequest;
@@ -345,7 +346,9 @@ class SubjectBrowseServiceTest {
     return Arrays.stream(subject).map(sub -> {
       var subjectResource = new SubjectResource();
       subjectResource.setValue(sub);
-      subjectResource.setInstances(sub.chars().mapToObj(String::valueOf).collect(Collectors.toSet()));
+      subjectResource.setInstances(sub.chars().mapToObj(String::valueOf)
+          .map(s -> InstanceSubResource.builder().instanceId(s).build())
+        .collect(Collectors.toSet()));
       return subjectResource;
     }).toArray(SubjectResource[]::new);
   }

--- a/src/test/java/org/folio/search/utils/AuthoritySearchUtils.java
+++ b/src/test/java/org/folio/search/utils/AuthoritySearchUtils.java
@@ -21,11 +21,18 @@ public class AuthoritySearchUtils {
     "id", "identifiers", "subjectHeadings", "metadata", "notes");
 
   public static Map<String, Object> expectedAuthorityAsMap(Authority source, String... fields) {
+    return expectedAuthorityAsMap(source, false, fields);
+  }
+
+  public static Map<String, Object> expectedAuthorityAsMap(Authority source, Boolean shared, String... fields) {
     var resultMap = new LinkedHashMap<String, Object>();
     var sourceMap = toMap(source);
     copyExpectedEntityFields(sourceMap, resultMap, List.of(fields));
     copyExpectedEntityFields(sourceMap, resultMap, AUTHORITY_COMMON_FIELDS);
     resultMap.put("tenantId", TENANT_ID);
+    if (shared) {
+      resultMap.put("shared", true);
+    }
     return resultMap;
   }
 

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -244,7 +244,7 @@ public class TestUtils {
       .name(name)
       .contributorNameTypeId(nameTypeId)
       .authorityId(authorityId)
-      .contributorTypeId(typeIds != null && typeIds.length != 0 ? Arrays.asList(typeIds) : null)
+      .contributorTypeId(Arrays.asList(typeIds))
       .totalRecords(totalRecords)
       .isAnchor(isAnchor);
   }


### PR DESCRIPTION
## Purpose
Add tenantId/shared fields to contributors/subjects so they could be used as filters for browsing
[MSEARCH-551](https://issues.folio.org/browse/MSEARCH-551)

## Approach
- Fix active affiliation query for central tenant
- Remove tenantId from constructing id for subjects/contributors
- Add tenantId/shared flags to contributors/subjects indexing
- Add authority shared flag population
- Update contributors/subjects upsert scripts

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Should we apply this filters to instance count also?
