### PR TITLE
MSEARCH-559: Call Numbers Browse with call number type shows irrelevant result corrected

### DIFF
--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -4,6 +4,7 @@ import static java.lang.Boolean.TRUE;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
+import static org.folio.search.utils.CallNumberUtils.excludeIrrelevantResultItems;
 import static org.folio.search.utils.CollectionUtils.mergeSafelyToList;
 
 import java.util.ArrayList;
@@ -41,6 +42,9 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
     var searchResponse = searchRepository.search(request, searchSource);
     var browseResult = callNumberBrowseResultConverter.convert(searchResponse, context, isBrowsingForward);
     var records = browseResult.getRecords();
+    if (request.getRefinedCondition() != null) {
+      browseResult.setRecords(excludeIrrelevantResultItems(request.getRefinedCondition(), browseResult.getRecords()));
+    }
     return new BrowseResult<CallNumberBrowseItem>()
       .records(trim(records, context, isBrowsingForward))
       .totalRecords(browseResult.getTotalRecords())
@@ -80,6 +84,12 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
       highlightMatchingCallNumber(context, callNumber, succeedingResult);
     }
 
+    if (request.getRefinedCondition() != null) {
+      precedingResult.setRecords(excludeIrrelevantResultItems(request.getRefinedCondition(),
+        precedingResult.getRecords()));
+      succeedingResult.setRecords(excludeIrrelevantResultItems(request.getRefinedCondition(),
+        succeedingResult.getRecords()));
+    }
     return new BrowseResult<CallNumberBrowseItem>()
       .totalRecords(precedingResult.getTotalRecords() + succeedingResult.getTotalRecords())
       .prev(getPrevBrowsingValue(precedingResult.getRecords(), context, false))

--- a/src/main/java/org/folio/search/utils/CallNumberUtils.java
+++ b/src/main/java/org/folio/search/utils/CallNumberUtils.java
@@ -3,6 +3,7 @@ package org.folio.search.utils;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Locale.ROOT;
 import static java.util.stream.Collectors.joining;
+import static org.folio.search.utils.CollectionUtils.distinctByKey;
 
 import java.util.HashMap;
 import java.util.List;
@@ -13,6 +14,8 @@ import java.util.stream.Stream;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.RegExUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.folio.search.domain.dto.CallNumberBrowseItem;
+import org.folio.search.model.types.CallNumberType;
 import org.springframework.util.Assert;
 
 @UtilityClass
@@ -142,6 +145,21 @@ public class CallNumberUtils {
     }
     long startVal = convertChar(firstPosition, CN_MAX_CHARS);
     return callNumberToLong(callNumber, startVal, CN_MAX_CHARS - 1);
+  }
+
+  public static List<CallNumberBrowseItem> excludeIrrelevantResultItems(String refinedCondition,
+                                                                        List<CallNumberBrowseItem> records) {
+    records = records
+      .stream()
+      .filter(distinctByKey(r -> r.getInstance().getId()))
+      .toList();
+    records
+      .forEach(r -> r.getInstance().setItems(r.getInstance().getItems()
+        .stream()
+        .filter(i -> CallNumberType.fromId(i.getEffectiveCallNumberComponents().getTypeId())
+          .equals(CallNumberType.fromName(refinedCondition)))
+        .toList()));
+    return records;
   }
 
   private static long callNumberToLong(String callNumber, long startVal, int maxChars) {

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
@@ -14,16 +14,11 @@ import static org.folio.search.utils.TestUtils.randomId;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
-import java.lang.reflect.Array;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-
 import org.folio.search.domain.dto.CallNumberBrowseResult;
-import org.folio.search.domain.dto.Holding;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
@@ -48,17 +43,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
   @BeforeAll
   static void prepare() {
-    Instance[] dest = instancesWithHoldings();
-    List<Instance> resultList = new ArrayList<>(INSTANCES.length + dest.length);
-    Collections.addAll(resultList, INSTANCES);
-    Collections.addAll(resultList, dest);
-
-    @SuppressWarnings("unchecked")
-    //the type cast is safe as the array1 has the type T[]
-    Instance[] resultArray = (Instance[]) Array.newInstance(INSTANCES.getClass().getComponentType(), 0);
-    Instance[] array = resultList.toArray(resultArray);
-
-    setUpTenant(array);
+    setUpTenant(INSTANCES);
   }
 
   @AfterAll
@@ -93,21 +78,6 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
         cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
         cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993", true)
-      )));
-  }
-
-  @Test
-  void browseByCallNumber_browsingAroundWhenPrecedingRecordsCountIsSpecified2() {
-    var request = get(instanceCallNumberBrowsePath())
-      .param("query", "typedCallNumber>=\"308 H977\" or typedCallNumber<\"308 H977\"")
-      .param("limit", "100")
-      .param("highlightMatch", "true")
-      .param("callNumberType", "dewey")
-      .param("precedingRecordsCount", "5");
-    var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
-    assertThat(actual).isEqualTo(new CallNumberBrowseResult()
-      .totalRecords(1).items(List.of(
-        cnBrowseItem(instance("instance #47"), "308 H977", true)
       )));
   }
 
@@ -396,12 +366,6 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       .toArray(Instance[]::new);
   }
 
-  private static Instance[] instancesWithHoldings() {
-    return callNumberBrowseHoldingsData().stream()
-      .map(BrowseCallNumberIT::instanceWithHoldings)
-      .toArray(Instance[]::new);
-  }
-
   @SuppressWarnings("unchecked")
   private static Instance instance(List<Object> data) {
     var items = ((List<String>) data.get(1)).stream()
@@ -424,29 +388,8 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       .holdings(emptyList());
   }
 
-  @SuppressWarnings("unchecked")
-  private static Instance instanceWithHoldings(List<Object> data) {
-    var holdings = ((List<String>) data.get(1)).stream()
-      .map(callNumber -> new Holding()
-        .callNumber(callNumber))
-      .toList();
-    return new Instance()
-      .id(randomId())
-      .title((String) data.get(0))
-      .staffSuppress(false)
-      .discoverySuppress(false)
-      .isBoundWith(false)
-      .shared(false)
-      .tenantId(TENANT_ID)
-      .holdings(holdings);
-  }
-
   private static Instance instance(String title) {
     return INSTANCE_MAP.get(title);
-  }
-
-  private static List<List<Object>> callNumberBrowseHoldingsData() {
-    return List.of(List.of("instance #47", List.of("308 H977", "Z669.R360 1975")));
   }
 
   private static List<List<Object>> callNumberBrowseInstanceData() {

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberIrrelevantResultTest.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberIrrelevantResultTest.java
@@ -1,0 +1,141 @@
+package org.folio.search.controller;
+
+import static java.util.Collections.emptyList;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.domain.dto.TenantConfiguredFeature.BROWSE_CN_INTERMEDIATE_VALUES;
+import static org.folio.search.support.base.ApiEndpoints.instanceCallNumberBrowsePath;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.folio.search.utils.TestUtils.cnBrowseItem;
+import static org.folio.search.utils.TestUtils.cnBrowseResult;
+import static org.folio.search.utils.TestUtils.getShelfKeyFromCallNumber;
+import static org.folio.search.utils.TestUtils.parseResponse;
+import static org.folio.search.utils.TestUtils.randomId;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.folio.search.domain.dto.CallNumberBrowseResult;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.domain.dto.Item;
+import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
+import org.folio.search.support.base.BaseIntegrationTest;
+import org.folio.search.utils.CallNumberUtils;
+import org.folio.spring.test.type.IntegrationTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@IntegrationTest
+class BrowseCallNumberIrrelevantResultTest extends BaseIntegrationTest {
+
+  private static final Instance[] INSTANCES = instances();
+  private static final Map<String, Instance> INSTANCE_MAP =
+    Arrays.stream(INSTANCES).collect(toMap(Instance::getTitle, identity()));
+
+  @BeforeAll
+  static void prepare() {
+    setUpTenant(INSTANCES);
+  }
+
+  @AfterAll
+  static void cleanUp() {
+    removeTenant();
+  }
+
+  @Test
+  void browseByCallNumber_browsingAroundWithEnabledIntermediateValues() {
+    enableFeature(BROWSE_CN_INTERMEDIATE_VALUES);
+
+    var request = get(instanceCallNumberBrowsePath())
+      .param("callNumberType", "dewey")
+      .param("query", prepareQuery("typedCallNumber >= {value} or typedCallNumber < {value}", "308 H977"))
+      .param("limit", "15")
+      .param("highlightMatch", "true")
+      .param("precedingRecordsCount", "5")
+      .param("expandAll", "true");
+    var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
+    var expected = cnBrowseResult(2, List.of(
+      cnBrowseItem(instance("instance #01"), "308 H977", true)
+    ));
+    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems("dewey", expected.getItems()));
+    assertThat(actual).isEqualTo(expected);
+
+    disableFeature(BROWSE_CN_INTERMEDIATE_VALUES);
+  }
+
+  private static Instance[] instances() {
+    return new Instance[] {
+      instances(callNumberBrowseInstanceData()),
+      instanceNew(additionalCallNumberBrowseInstanceData())
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Instance instances(List<List<String>> data) {
+    var item = data.stream().map(d -> new Item()
+        .id(randomId())
+        .tenantId(TENANT_ID)
+        .discoverySuppress(false)
+        .effectiveCallNumberComponents(new ItemEffectiveCallNumberComponents()
+          .callNumber(d.get(1))
+          .typeId(d.get(0)))
+        .effectiveShelvingOrder(getShelfKeyFromCallNumber(d.get(1))))
+      .toList();
+
+    return new Instance()
+      .id(randomId())
+      .title("instance #01")
+      .staffSuppress(false)
+      .discoverySuppress(false)
+      .isBoundWith(false)
+      .shared(false)
+      .tenantId(TENANT_ID)
+      .items(item)
+      .holdings(emptyList());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Instance instanceNew(List<List<String>> data) {
+    var item = data.stream().map(d -> new Item()
+        .id(randomId())
+        .tenantId(TENANT_ID)
+        .discoverySuppress(false)
+        .effectiveCallNumberComponents(new ItemEffectiveCallNumberComponents()
+          .callNumber(d.get(1))
+          .typeId(d.get(0)))
+        .effectiveShelvingOrder(getShelfKeyFromCallNumber(d.get(1))))
+      .toList();
+
+    return new Instance()
+      .id(randomId())
+      .title("instance #02")
+      .staffSuppress(false)
+      .discoverySuppress(false)
+      .isBoundWith(false)
+      .shared(false)
+      .tenantId(TENANT_ID)
+      .items(item)
+      .holdings(emptyList());
+  }
+
+  private static Instance instance(String title) {
+    return INSTANCE_MAP.get(title);
+  }
+
+  private static List<List<String>> callNumberBrowseInstanceData() {
+    return List.of(
+      List.of("95467209-6d7b-468b-94df-0f5d7ad2747d", "Z669.R360 1977"),
+      List.of("95467209-6d7b-468b-94df-0f5d7ad2747d", "Z669.R360 1975"),
+      List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H977")
+    );
+  }
+
+  private static List<List<String>> additionalCallNumberBrowseInstanceData() {
+    return List.of(
+      List.of("95467209-6d7b-468b-94df-0f5d7ad2747d", "Z669.R360 197")
+    );
+  }
+}


### PR DESCRIPTION
## Purpose
Fix irrelevant result on browsing call numbers by call number type

## Approach
Add filter for search result to eliminate irrelevant search results which came together with instance.

### Learning
(MSEARCH-557)[https://issues.folio.org/browse/MSEARCH-557]