### PR TITLE
MSEARCH-587: Use new refactored authority domain event

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -106,7 +106,7 @@ folio:
         group-id: ${folio.environment}-mod-search-events-group
       authorities:
         concurrency: ${KAFKA_AUTHORITIES_CONCURRENCY:1}
-        topic-pattern: ${KAFKA_AUTHORITIES_CONSUMER_PATTERN:(${folio.environment}\.)(.*\.)inventory\.authority}
+        topic-pattern: ${KAFKA_AUTHORITIES_CONSUMER_PATTERN:(${folio.environment}\.)(.*\.)authorities\.authority}
         group-id: ${folio.environment}-mod-search-authorities-group
       contributors:
         concurrency: ${KAFKA_CONTRIBUTORS_CONCURRENCY:2}

--- a/src/test/java/org/folio/search/utils/TestConstants.java
+++ b/src/test/java/org/folio/search/utils/TestConstants.java
@@ -24,7 +24,7 @@ public class TestConstants {
   public static final String RESOURCE_NAME = getResourceName(TestResource.class);
   public static final String INDEX_NAME = indexName(TENANT_ID);
 
-  public static final String AUTHORITY_TOPIC = "inventory.authority";
+  public static final String AUTHORITY_TOPIC = "authorities.authority";
   public static final String CONTRIBUTOR_TOPIC = "search.instance-contributor";
   public static final String INVENTORY_ITEM_TOPIC = "inventory.item";
   public static final String INVENTORY_INSTANCE_TOPIC = "inventory.instance";

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -86,7 +86,7 @@ folio:
       - name: inventory.bound-with
         numPartitions: 1
         replicationFactor: 1
-      - name: inventory.authority
+      - name: authorities.authority
         numPartitions: 1
         replicationFactor: 1
       - name: search.instance-contributor
@@ -105,7 +105,7 @@ folio:
         group-id: ${folio.environment}-mod-search-events-group
       authorities:
         concurrency: 1
-        topic-pattern: ${KAFKA_AUTHORITIES_CONSUMER_PATTERN:(${folio.environment}\.)(.*\.)inventory\.authority}
+        topic-pattern: ${KAFKA_AUTHORITIES_CONSUMER_PATTERN:(${folio.environment}\.)(.*\.)authorities\.authority}
         group-id: ${folio.environment}-mod-search-authorities-group
       contributors:
         concurrency: ${KAFKA_CONTRIBUTORS_CONCURRENCY:1}


### PR DESCRIPTION
## Purpose
_Replace the Authority Domain Event from inventory-storage with the one moved to mod-entity-links._

## Approach
_Rename the old Authority Domain Event_

### Learning
[_MSEARCH-587._](https://issues.folio.org/browse/MSEARCH-587)
