### PR TITLE
fix(consortium) Set default value for 'shared' field on subjects/constributors

### DIFF
--- a/src/main/resources/model/contributor.json
+++ b/src/main/resources/model/contributor.json
@@ -31,7 +31,8 @@
         },
         "shared": {
           "index": "bool",
-          "searchTypes": [ "filter" ]
+          "searchTypes": [ "filter" ],
+          "default": false
         }
       }
     },

--- a/src/main/resources/model/instance_subject.json
+++ b/src/main/resources/model/instance_subject.json
@@ -25,7 +25,8 @@
         },
         "shared": {
           "index": "bool",
-          "searchTypes": [ "filter" ]
+          "searchTypes": [ "filter" ],
+          "default": false
         }
       }
     }


### PR DESCRIPTION
## Purpose
Fix retrieving contributors without 'shared' flag
[MSEARCH-551](https://issues.folio.org/browse/MSEARCH-551)

## Approach
Set default 'shared' value to false for subjects/contributors

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

