### PR TITLE
feat(consortium): Restrict central tenant queries to only shared records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * Implement Active Affiliation Context for Search in Consortia Mode  ([MSEARCH-533](https://issues.folio.org/browse/MSEARCH-533))
 * Add tenantId/shared fields to contributors/subjects ([MSEARCH-551](https://issues.folio.org/browse/MSEARCH-551))
 * Implement Active Affiliation Context for stream IDs in Consortia Mode ([MSEARCH-576](https://issues.folio.org/browse/MSEARCH-576))
+* Restrict central tenant queries to only shared records ([MSEARCH-588](https://issues.folio.org/browse/MSEARCH-588))
 
 ### Bug fixes
 * Fix bug when number of titles response is greater than real ([MSEARCH-526](https://issues.folio.org/browse/MSEARCH-526))

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -37,6 +37,8 @@ public class SearchUtils {
   public static final String INSTANCE_ITEM_FIELD_NAME = "items";
   public static final String INSTANCE_HOLDING_FIELD_NAME = "holdings";
   public static final String INSTANCE_CONTRIBUTORS_FIELD_NAME = "contributors";
+  public static final String SHARED_FIELD_NAME = "shared";
+  public static final String TENANT_ID_FIELD_NAME = "tenantId";
   public static final String IS_BOUND_WITH_FIELD_NAME = "isBoundWith";
   public static final String CALL_NUMBER_BROWSING_FIELD = "callNumber";
   public static final String TYPED_CALL_NUMBER_BROWSING_FIELD = "typedCallNumber";

--- a/src/test/java/org/folio/search/cql/CqlSearchQueryConverterTest.java
+++ b/src/test/java/org/folio/search/cql/CqlSearchQueryConverterTest.java
@@ -65,6 +65,7 @@ class CqlSearchQueryConverterTest {
   private static final String[] TITLE_FIELDS = new String[] {"title.*", "source.*", "source"};
   private static final String TITLE_SEARCH_TYPE = "title";
   private static final String FIELD = "field";
+  private static final String SHARED_FIELD = "shared";
 
   @Autowired
   private CqlSearchQueryConverter cqlSearchQueryConverter;
@@ -364,7 +365,7 @@ class CqlSearchQueryConverterTest {
     assertThat(actual).isEqualTo(searchSource().query(boolQuery()
       .filter(termQuery("f1", "value"))
       .should(termQuery("tenantId", TENANT_ID))
-      .should(termQuery("shared", true))
+      .should(termQuery(SHARED_FIELD, true))
       .minimumShouldMatch(1)));
   }
 
@@ -376,7 +377,10 @@ class CqlSearchQueryConverterTest {
     var cqlQuery = "f1==value";
     var actual = cqlSearchQueryConverter.convertForConsortia(cqlQuery, RESOURCE_NAME);
     assertThat(actual).isEqualTo(searchSource().query(
-      boolQuery().filter(termQuery("f1", "value"))));
+      boolQuery()
+        .filter(termQuery("f1", "value"))
+        .should(termQuery(SHARED_FIELD, true))
+        .minimumShouldMatch(1)));
   }
 
   @Test
@@ -388,7 +392,7 @@ class CqlSearchQueryConverterTest {
     assertThat(actual).isEqualTo(searchSource().query(
       boolQuery()
         .should(termQuery("tenantId", TENANT_ID))
-        .should(termQuery("shared", true))
+        .should(termQuery(SHARED_FIELD, true))
         .minimumShouldMatch(1)));
   }
 
@@ -404,7 +408,7 @@ class CqlSearchQueryConverterTest {
         .should(termQuery("f2", "v2"))
         .must(boolQuery()
           .should(termQuery("tenantId", TENANT_ID))
-          .should(termQuery("shared", true)))
+          .should(termQuery(SHARED_FIELD, true)))
         .minimumShouldMatch(1)
     ));
   }


### PR DESCRIPTION
## Purpose
Restrict Central tenant search and browse results to ONLY Shared records

## Approach
Restrict central tenant queries to only shared records

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.


### Learning
https://issues.folio.org/browse/MSEARCH-588