### PR TITLE
feat(consortium): Implement active affiliation context for browse

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 * Add tenantId/shared fields to contributors/subjects ([MSEARCH-551](https://issues.folio.org/browse/MSEARCH-551))
 * Implement Active Affiliation Context for stream IDs in Consortia Mode ([MSEARCH-576](https://issues.folio.org/browse/MSEARCH-576))
 * Restrict central tenant queries to only shared records ([MSEARCH-588](https://issues.folio.org/browse/MSEARCH-588))
+* Implement Active Affiliation Context for browsing ([MSEARCH-580](https://issues.folio.org/browse/MSEARCH-580))
 
 ### Bug fixes
 * Fix bug when number of titles response is greater than real ([MSEARCH-526](https://issues.folio.org/browse/MSEARCH-526))

--- a/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
@@ -3,8 +3,6 @@ package org.folio.search.cql;
 import static org.folio.search.utils.SearchQueryUtils.isBoolQuery;
 import static org.folio.search.utils.SearchQueryUtils.isDisjunctionFilterQuery;
 import static org.folio.search.utils.SearchQueryUtils.isFilterQuery;
-import static org.folio.search.utils.SearchUtils.SHARED_FIELD_NAME;
-import static org.folio.search.utils.SearchUtils.TENANT_ID_FIELD_NAME;
 import static org.opensearch.index.query.QueryBuilders.boolQuery;
 
 import java.util.ArrayList;
@@ -60,9 +58,6 @@ public class CqlSearchQueryConverter {
     var enhancedQuery = enhanceQuery(boolQuery, resource);
     return queryBuilder.query(enhancedQuery);
   }
-
-  //todo(MSEARCH-576): may be reworked after implemented for browse/streamIds.
-  // Implemented separately because it crashes 'browse/streamIds' functionality.
 
   /**
    * Converts given CQL search query value to the elasticsearch {@link SearchSourceBuilder} object.
@@ -149,61 +144,6 @@ public class CqlSearchQueryConverter {
     conditions.add(leftOperandQuery);
     conditions.add(rightOperandQuery);
     return boolQuery;
-  }
-
-  private QueryBuilder filterForActiveAffiliation(QueryBuilder query) {
-    var contextTenantId = folioExecutionContext.getTenantId();
-    var centralTenantId = consortiumTenantService.getCentralTenant(contextTenantId);
-    if (centralTenantId.isEmpty()) {
-      return query;
-    }
-
-    var boolQuery = prepareBoolQueryForActiveAffiliation(query);
-    addActiveAffiliationClauses(boolQuery, contextTenantId, centralTenantId.get());
-
-    return boolQuery;
-  }
-
-  private BoolQueryBuilder prepareBoolQueryForActiveAffiliation(QueryBuilder query) {
-    BoolQueryBuilder boolQuery;
-    if (query instanceof MatchAllQueryBuilder) {
-      boolQuery = boolQuery();
-    } else if (query instanceof BoolQueryBuilder bq) {
-      boolQuery = bq;
-    } else {
-      boolQuery = boolQuery().must(query);
-    }
-    boolQuery.minimumShouldMatch(1);
-    return boolQuery;
-  }
-
-  private void addActiveAffiliationClauses(BoolQueryBuilder boolQuery, String contextTenantId, String centralTenantId) {
-    var affiliationShouldClauses = getAffiliationShouldClauses(contextTenantId, centralTenantId);
-    if (boolQuery.should().isEmpty()) {
-      affiliationShouldClauses.forEach(boolQuery::should);
-    } else {
-      var innerBoolQuery = boolQuery();
-      affiliationShouldClauses.forEach(innerBoolQuery::should);
-      boolQuery.must(innerBoolQuery);
-    }
-  }
-
-  private LinkedList<QueryBuilder> getAffiliationShouldClauses(String contextTenantId, String centralTenantId) {
-    var affiliationShouldClauses = new LinkedList<QueryBuilder>();
-    addTenantIdAffiliationShouldClause(contextTenantId, centralTenantId, affiliationShouldClauses);
-    addSharedAffiliationShouldClause(affiliationShouldClauses);
-    return affiliationShouldClauses;
-  }
-
-  private void addTenantIdAffiliationShouldClause(String contextTenantId, String centralTenantId,
-                                                  LinkedList<QueryBuilder> affiliationShouldClauses) {
-    if (!contextTenantId.equals(centralTenantId)) {
-      affiliationShouldClauses.add(termQuery(TENANT_ID_FIELD_NAME, contextTenantId));
-    }
-  }
-
-  private void addSharedAffiliationShouldClause(LinkedList<QueryBuilder> affiliationShouldClauses) {
-    affiliationShouldClauses.add(termQuery(SHARED_FIELD_NAME, true));
   }
 
   private QueryBuilder enhanceQuery(QueryBuilder query, String resource) {

--- a/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlSearchQueryConverter.java
@@ -4,20 +4,16 @@ import static org.folio.search.utils.SearchQueryUtils.isBoolQuery;
 import static org.folio.search.utils.SearchQueryUtils.isDisjunctionFilterQuery;
 import static org.folio.search.utils.SearchQueryUtils.isFilterQuery;
 import static org.opensearch.index.query.QueryBuilders.boolQuery;
-import static org.opensearch.index.query.QueryBuilders.termQuery;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
 import org.folio.search.model.types.SearchType;
-import org.folio.search.service.consortium.ConsortiumTenantService;
+import org.folio.search.service.consortium.ConsortiumSearchHelper;
 import org.folio.search.service.metadata.SearchFieldProvider;
-import org.folio.spring.FolioExecutionContext;
 import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.springframework.stereotype.Component;
@@ -41,8 +37,7 @@ public class CqlSearchQueryConverter {
   private final CqlSortProvider cqlSortProvider;
   private final SearchFieldProvider searchFieldProvider;
   private final CqlTermQueryConverter cqlTermQueryConverter;
-  private final FolioExecutionContext folioExecutionContext;
-  private final ConsortiumTenantService consortiumTenantService;
+  private final ConsortiumSearchHelper consortiumSearchHelper;
 
   /**
    * Converts given CQL search query value to the elasticsearch {@link SearchSourceBuilder} object.
@@ -76,7 +71,7 @@ public class CqlSearchQueryConverter {
    */
   public SearchSourceBuilder convertForConsortia(String query, String resource) {
     var sourceBuilder = convert(query, resource);
-    var queryBuilder = filterForActiveAffiliation(sourceBuilder.query());
+    var queryBuilder = consortiumSearchHelper.filterQueryForActiveAffiliation(sourceBuilder.query());
 
     return sourceBuilder.query(queryBuilder);
   }
@@ -150,38 +145,6 @@ public class CqlSearchQueryConverter {
     var conditions = conditionProvider.apply(boolQuery);
     conditions.add(leftOperandQuery);
     conditions.add(rightOperandQuery);
-    return boolQuery;
-  }
-
-  private QueryBuilder filterForActiveAffiliation(QueryBuilder query) {
-    var contextTenantId = folioExecutionContext.getTenantId();
-    var centralTenantId = consortiumTenantService.getCentralTenant(contextTenantId);
-    if (centralTenantId.isEmpty() || contextTenantId.equals(centralTenantId.get())) {
-      return query;
-    }
-
-    var affiliationShouldClauses = new LinkedList<QueryBuilder>();
-    affiliationShouldClauses.add(termQuery("tenantId", contextTenantId));
-    affiliationShouldClauses.add(termQuery("shared", true));
-
-    BoolQueryBuilder boolQuery;
-    if (query instanceof MatchAllQueryBuilder) {
-      boolQuery = boolQuery();
-    } else if (query instanceof BoolQueryBuilder bq) {
-      boolQuery = bq;
-    } else {
-      boolQuery = boolQuery().must(query);
-    }
-    boolQuery.minimumShouldMatch(1);
-
-    if (boolQuery.should().isEmpty()) {
-      affiliationShouldClauses.forEach(boolQuery::should);
-    } else {
-      var innerBoolQuery = boolQuery();
-      affiliationShouldClauses.forEach(innerBoolQuery::should);
-      boolQuery.must(innerBoolQuery);
-    }
-
     return boolQuery;
   }
 

--- a/src/main/java/org/folio/search/model/index/SubjectResource.java
+++ b/src/main/java/org/folio/search/model/index/SubjectResource.java
@@ -1,9 +1,15 @@
 package org.folio.search.model.index;
 
 import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SubjectResource {
 
   private String id;

--- a/src/main/java/org/folio/search/service/browse/BrowseContextProvider.java
+++ b/src/main/java/org/folio/search/service/browse/BrowseContextProvider.java
@@ -38,7 +38,6 @@ public class BrowseContextProvider {
   public BrowseContext get(BrowseRequest request) {
     log.debug("get:: by [query: {}, resource: {}]", request.getQuery(), request.getResource());
 
-    // todo(MSEARCH-580): use 'convertForConsortia' or/and check todo item for 'convertForConsortia'
     var searchSource = cqlSearchQueryConverter.convert(request.getQuery(), request.getResource());
     var cqlQuery = request.getQuery();
     if (isNotEmpty(searchSource.sorts())) {

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseQueryProvider.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseQueryProvider.java
@@ -20,6 +20,7 @@ import org.folio.search.configuration.properties.SearchQueryConfigurationPropert
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.model.service.BrowseRequest;
 import org.folio.search.model.types.CallNumberType;
+import org.folio.search.service.consortium.ConsortiumSearchHelper;
 import org.folio.search.service.metadata.SearchFieldProvider;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.script.Script;
@@ -38,6 +39,7 @@ public class CallNumberBrowseQueryProvider {
   private final SearchFieldProvider searchFieldProvider;
   private final SearchQueryConfigurationProperties queryConfiguration;
   private final CallNumberBrowseRangeService callNumberBrowseRangeService;
+  private final ConsortiumSearchHelper consortiumSearchHelper;
 
   /**
    * Creates query as {@link SearchSourceBuilder} object for call number browsing.
@@ -56,8 +58,10 @@ public class CallNumberBrowseQueryProvider {
 
     var multiplier = queryConfiguration.getRangeQueryLimitMultiplier();
     var pageSize = (int) Math.max(MIN_QUERY_SIZE, Math.ceil(ctx.getLimit(isBrowsingForward) * multiplier));
+    var initialQuery = getQuery(ctx, request, pageSize, isBrowsingForward);
+    var query = consortiumSearchHelper.filterQueryForActiveAffiliation(initialQuery);
     var searchSource = searchSource().from(0).size(pageSize)
-      .query(getQuery(ctx, request, pageSize, isBrowsingForward))
+      .query(query)
       .sort(scriptSort(script, STRING).order(isBrowsingForward ? ASC : DESC));
 
     if (isFalse(request.getExpandAll())) {

--- a/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
@@ -17,8 +17,10 @@ import org.folio.search.model.SearchResult;
 import org.folio.search.model.index.SubjectResource;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.model.service.BrowseRequest;
+import org.folio.search.service.consortium.ConsortiumSearchHelper;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Log4j2
@@ -26,10 +28,19 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SubjectBrowseService extends AbstractBrowseServiceBySearchAfter<SubjectBrowseItem, SubjectResource> {
 
+  private ConsortiumSearchHelper consortiumSearchHelper;
+
+  @Autowired
+  public void setConsortiumSearchHelper(ConsortiumSearchHelper consortiumSearchHelper) {
+    this.consortiumSearchHelper = consortiumSearchHelper;
+  }
+
   @Override
   protected SearchSourceBuilder getAnchorSearchQuery(BrowseRequest request, BrowseContext context) {
     log.debug("getAnchorSearchQuery:: by [request: {}]", request);
-    return searchSource().query(termQuery(request.getTargetField(), context.getAnchor()))
+    var query = consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(context,
+      termQuery(request.getTargetField(), context.getAnchor()));
+    return searchSource().query(query)
       .size(context.getLimit(context.isBrowsingForward()))
       .from(0);
   }
@@ -45,6 +56,7 @@ public class SubjectBrowseService extends AbstractBrowseServiceBySearchAfter<Sub
       ctx.getFilters().forEach(boolQuery::filter);
       query = boolQuery;
     }
+    query = consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(ctx, query);
     return searchSource().query(query)
       .searchAfter(new Object[] {ctx.getAnchor().toLowerCase(ROOT)})
       .sort(fieldSort(req.getTargetField()).order(isBrowsingForward ? ASC : DESC))
@@ -65,7 +77,8 @@ public class SubjectBrowseService extends AbstractBrowseServiceBySearchAfter<Sub
         .value(subjectResource.getValue())
         .authorityId(subjectResource.getAuthorityId())
         .isAnchor(isAnchor ? true : null)
-        .totalRecords(filterSubResourcesForConsortium(context, subjectResource, SubjectResource::getInstances).size()));
+        .totalRecords(consortiumSearchHelper.filterSubResourcesForConsortium(
+          context, subjectResource, SubjectResource::getInstances).size()));
   }
 
   @Override

--- a/src/main/java/org/folio/search/service/consortium/ConsortiumSearchHelper.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumSearchHelper.java
@@ -1,0 +1,149 @@
+package org.folio.search.service.consortium;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.opensearch.index.query.QueryBuilders.boolQuery;
+import static org.opensearch.index.query.QueryBuilders.termQuery;
+
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.folio.search.model.index.InstanceSubResource;
+import org.folio.search.model.service.BrowseContext;
+import org.folio.spring.FolioExecutionContext;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ConsortiumSearchHelper {
+
+  private static final String BROWSE_SHARED_FILTER_KEY = "instances.shared";
+
+  private final FolioExecutionContext folioExecutionContext;
+  private final ConsortiumTenantService consortiumTenantService;
+
+  public QueryBuilder filterQueryForActiveAffiliation(QueryBuilder query) {
+    var contextTenantId = folioExecutionContext.getTenantId();
+    var centralTenantId = consortiumTenantService.getCentralTenant(contextTenantId);
+    if (centralTenantId.isEmpty() || contextTenantId.equals(centralTenantId.get())) {
+      return query;
+    }
+
+    return filterQueryForActiveAffiliation(query, contextTenantId);
+  }
+
+  public QueryBuilder filterQueryForActiveAffiliation(QueryBuilder query, String tenantId) {
+    return filterQueryForActiveAffiliation(EMPTY, query, tenantId);
+  }
+
+  public QueryBuilder filterQueryForActiveAffiliation(String subResourcePrefix, QueryBuilder query, String tenantId) {
+
+    var affiliationShouldClauses = new LinkedList<QueryBuilder>();
+    affiliationShouldClauses.add(termQuery(subResourcePrefix + "tenantId", tenantId));
+    affiliationShouldClauses.add(termQuery(subResourcePrefix + "shared", true));
+
+    var boolQuery = getBoolQuery(query);
+    boolQuery.minimumShouldMatch(1);
+
+    if (boolQuery.should().isEmpty()) {
+      affiliationShouldClauses.forEach(boolQuery::should);
+    } else {
+      var innerBoolQuery = boolQuery();
+      affiliationShouldClauses.forEach(innerBoolQuery::should);
+      boolQuery.must(innerBoolQuery);
+    }
+
+    return boolQuery;
+  }
+
+  /**
+   * Modifies query to support both 'instances.shared' filter and Active Affiliation.
+   * 'instances.shared' filter have precedence over Active Affiliation so in case of 'false' value - only local records
+   * will be returned (original query have only 'tenantId' additional filter).
+  * */
+  public QueryBuilder filterBrowseQueryForActiveAffiliation(BrowseContext browseContext, QueryBuilder query) {
+    var contextTenantId = folioExecutionContext.getTenantId();
+    var centralTenantId = consortiumTenantService.getCentralTenant(contextTenantId);
+    var sharedFilter = getBrowseSharedFilter(browseContext);
+    if (centralTenantId.isEmpty() || contextTenantId.equals(centralTenantId.get())) {
+      sharedFilter.ifPresent(filter -> browseContext.getFilters().remove(filter));
+      return query;
+    }
+
+    removeOriginalSharedFilterFromQuery(query);
+
+    var shared = sharedFilter.map(this::sharedFilterValue).orElse(true);
+    if (Boolean.TRUE.equals(shared)) {
+      return filterQueryForActiveAffiliation("instances.", query, contextTenantId);
+    }
+
+    var boolQuery = getBoolQuery(query);
+    if (!boolQuery.should().isEmpty()) {
+      boolQuery.minimumShouldMatch(1);
+    }
+    boolQuery.must(termQuery("instances.tenantId", contextTenantId));
+
+    return boolQuery;
+  }
+
+  private void removeOriginalSharedFilterFromQuery(QueryBuilder queryBuilder) {
+    if (queryBuilder instanceof BoolQueryBuilder bqb) {
+      bqb.filter().removeIf(filter -> filter instanceof TermQueryBuilder tqb
+        && tqb.fieldName().equals(BROWSE_SHARED_FILTER_KEY));
+    }
+  }
+
+  private BoolQueryBuilder getBoolQuery(QueryBuilder query) {
+    if (query instanceof MatchAllQueryBuilder) {
+      return boolQuery();
+    } else if (query instanceof BoolQueryBuilder bq) {
+      return bq;
+    } else {
+      return boolQuery().must(query);
+    }
+  }
+
+  public <T> Set<InstanceSubResource> filterSubResourcesForConsortium(
+    BrowseContext context, T resource,
+    Function<T, Set<InstanceSubResource>> subResourceExtractor) {
+
+    var subResources = subResourceExtractor.apply(resource);
+    var contextTenantId = folioExecutionContext.getTenantId();
+    var centralTenantId = consortiumTenantService.getCentralTenant(contextTenantId);
+    if (centralTenantId.isEmpty() || contextTenantId.equals(centralTenantId.get())) {
+      return subResources;
+    }
+
+    var sharedFilter = getBrowseSharedFilter(context);
+    Predicate<InstanceSubResource> subResourcesFilter =
+      sharedFilter.isPresent() && !sharedFilterValue(sharedFilter.get())
+        ? subResource -> subResource.getTenantId().equals(contextTenantId)
+        : subResource -> subResource.getTenantId().equals(contextTenantId) || subResource.getShared();
+    return subResources.stream()
+      .filter(subResourcesFilter)
+      .collect(Collectors.toSet());
+  }
+
+  private Optional<TermQueryBuilder> getBrowseSharedFilter(BrowseContext context) {
+    return context.getFilters().stream()
+      .map(filter ->
+        filter instanceof TermQueryBuilder termFilter && termFilter.fieldName().equals(BROWSE_SHARED_FILTER_KEY)
+          ? termFilter
+          : null)
+      .filter(Objects::nonNull)
+      .findFirst();
+  }
+
+  private boolean sharedFilterValue(TermQueryBuilder sharedQuery) {
+    return sharedQuery.value() instanceof Boolean boolValue && boolValue
+      || sharedQuery.value() instanceof String stringValue && Boolean.parseBoolean(stringValue);
+  }
+}

--- a/src/test/java/org/folio/search/controller/BrowseContributorConsortiumIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorConsortiumIT.java
@@ -146,19 +146,37 @@ class BrowseContributorConsortiumIT extends BaseIntegrationTest {
   }
 
   @Test
-  void browseByContributor_withNameAndConsortiumInstanceFilter() {
+  void browseByContributor_shared() {
     var request = get(instanceContributorBrowsePath()).param("query",
       "(" + prepareQuery("name >= {value} or name < {value}", '"' + "Bon Jovi" + '"') + ") "
         + "and instances.shared==true").param("limit", "5");
 
     var actual = parseResponse(doGet(request), InstanceContributorBrowseResult.class);
-    var expected = new InstanceContributorBrowseResult().totalRecords(5).prev(null).next(null).items(
+    var expected = new InstanceContributorBrowseResult().totalRecords(12).prev(null).next("George Harrison").items(
       List.of(
         contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0]),
         contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[2]),
+        contributorBrowseItem(2, true, "Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0],
+          TYPE_IDS[0], TYPE_IDS[1], TYPE_IDS[2]),
         contributorBrowseItem(1, true, "Bon Jovi", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[0]),
-        contributorBrowseItem(1, true, "Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0]),
-        contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1])));
+        contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], TYPE_IDS[2])));
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void browseByContributor_local() {
+    var request = get(instanceContributorBrowsePath()).param("query",
+      "(" + prepareQuery("name >= {value} or name < {value}", '"' + "Bon Jovi" + '"') + ") "
+        + "and instances.shared==false").param("limit", "5");
+
+    var actual = parseResponse(doGet(request), InstanceContributorBrowseResult.class);
+    var expected = new InstanceContributorBrowseResult().totalRecords(8).prev(null).next("John Lennon").items(
+      List.of(
+        contributorBrowseItem(1, true, "Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0],
+          TYPE_IDS[1], TYPE_IDS[2]),
+        contributorBrowseItem(2, "George Harrison", NAME_TYPE_IDS[1], AUTHORITY_IDS[0], TYPE_IDS[2]),
+        contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], AUTHORITY_IDS[1], TYPE_IDS[0])));
 
     assertThat(actual).isEqualTo(expected);
   }

--- a/src/test/java/org/folio/search/controller/BrowseSubjectConsortiumIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseSubjectConsortiumIT.java
@@ -117,7 +117,7 @@ class BrowseSubjectConsortiumIT extends BaseIntegrationTest {
   }
 
   @Test
-  void browseBySubject_browsingAroundWithConsortiumInstanceFilter() {
+  void browseBySubject_browsingAround_shared() {
     var request = get(instanceSubjectBrowsePath())
       .param("query", "("
         + prepareQuery("value < {value} or value >= {value}", "\"Rules\"") + ") "
@@ -126,13 +126,32 @@ class BrowseSubjectConsortiumIT extends BaseIntegrationTest {
       .param("precedingRecordsCount", "2");
     var actual = parseResponse(doGet(request), SubjectBrowseResult.class);
     assertThat(actual).isEqualTo(new SubjectBrowseResult()
-      .totalRecords(10).prev("Music")
+      .totalRecords(23).prev("Philosophy").next("Science--Methodology")
       .items(List.of(
-        subjectBrowseItem(1, "Music", MUSIC_AUTHORITY_ID_2),
-        subjectBrowseItem(2, "Music", MUSIC_AUTHORITY_ID_1),
+        subjectBrowseItem(1, "Philosophy"),
+        subjectBrowseItem(1, "Religion"),
         subjectBrowseItem(1, "Rules", true),
-        subjectBrowseItem(1, "Text"),
-        subjectBrowseItem(1, "United States"))));
+        subjectBrowseItem(1, "Science"),
+        subjectBrowseItem(1, "Science--Methodology"))));
+  }
+
+  @Test
+  void browseBySubject_browsingAround_local() {
+    var request = get(instanceSubjectBrowsePath())
+      .param("query", "("
+        + prepareQuery("value < {value} or value >= {value}", "\"Science\"") + ") "
+        + "and instances.shared==false")
+      .param("limit", "5")
+      .param("precedingRecordsCount", "2");
+    var actual = parseResponse(doGet(request), SubjectBrowseResult.class);
+    assertThat(actual).isEqualTo(new SubjectBrowseResult()
+      .totalRecords(15).prev("Philosophy").next("Science--Philosophy")
+      .items(List.of(
+        subjectBrowseItem(1, "Philosophy"),
+        subjectBrowseItem(1, "Religion"),
+        subjectBrowseItem(1, "Science", true),
+        subjectBrowseItem(1, "Science--Methodology"),
+        subjectBrowseItem(1, "Science--Philosophy"))));
   }
 
   //todo: move 4 methods below to consortium integration test base in a scope of MSEARCH-562

--- a/src/test/java/org/folio/search/service/browse/ContributorBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/ContributorBrowseServiceTest.java
@@ -2,6 +2,11 @@ package org.folio.search.service.browse;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.opensearch.index.query.QueryBuilders.disMaxQuery;
+import static org.opensearch.index.query.QueryBuilders.rangeQuery;
 import static org.opensearch.index.query.QueryBuilders.termQuery;
 
 import java.util.List;
@@ -11,40 +16,26 @@ import org.folio.search.model.SearchResult;
 import org.folio.search.model.index.ContributorResource;
 import org.folio.search.model.index.InstanceSubResource;
 import org.folio.search.model.service.BrowseContext;
+import org.folio.search.model.service.BrowseRequest;
+import org.folio.search.service.consortium.ConsortiumSearchHelper;
 import org.folio.spring.test.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
 class ContributorBrowseServiceTest {
 
-  private final ContributorBrowseService service = new ContributorBrowseService();
+  @Mock
+  private ConsortiumSearchHelper consortiumSearchHelper;
 
-  @Test
-  void mapToBrowseResult_positive_withConsortiumFilter() {
-    var contributors = contributors();
-    var searchResult = new SearchResult<ContributorResource>();
-    searchResult.setTotalRecords(1);
-    searchResult.setRecords(contributors);
-    var browseContext = BrowseContext.builder()
-      .filters(singletonList(termQuery("instances.shared", false)))
-      .build();
-
-    var expected = new InstanceContributorBrowseItem()
-      .isAnchor(false)
-      .contributorTypeId(List.of("type1", "type2"))
-      .name("name")
-      .contributorNameTypeId("nameType")
-      .authorityId("auth")
-      .totalRecords(1);
-
-    var browseResult = service.mapToBrowseResult(browseContext, searchResult, false);
-
-    assertThat(browseResult.getRecords().get(0))
-      .isEqualTo(expected);
-  }
+  @InjectMocks
+  private ContributorBrowseService service;
 
   @Test
   void mapToBrowseResult_positive() {
@@ -52,7 +43,17 @@ class ContributorBrowseServiceTest {
     var searchResult = new SearchResult<ContributorResource>();
     searchResult.setTotalRecords(1);
     searchResult.setRecords(contributors);
-    var browseContext = BrowseContext.builder().build();
+    var browseContext = BrowseContext.builder()
+      .filters(singletonList(termQuery("instances.shared", false)))
+      .build();
+    var instanceId1 = "ins1";
+    var instanceId2 = "ins2";
+    var contributorsSubResourcesMock = Set.of(
+      contributorSubResource(instanceId1, "type1"),
+      contributorSubResource(instanceId1, "type2"),
+      contributorSubResource(instanceId2, "type1"),
+      contributorSubResource(instanceId2, null),
+      contributorSubResource(instanceId1, "null"));
 
     var expected = new InstanceContributorBrowseItem()
       .isAnchor(false)
@@ -62,10 +63,43 @@ class ContributorBrowseServiceTest {
       .authorityId("auth")
       .totalRecords(2);
 
+    when(consortiumSearchHelper.filterSubResourcesForConsortium(any(), any(), any()))
+      .thenReturn(contributorsSubResourcesMock);
+
     var browseResult = service.mapToBrowseResult(browseContext, searchResult, false);
 
     assertThat(browseResult.getRecords().get(0))
       .isEqualTo(expected);
+  }
+
+  @ValueSource(booleans = {true, false})
+  @ParameterizedTest
+  void getSearchQuery_positive(Boolean isBrowsingForward) {
+    var browseRequest = BrowseRequest.builder().targetField("test").build();
+    var browseContext = BrowseContext.builder().anchor("test").succeedingLimit(1).precedingLimit(1).build();
+    var queryMock = disMaxQuery();
+
+    when(consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(eq(browseContext), any()))
+      .thenReturn(queryMock);
+
+    var result = service.getSearchQuery(browseRequest, browseContext, isBrowsingForward);
+
+    assertThat(result.query()).isEqualTo(queryMock);
+  }
+
+  @Test
+  void getAnchorSearchQuery_positive() {
+    var browseRequest = BrowseRequest.builder().targetField("test").build();
+    var browseContext = BrowseContext.builder()
+      .anchor("test").succeedingQuery(rangeQuery("test")).succeedingLimit(1).build();
+    var queryMock = disMaxQuery();
+
+    when(consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(eq(browseContext), any()))
+      .thenReturn(queryMock);
+
+    var result = service.getAnchorSearchQuery(browseRequest, browseContext);
+
+    assertThat(result.query()).isEqualTo(queryMock);
   }
 
   private List<ContributorResource> contributors() {
@@ -86,6 +120,13 @@ class ContributorBrowseServiceTest {
       .typeId(typeId)
       .shared(shared)
       .tenantId(tenantId)
+      .build();
+  }
+
+  private InstanceSubResource contributorSubResource(String instanceId, String typeId) {
+    return InstanceSubResource.builder()
+      .instanceId(instanceId)
+      .typeId(typeId)
       .build();
   }
 }

--- a/src/test/java/org/folio/search/service/browse/SubjectBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/SubjectBrowseServiceTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.searchResult;
 import static org.folio.search.utils.TestUtils.subjectBrowseItem;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
@@ -26,9 +29,11 @@ import org.folio.search.model.index.SubjectResource;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.model.service.BrowseRequest;
 import org.folio.search.repository.SearchRepository;
+import org.folio.search.service.consortium.ConsortiumSearchHelper;
 import org.folio.search.service.converter.ElasticsearchDocumentConverter;
 import org.folio.search.service.setter.SearchResponsePostProcessor;
 import org.folio.spring.test.type.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -58,9 +63,19 @@ class SubjectBrowseServiceTest {
   @Mock
   private ElasticsearchDocumentConverter documentConverter;
   @Mock
+  private ConsortiumSearchHelper consortiumSearchHelper;
+  @Mock
   private SearchResponse searchResponse;
   @Mock
   private Map<Class<?>, SearchResponsePostProcessor<?>> searchResponsePostProcessors = Collections.emptyMap();
+
+  @BeforeEach
+  public void setUpMocks() {
+    doAnswer(invocation -> invocation.getArgument(1))
+      .when(consortiumSearchHelper).filterBrowseQueryForActiveAffiliation(any(), any());
+    lenient().doAnswer(invocation -> ((SubjectResource) invocation.getArgument(1)).getInstances())
+      .when(consortiumSearchHelper).filterSubResourcesForConsortium(any(), any(), any());
+  }
 
   @Test
   void browse_positive_forward() {

--- a/src/test/java/org/folio/search/service/consortium/ConsortiumSearchHelperTest.java
+++ b/src/test/java/org/folio/search/service/consortium/ConsortiumSearchHelperTest.java
@@ -57,21 +57,34 @@ class ConsortiumSearchHelperTest {
 
     consortiumSearchHelper.filterQueryForActiveAffiliation(query);
 
-    verify(consortiumSearchHelper).filterQueryForActiveAffiliation(query, TENANT_ID);
+    verify(consortiumSearchHelper).filterQueryForActiveAffiliation(query, TENANT_ID, CONSORTIUM_TENANT_ID);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = TENANT_ID)
-  @NullSource
-  void filterQueryForActiveAffiliation_positive_basicNotConsortiumMemberTenant(String centralTenantId) {
+  @Test
+  void filterQueryForActiveAffiliation_positive_basicNotConsortiumTenant() {
     var query = matchAllQuery();
     when(context.getTenantId()).thenReturn(TENANT_ID);
-    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.ofNullable(centralTenantId));
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.empty());
 
     var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(query);
 
     assertThat(actual).isEqualTo(query);
-    verify(consortiumSearchHelper, times(0)).filterQueryForActiveAffiliation(any(), any());
+    verify(consortiumSearchHelper, times(0)).filterQueryForActiveAffiliation(any(), any(), any());
+  }
+
+  @Test
+  void filterQueryForActiveAffiliation_positive_basicConsortiumCentralTenant() {
+    var query = matchAllQuery();
+    var expected = boolQuery()
+      .minimumShouldMatch(1)
+      .should(termQuery("shared", true));
+
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.of(TENANT_ID));
+
+    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(query);
+
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -82,10 +95,10 @@ class ConsortiumSearchHelperTest {
       .should(termQuery("tenantId", TENANT_ID))
       .should(termQuery("shared", true));
 
-    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(query, TENANT_ID);
+    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(query, TENANT_ID, CONSORTIUM_TENANT_ID);
 
     assertThat(actual).isEqualTo(expected);
-    verify(consortiumSearchHelper).filterQueryForActiveAffiliation(EMPTY, query, TENANT_ID);
+    verify(consortiumSearchHelper).filterQueryForActiveAffiliation(EMPTY, query, TENANT_ID, CONSORTIUM_TENANT_ID);
   }
 
   @Test
@@ -96,7 +109,8 @@ class ConsortiumSearchHelperTest {
       .should(termQuery(TENANT_ID_FIELD, TENANT_ID))
       .should(termQuery(SHARED_FIELD, true));
 
-    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(SUBRESOURCE_PREFIX, query, TENANT_ID);
+    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(SUBRESOURCE_PREFIX, query, TENANT_ID,
+      CONSORTIUM_TENANT_ID);
 
     assertThat(actual).isEqualTo(expected);
   }
@@ -109,7 +123,8 @@ class ConsortiumSearchHelperTest {
       .should(termQuery(TENANT_ID_FIELD, TENANT_ID))
       .should(termQuery(SHARED_FIELD, true));
 
-    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(SUBRESOURCE_PREFIX, query, TENANT_ID);
+    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(SUBRESOURCE_PREFIX, query, TENANT_ID,
+      CONSORTIUM_TENANT_ID);
 
     assertThat(actual).isEqualTo(expected);
   }
@@ -124,7 +139,8 @@ class ConsortiumSearchHelperTest {
         .should(termQuery(TENANT_ID_FIELD, TENANT_ID))
         .should(termQuery(SHARED_FIELD, true)));
 
-    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(SUBRESOURCE_PREFIX, query, TENANT_ID);
+    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(SUBRESOURCE_PREFIX, query, TENANT_ID,
+      CONSORTIUM_TENANT_ID);
 
     assertThat(actual).isEqualTo(expected);
   }
@@ -138,25 +154,39 @@ class ConsortiumSearchHelperTest {
       .should(termQuery(TENANT_ID_FIELD, TENANT_ID))
       .should(termQuery(SHARED_FIELD, true));
 
-    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(SUBRESOURCE_PREFIX, query, TENANT_ID);
+    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(SUBRESOURCE_PREFIX, query, TENANT_ID,
+      CONSORTIUM_TENANT_ID);
 
     assertThat(actual).isEqualTo(expected);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = TENANT_ID)
-  @NullSource
-  void filterBrowseQueryForActiveAffiliation_positive_notConsortiumMemberTenant(String centralTenantId) {
+  @Test
+  void filterBrowseQueryForActiveAffiliation_positive_notConsortiumTenant() {
     var browseContext = browseContext(false);
     var query = matchAllQuery();
 
     when(context.getTenantId()).thenReturn(TENANT_ID);
-    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.ofNullable(centralTenantId));
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.empty());
 
     var actual = consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(browseContext, query);
 
     assertThat(actual).isEqualTo(query);
     assertThat(browseContext.getFilters()).isEmpty();
+  }
+
+  @Test
+  void filterBrowseQueryForActiveAffiliation_positive_consortiumCentralTenant() {
+    var browseContext = browseContext(false);
+    var query = matchAllQuery();
+    var expected = boolQuery()
+      .must(termQuery(TENANT_ID_FIELD, TENANT_ID));
+
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.ofNullable(TENANT_ID));
+
+    var actual = consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(browseContext, query);
+
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -169,7 +199,8 @@ class ConsortiumSearchHelperTest {
 
     consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(browseContext, query);
 
-    verify(consortiumSearchHelper).filterQueryForActiveAffiliation("instances.", query, TENANT_ID);
+    verify(consortiumSearchHelper).filterQueryForActiveAffiliation("instances.", query, TENANT_ID,
+      CONSORTIUM_TENANT_ID);
   }
 
   @Test

--- a/src/test/java/org/folio/search/service/consortium/ConsortiumSearchHelperTest.java
+++ b/src/test/java/org/folio/search/service/consortium/ConsortiumSearchHelperTest.java
@@ -1,0 +1,283 @@
+package org.folio.search.service.consortium;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.TestConstants.CONSORTIUM_TENANT_ID;
+import static org.folio.search.utils.TestConstants.TENANT_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.index.query.QueryBuilders.boolQuery;
+import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
+import static org.opensearch.index.query.QueryBuilders.termQuery;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.folio.search.model.index.InstanceSubResource;
+import org.folio.search.model.index.SubjectResource;
+import org.folio.search.model.service.BrowseContext;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.test.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class ConsortiumSearchHelperTest {
+
+  private static final String SUBRESOURCE_PREFIX = "instances.";
+  private static final String TENANT_ID_FIELD = SUBRESOURCE_PREFIX + "tenantId";
+  private static final String SHARED_FIELD = SUBRESOURCE_PREFIX + "shared";
+
+  @Mock
+  private FolioExecutionContext context;
+  @Mock
+  private ConsortiumTenantService tenantService;
+
+  @Spy
+  @InjectMocks
+  private ConsortiumSearchHelper consortiumSearchHelper;
+
+  @Test
+  void filterQueryForActiveAffiliation_positive_basic() {
+    var query = matchAllQuery();
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.of(CONSORTIUM_TENANT_ID));
+
+    consortiumSearchHelper.filterQueryForActiveAffiliation(query);
+
+    verify(consortiumSearchHelper).filterQueryForActiveAffiliation(query, TENANT_ID);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = TENANT_ID)
+  @NullSource
+  void filterQueryForActiveAffiliation_positive_basicNotConsortiumMemberTenant(String centralTenantId) {
+    var query = matchAllQuery();
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.ofNullable(centralTenantId));
+
+    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(query);
+
+    assertThat(actual).isEqualTo(query);
+    verify(consortiumSearchHelper, times(0)).filterQueryForActiveAffiliation(any(), any());
+  }
+
+  @Test
+  void filterQueryForActiveAffiliation_positive_noPrefix() {
+    var query = matchAllQuery();
+    var expected = boolQuery()
+      .minimumShouldMatch(1)
+      .should(termQuery("tenantId", TENANT_ID))
+      .should(termQuery("shared", true));
+
+    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(query, TENANT_ID);
+
+    assertThat(actual).isEqualTo(expected);
+    verify(consortiumSearchHelper).filterQueryForActiveAffiliation(EMPTY, query, TENANT_ID);
+  }
+
+  @Test
+  void filterQueryForActiveAffiliation_positive() {
+    var query = matchAllQuery();
+    var expected = boolQuery()
+      .minimumShouldMatch(1)
+      .should(termQuery(TENANT_ID_FIELD, TENANT_ID))
+      .should(termQuery(SHARED_FIELD, true));
+
+    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(SUBRESOURCE_PREFIX, query, TENANT_ID);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filterQueryForActiveAffiliation_positive_boolQuery() {
+    var query = boolQuery();
+    var expected = boolQuery()
+      .minimumShouldMatch(1)
+      .should(termQuery(TENANT_ID_FIELD, TENANT_ID))
+      .should(termQuery(SHARED_FIELD, true));
+
+    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(SUBRESOURCE_PREFIX, query, TENANT_ID);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filterQueryForActiveAffiliation_positive_boolQueryWithShould() {
+    var query = boolQuery().should(termQuery("test", "test"));
+    var expected = boolQuery()
+      .minimumShouldMatch(1)
+      .should(termQuery("test", "test"))
+      .must(boolQuery()
+        .should(termQuery(TENANT_ID_FIELD, TENANT_ID))
+        .should(termQuery(SHARED_FIELD, true)));
+
+    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(SUBRESOURCE_PREFIX, query, TENANT_ID);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void filterQueryForActiveAffiliation_positive_otherQuery() {
+    var query = termQuery("test", "test");
+    var expected = boolQuery()
+      .minimumShouldMatch(1)
+      .must(termQuery("test", "test"))
+      .should(termQuery(TENANT_ID_FIELD, TENANT_ID))
+      .should(termQuery(SHARED_FIELD, true));
+
+    var actual = consortiumSearchHelper.filterQueryForActiveAffiliation(SUBRESOURCE_PREFIX, query, TENANT_ID);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = TENANT_ID)
+  @NullSource
+  void filterBrowseQueryForActiveAffiliation_positive_notConsortiumMemberTenant(String centralTenantId) {
+    var browseContext = browseContext(false);
+    var query = matchAllQuery();
+
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.ofNullable(centralTenantId));
+
+    var actual = consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(browseContext, query);
+
+    assertThat(actual).isEqualTo(query);
+    assertThat(browseContext.getFilters()).isEmpty();
+  }
+
+  @Test
+  void filterBrowseQueryForActiveAffiliation_positive_shared() {
+    var browseContext = browseContext(true);
+    var query = matchAllQuery();
+
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.of(CONSORTIUM_TENANT_ID));
+
+    consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(browseContext, query);
+
+    verify(consortiumSearchHelper).filterQueryForActiveAffiliation("instances.", query, TENANT_ID);
+  }
+
+  @Test
+  void filterBrowseQueryForActiveAffiliation_positive_local() {
+    var browseContext = browseContext(false);
+    var query = matchAllQuery();
+    var expected = boolQuery()
+      .must(termQuery(TENANT_ID_FIELD, TENANT_ID));
+
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.of(CONSORTIUM_TENANT_ID));
+
+    var actual = consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(browseContext, query);
+
+    assertThat(actual).isEqualTo(expected);
+    assertThat(browseContext.getFilters()).isNotEmpty();
+  }
+
+  @Test
+  void filterBrowseQueryForActiveAffiliation_positive_localWithShould() {
+    var browseContext = browseContext(false);
+    var query = boolQuery()
+      .should(termQuery("test", "test"));
+    var expected = boolQuery()
+      .should(termQuery("test", "test"))
+      .minimumShouldMatch(1)
+      .must(termQuery(TENANT_ID_FIELD, TENANT_ID));
+
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.of(CONSORTIUM_TENANT_ID));
+
+    var actual = consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(browseContext, query);
+
+    assertThat(actual).isEqualTo(expected);
+    assertThat(browseContext.getFilters()).isNotEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = TENANT_ID)
+  @NullSource
+  void filterSubResourcesForConsortium_positive_notConsortiumMemberTenant(String centralTenantId) {
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.ofNullable(centralTenantId));
+
+    var browseContext = browseContext(false);
+    var resource = new SubjectResource();
+    resource.setInstances(subResources());
+
+    var actual = consortiumSearchHelper.filterSubResourcesForConsortium(browseContext, resource,
+      SubjectResource::getInstances);
+
+    assertThat(actual).isEqualTo(resource.getInstances());
+  }
+
+  @Test
+  void filterSubResourcesForConsortium_positive_local() {
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.of(CONSORTIUM_TENANT_ID));
+
+    var browseContext = browseContext(false);
+    var subResources = subResources();
+    var resource = new SubjectResource();
+    resource.setInstances(subResources);
+    var expected = subResources.stream().filter(s -> s.getTenantId().equals(TENANT_ID)).collect(Collectors.toSet());
+
+    var actual = consortiumSearchHelper.filterSubResourcesForConsortium(browseContext, resource,
+      SubjectResource::getInstances);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = true)
+  @NullSource
+  void filterSubResourcesForConsortium_positive_shared(Boolean shared) {
+    when(context.getTenantId()).thenReturn(TENANT_ID);
+    when(tenantService.getCentralTenant(TENANT_ID)).thenReturn(Optional.of(CONSORTIUM_TENANT_ID));
+
+    var browseContext = browseContext(shared);
+    var subResources = subResources();
+    var resource = SubjectResource.builder().instances(subResources).build();
+    var expected = newHashSet(subResources);
+    expected.removeIf(s -> s.getTenantId().equals(CONSORTIUM_TENANT_ID) && !s.getShared());
+
+    var actual = consortiumSearchHelper.filterSubResourcesForConsortium(browseContext, resource,
+      SubjectResource::getInstances);
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  private BrowseContext browseContext(Boolean sharedFilter) {
+    var browseContext = BrowseContext.builder();
+
+    if (sharedFilter != null) {
+      browseContext.filters(newArrayList(termQuery(SHARED_FIELD, sharedFilter)));
+    }
+
+    return browseContext.build();
+  }
+
+  private Set<InstanceSubResource> subResources() {
+    return newHashSet(subResource(TENANT_ID, false),
+      subResource(TENANT_ID, true),
+      subResource(CONSORTIUM_TENANT_ID, false),
+      subResource(CONSORTIUM_TENANT_ID, true));
+  }
+
+  private InstanceSubResource subResource(String tenantId, boolean shared) {
+    return InstanceSubResource.builder().tenantId(tenantId).shared(shared).build();
+  }
+}


### PR DESCRIPTION
## Purpose
Implement active affiliation context for browse so it works together with instances.shared filter
[MSEARCH-580](https://issues.folio.org/browse/MSEARCH-580)

## Approach
- Move consortium filtering logic into a new class ConsortiumSerachHelper
- Add active affiliation logic for browse authorities/call numbers/subjects/contributors
- Add active affiliation logic to sub-resource result filtration on subjects/contributors

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
