### PR TITLE
fix(consortium) Fix records created in central tenant are sometimes saved as local

### DIFF
--- a/src/main/java/org/folio/search/model/event/ConsortiumInstanceEvent.java
+++ b/src/main/java/org/folio/search/model/event/ConsortiumInstanceEvent.java
@@ -4,11 +4,13 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 import org.folio.spring.tools.kafka.BaseKafkaMessage;
 
 @Getter
 @Setter
 @RequiredArgsConstructor
+@ToString
 @EqualsAndHashCode
 public class ConsortiumInstanceEvent implements BaseKafkaMessage {
 

--- a/src/main/java/org/folio/search/service/consortium/ConsortiumTenantService.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumTenantService.java
@@ -4,19 +4,26 @@ import static org.folio.search.configuration.SearchCacheNames.USER_TENANTS_CACHE
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.folio.search.client.UserTenantsClient;
+import org.folio.spring.FolioExecutionContext;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+@Log4j2
 @Service
 @RequiredArgsConstructor
 public class ConsortiumTenantService {
 
   private final UserTenantsClient userTenantsClient;
 
-  @Cacheable(USER_TENANTS_CACHE)
+  private final FolioExecutionContext context;
+
+  @Cacheable(cacheNames = USER_TENANTS_CACHE, key = "@folioExecutionContext.tenantId + ':' + #tenantId")
   public Optional<String> getCentralTenant(String tenantId) {
     var userTenants = userTenantsClient.getUserTenants(tenantId);
+    log.debug("getCentralTenant: contextTenantId: {}, tenantId: {}, response: {}",
+      context.getTenantId(), tenantId, userTenants);
 
     return Optional.ofNullable(userTenants)
       .flatMap(tenants -> tenants.userTenants().stream()


### PR DESCRIPTION
## Purpose
Fix a problem when records created in central tenant are sometimes saved as local
[MSEARCH-590](https://issues.folio.org/browse/MSEARCH-590)

## Approach
Add context tenantId to a cache key for /user-tenants response

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
