### PR TITLE
fix(reindex): Add missed authority-reindex interface to module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -247,6 +247,10 @@
       "version": "0.1"
     },
     {
+      "id": "authority-reindex",
+      "version": "0.1"
+    },
+    {
       "id": "alternative-title-types",
       "version": "1.0"
     },


### PR DESCRIPTION
## Purpose
Add missed authority-reindex interface to module descriptor

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [x] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
