### PR TITLE
fix(cn-browse): Fix browsing for not specified call number type

### DIFF
--- a/src/main/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessor.java
@@ -25,7 +25,6 @@ public class EffectiveShelvingOrderTermProcessor implements SearchTermProcessor 
   }
 
   public List<String> getSearchTerms(String inputTerm) {
-
     var searchTerms = new ArrayList<String>();
 
     addShelfKeyIfValid(searchTerms, new NlmCallNumber(inputTerm));
@@ -33,9 +32,7 @@ public class EffectiveShelvingOrderTermProcessor implements SearchTermProcessor 
     addShelfKeyIfValid(searchTerms, new DeweyCallNumber(inputTerm));
     addShelfKeyIfValid(searchTerms, new SuDocCallNumber(inputTerm));
 
-    if (searchTerms.isEmpty()) {
-      searchTerms.add(normalizeEffectiveShelvingOrder(inputTerm));
-    }
+    searchTerms.add(normalizeEffectiveShelvingOrder(inputTerm));
 
     return searchTerms;
   }

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -45,24 +45,27 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
     log.debug("browseInOneDirection:: by: [request: {}]", request);
 
     var isBrowsingForward = context.isBrowsingForward();
-    SearchResponse searchResponse = null;
+    var searchSource = callNumberBrowseQueryProvider.get(request, context, isBrowsingForward);
+    var searchResponse = searchRepository.search(request, searchSource);
 
-    var anchors = getAnchors(request);
-    if (anchors.size() > 1) {
+    if (!isAnchorPresent(searchResponse, context)) {
+      var anchors = getAnchors(request);
+      if (!anchors.isEmpty()) {
+        anchors.remove(0);
+      }
       for (String anchor : anchors) {
-        if (!anchor.equals(context.getAnchor())) {
-          context = buildBrowseContext(context, anchor);
-        }
-        var searchSource = callNumberBrowseQueryProvider.get(request, context, isBrowsingForward);
-        searchResponse = searchRepository.search(request, searchSource);
+        var contextForAnchor = buildBrowseContext(context, anchor);
+        var searchSourceForAnchor = callNumberBrowseQueryProvider.get(request, contextForAnchor, isBrowsingForward);
+        var responseForAnchor = searchRepository.search(request, searchSourceForAnchor);
+
         if (isAnchorPresent(searchResponse, context)) {
+          context = contextForAnchor;
+          searchResponse = responseForAnchor;
           break;
         }
       }
-    } else {
-      var searchSource = callNumberBrowseQueryProvider.get(request, context, isBrowsingForward);
-      searchResponse = searchRepository.search(request, searchSource);
     }
+
     var browseResult = callNumberBrowseResultConverter.convert(searchResponse, context, isBrowsingForward);
     var records = browseResult.getRecords();
     browseResult.setRecords(excludeIrrelevantResultItems(request.getRefinedCondition(), records));
@@ -76,26 +79,29 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
   @Override
   protected BrowseResult<CallNumberBrowseItem> browseAround(BrowseRequest request, BrowseContext context) {
     log.debug("browseAround:: by: [request: {}]", request);
-    MultiSearchResponse.Item[] responses = {};
 
     var precedingQuery = callNumberBrowseQueryProvider.get(request, context, false);
+    var responses = getBrowseAround(request, context, precedingQuery);
 
     var callNumber = callNumberFromRequest(request);
-    var anchors = getAnchors(callNumber);
-    if (anchors.size() > 1) {
-      for (String anchor : anchors) {
-        if (!anchor.equals(context.getAnchor())) {
-          context = buildBrowseContext(context, anchor);
-          precedingQuery = callNumberBrowseQueryProvider.get(request, context, false);
-        }
 
-        responses = getBrowseAround(request, context, precedingQuery);
-        if (isAnchorPresent(responses[1].getResponse(), context)) {
+    if (!isAnchorPresent(responses[1].getResponse(), context)) {
+      var anchors = getAnchors(callNumber);
+      if (!anchors.isEmpty()) {
+        anchors.remove(0);
+      }
+      for (String anchor : anchors) {
+        var contextForAnchor = buildBrowseContext(context, anchor);
+        var precedingQueryForAnchor = callNumberBrowseQueryProvider.get(request, contextForAnchor, false);
+        var responsesForAnchor = getBrowseAround(request, contextForAnchor, precedingQueryForAnchor);
+
+        if (isAnchorPresent(responsesForAnchor[1].getResponse(), contextForAnchor)) {
+          context = contextForAnchor;
+          precedingQuery = precedingQueryForAnchor;
+          responses = responsesForAnchor;
           break;
         }
       }
-    } else {
-      responses = getBrowseAround(request, context, precedingQuery);
     }
 
     var precedingResult = callNumberBrowseResultConverter.convert(responses[0].getResponse(), context, false);
@@ -193,7 +199,8 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
   }
 
   private boolean isAnchorPresent(SearchResponse searchResponse, BrowseContext context) {
-    var items = callNumberBrowseResultConverter.convert(searchResponse, context, true).getRecords();
+    var items = callNumberBrowseResultConverter.convert(searchResponse, context, context.isBrowsingForward())
+      .getRecords();
 
     return isNotEmpty(items) && StringUtils.equals(items.get(0).getShelfKey(), context.getAnchor());
   }

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
@@ -14,12 +14,10 @@ import static org.folio.search.utils.TestUtils.randomId;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.ThreadUtils;
 import org.folio.search.domain.dto.CallNumberBrowseResult;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
@@ -110,7 +108,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       .param("precedingRecordsCount", "4");
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
     var expected = new CallNumberBrowseResult()
-      .totalRecords(41).prev("GA 216 D64 541548A").next("J 229 229  !M 254 !3990").items(List.of(
+      .totalRecords(41).prev("GA 216 D64 541548A").next("J 229.29 M54 3990").items(List.of(
         cnBrowseItem(instance("instance #39"), "GA 16 D64 41548A"),
         cnBrowseItem(instance("instance #30"), "GA 16 G32 41557 V1"),
         cnBrowseItem(instance("instance #30"), "GA 16 G32 41557 V2"),
@@ -161,7 +159,6 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       )));
 
     disableFeature(BROWSE_CN_INTERMEDIATE_VALUES);
-    ThreadUtils.sleep(Duration.ofSeconds(5)); //needed to wait feature disabling. ...MultipleAnchors breaks otherwise
   }
 
   private static Stream<Arguments> callNumberBrowsingDataProvider() {
@@ -243,10 +240,8 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
           cnBrowseItem(instance("instance #28"), "DB 11 A31 BD 3124"),
           cnBrowseItem(instance("instance #23"), "DB 11 A66 SUPPL NO 11"),
           cnBrowseItem(instance("instance #10"), "DC 3201 B34 41972"),
-          //this one below goes before the next because call number type not specified for indexing, and so it's
-          //indexed as system call number (most likely SuDoc) which causes shelf key to be higher in a list
-          cnBrowseItem(instance("instance #33"), "E 12.11 I2 298"),
           cnBrowseItem(instance("instance #35"), "E 12.11 I12 288 D"),
+          cnBrowseItem(instance("instance #33"), "E 12.11 I2 298"),
           cnBrowseItem(instance("instance #27"), "E 211 A506"),
           cnBrowseItem(instance("instance #12"), "E 211 N52 VOL 14")
         ))),
@@ -351,11 +346,9 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(backwardQuery, "F 11", 5, new CallNumberBrowseResult()
-        .totalRecords(28).prev("E 212 211   !I 12 !3298").next("F  PR1866.S63 V.1 C.1").items(List.of(
-          //this one below goes before the next because call number type not specified for indexing, and so it's
-          //indexed as system call number (most likely SuDoc) which causes shelf key to be higher in a list
-          cnBrowseItem(instance("instance #33"), "E 12.11 I2 298"),
+        .totalRecords(28).prev("E 212.11 I12 3288 D").next("F  PR1866.S63 V.1 C.1").items(List.of(
           cnBrowseItem(instance("instance #35"), "E 12.11 I12 288 D"),
+          cnBrowseItem(instance("instance #33"), "E 12.11 I2 298"),
           cnBrowseItem(instance("instance #27"), "E 211 A506"),
           cnBrowseItem(instance("instance #12"), "E 211 N52 VOL 14"),
           cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1")

--- a/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIT.java
@@ -72,16 +72,16 @@ class BrowseTypedCallNumberIT extends BaseIntegrationTest {
   @Test
   void browseByCallNumberDewey_browsingAroundWhenPrecedingRecordsCountIsSpecified() {
     var request = get(instanceCallNumberBrowsePath())
-      .param("query", prepareQuery("typedCallNumber < {value} or typedCallNumber >= {value}", "\"CE 16 B6724 41993\""))
+      .param("query", prepareQuery("typedCallNumber < {value} or typedCallNumber >= {value}", "\"1CE 16 B6724 41993\""))
       .param("callNumberType", "dewey")
       .param("limit", "5")
       .param("expandAll", "true")
       .param("precedingRecordsCount", "4");
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
-      .totalRecords(6).prev(null).next("CE 216 B6724 541993").items(List.of(
-        cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993"),
-        cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993", true)
+      .totalRecords(7).prev(null).next("11 CE 216 B 46724 541993").items(List.of(
+        cnBrowseItem(instance("instance #44"), "1CE 16 B6713 X 41993"),
+        cnBrowseItem(instance("instance #45"), "1CE 16 B6724 41993", true)
       )));
   }
 
@@ -106,7 +106,7 @@ class BrowseTypedCallNumberIT extends BaseIntegrationTest {
   @Test
   void browseByCallNumberSudoc_browsingAroundWhenPrecedingRecordsCountIsSpecified() {
     var request = get(instanceCallNumberBrowsePath())
-      .param("query", prepareQuery("typedCallNumber < {value} or typedCallNumber >= {value}", "\"PR 44034 B38 41993\""))
+      .param("query", prepareQuery("typedCallNumber < {value} or typedCallNumber >= {value}", "\"P1.44034 B38 41993\""))
       .param("callNumberType", "sudoc")
       .param("limit", "5")
       .param("expandAll", "true")
@@ -114,10 +114,10 @@ class BrowseTypedCallNumberIT extends BaseIntegrationTest {
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
       .totalRecords(5).prev(null).next(null).items(List.of(
-        cnBrowseItem(instance("instance #12"), "DC 211 N52 VOL 14"),
-        cnBrowseItem(instance("instance #10"), "DC 3201 B34 41972"),
-        cnBrowseItem(instance("instance #17"), "GA 16 A63 41581"),
-        cnBrowseItem(instance("instance #16"), "PR 44034 B38 41993", true)
+        cnBrowseItem(instance("instance #12"), "D1.211 N52 VOL 14"),
+        cnBrowseItem(instance("instance #10"), "D1.3201 B34 41972"),
+        cnBrowseItem(instance("instance #17"), "G1.16 A63 41581"),
+        cnBrowseItem(instance("instance #16"), "P1.44034 B38 41993", true)
       )));
   }
 
@@ -198,20 +198,20 @@ class BrowseTypedCallNumberIT extends BaseIntegrationTest {
       List.of("instance #01", List.of("DA 3880 O6 J72"), LC.getId()),
       List.of("instance #02", List.of("DA 3880 O6 M96"), LC.getId()),
       List.of("instance #03", List.of("DA 3880 O6 L5 41955"), LC.getId()),
-      List.of("instance #04", List.of("CE 16 D86 X 41998"), DEWEY.getId()),
+      List.of("instance #04", List.of("1CE 16 D86 X 41998"), DEWEY.getId()),
       List.of("instance #05", List.of("DA 3880 O6 M15"), LC.getId()),
       List.of("instance #06", List.of("DA 3880 O6 L6 V1"), LC.getId()),
       List.of("instance #07", List.of("DA 3870 H47 41975"), LC.getId()),
       List.of("instance #08", List.of("AC 11 A67 X 42000"), NLM.getId()),
       List.of("instance #09", List.of("DA 3700 C95 NO 18"), LC.getId()),
-      List.of("instance #10", List.of("DC 3201 B34 41972"), SUDOC.getId()),
+      List.of("instance #10", List.of("D1.3201 B34 41972"), SUDOC.getId()),
       List.of("instance #11", List.of("DA 3880 K56 M27 41984"), LC.getId()),
-      List.of("instance #12", List.of("DC 211 N52 VOL 14"), SUDOC.getId()),
+      List.of("instance #12", List.of("D1.211 N52 VOL 14"), SUDOC.getId()),
       List.of("instance #13", List.of("DA 3880 O6 M81"), LC.getId()),
       List.of("instance #14", List.of("DA 3890 A1 I72 41885"), LC.getId()),
       List.of("instance #15", List.of("DA 3880 O6 L76"), LC.getId()),
-      List.of("instance #16", List.of("PR 44034 B38 41993"), SUDOC.getId()),
-      List.of("instance #17", List.of("GA 16 A63 41581"), SUDOC.getId()),
+      List.of("instance #16", List.of("P1.44034 B38 41993"), SUDOC.getId()),
+      List.of("instance #17", List.of("G1.16 A63 41581"), SUDOC.getId()),
       List.of("instance #18", List.of("AC 11 E8 NO 14 P S1487"), NLM.getId()),
       List.of("instance #19", List.of("DA 3890 A2 F57 42011"), LC.getId()),
       List.of("instance #20", List.of("DA 3880 O6 L75"), LC.getId()),
@@ -232,14 +232,14 @@ class BrowseTypedCallNumberIT extends BaseIntegrationTest {
       List.of("instance #35", List.of("E 12.11 I12 288 D"), LOCAL_TYPE_2),
       List.of("instance #36", List.of("DA 3700 B91 L79"), LC.getId()),
       List.of("instance #37", List.of("FC 17 B89"), LOCAL_TYPE_2),
-      List.of("instance #38", List.of("CE 210 K297 41858"), DEWEY.getId()),
+      List.of("instance #38", List.of("1CE 210 K297 41858"), DEWEY.getId()),
       List.of("instance #39", List.of("GA 16 D64 41548A"), OTHER.getId()),
       List.of("instance #40", List.of("PR 213 E5 41999"), LOCAL_TYPE_2),
       List.of("instance #41", List.of("DA 3870 B55 41868"), LC.getId()),
       List.of("instance #42", List.of("FA 46252 3977 12 237"), OTHER.getId()),
       List.of("instance #43", List.of("FA 42010 3546 256"), OTHER.getId()),
-      List.of("instance #44", List.of("CE 16 B6713 X 41993"), DEWEY.getId()),
-      List.of("instance #45", List.of("CE 16 B6724 41993"), DEWEY.getId()),
+      List.of("instance #44", List.of("1CE 16 B6713 X 41993"), DEWEY.getId()),
+      List.of("instance #45", List.of("1CE 16 B6724 41993"), DEWEY.getId()),
       List.of("instance #46", List.of("F  PR1866.S63 V.1 C.1"), LOCAL_TYPE_1)
     );
   }

--- a/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIrrelevantResultIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIrrelevantResultIT.java
@@ -89,9 +89,9 @@ class BrowseTypedCallNumberIrrelevantResultIT extends BaseIntegrationTest {
     var expected = new CallNumberBrowseResult()
       .totalRecords(4)
       .items(Arrays.asList(
-        cnBrowseItem(instance("instance #10"), "Z669.R360 1975", true),
-        cnBrowseItem(instance("instance #02"), "Z669.R360 1976"),
-        cnBrowseItem(instance("instance #10"), "Z669.R360 1977")
+        cnBrowseItem(instance("instance #10"), "Z669.R360 1975", 3, true),
+        cnBrowseItem(instance("instance #02"), "Z669.R360 1976", 1),
+        cnBrowseItem(instance("instance #10"), "Z669.R360 1977", 1)
     ));
     expected.setItems(CallNumberUtils.excludeIrrelevantResultItems("lc", expected.getItems()));
     leaveOnlyBasicProps(expected);
@@ -183,7 +183,7 @@ class BrowseTypedCallNumberIrrelevantResultIT extends BaseIntegrationTest {
         .effectiveCallNumberComponents(new ItemEffectiveCallNumberComponents()
           .callNumber(d.get(1))
           .typeId(d.get(0)))
-        .effectiveShelvingOrder(getShelfKeyFromCallNumber(d.get(1))))
+        .effectiveShelvingOrder(getShelfKeyFromCallNumber(d.get(1), d.get(0))))
       .toList();
 
     return new Instance()
@@ -200,8 +200,8 @@ class BrowseTypedCallNumberIrrelevantResultIT extends BaseIntegrationTest {
 
   private static List<List<String>> callNumberBrowseInstanceData() {
     return List.of(
-      List.of("95467209-6d7b-468b-94df-0f5d7ad2747d", "Z669.R360 1977", "instance #10"),
       List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H970", "instance #10"),
+      List.of("95467209-6d7b-468b-94df-0f5d7ad2747d", "Z669.R360 1977", "instance #10"),
       List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H971", "instance #01"),
       List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H972", "instance #11"),
       List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H973", "instance #11"),
@@ -211,9 +211,9 @@ class BrowseTypedCallNumberIrrelevantResultIT extends BaseIntegrationTest {
       List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H977", "instance #09"),
       List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H978", "instance #01"),
       List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H979", "instance #10"),
+      List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H980", "instance #02"),
       List.of("95467209-6d7b-468b-94df-0f5d7ad2747d", "Z669.R360 1976", "instance #02"),
       List.of("95467209-6d7b-468b-94df-0f5d7ad2747d", "Z669.R360 1975", "instance #10"),
-      List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H980", "instance #02"),
       List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H981", "instance #08"),
       List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H982", "instance #09"),
       List.of("03dd64d0-5626-4ecd-8ece-4531e0069f35", "308 H983", "instance #07"),

--- a/src/test/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessorTest.java
@@ -1,6 +1,7 @@
 package org.folio.search.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.CallNumberUtils.normalizeEffectiveShelvingOrder;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -116,7 +117,9 @@ class EffectiveShelvingOrderTermProcessorTest {
   @Test
   void getSearchTerms_getMultiple() {
     var given = "T22.19:M54/990";
-    var expected = List.of(new LCCallNumber(given).getShelfKey(), new SuDocCallNumber(given).getShelfKey());
+    var expected = List.of(new LCCallNumber(given).getShelfKey(),
+      new SuDocCallNumber(given).getShelfKey(),
+      normalizeEffectiveShelvingOrder(given));
     var actual = searchTermProcessor.getSearchTerms(given);
 
     assertThat(actual).isEqualTo(expected);

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
@@ -1,5 +1,6 @@
 package org.folio.search.service.browse;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Arrays.stream;
 import static org.apache.lucene.search.TotalHits.Relation.EQUAL_TO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,6 +80,7 @@ class CallNumberBrowseServiceTest {
     callNumberBrowseService.setBrowseContextProvider(browseContextProvider);
     lenient().when(cqlSearchQueryConverter.convertToTermNode(anyString(), anyString()))
       .thenReturn(new CQLTermNode(null, null, "B"));
+    lenient().when(shelvingOrderProcessor.getSearchTerms(ANCHOR)).thenReturn(newArrayList(ANCHOR));
   }
 
   @Test
@@ -173,6 +175,7 @@ class CallNumberBrowseServiceTest {
 
     when(cqlSearchQueryConverter.convertToTermNode(anyString(), anyString()))
       .thenReturn(new CQLTermNode(null, null, callNumber));
+    lenient().when(shelvingOrderProcessor.getSearchTerms(callNumber)).thenReturn(newArrayList(callNumber));
 
     prepareMockForBrowsingAround(request,
       contextAroundIncluding(callNumber, callNumber),
@@ -249,7 +252,7 @@ class CallNumberBrowseServiceTest {
 
     when(cqlSearchQueryConverter.convertToTermNode(anyString(), anyString()))
       .thenReturn(new CQLTermNode(null, null, "B"));
-    when(shelvingOrderProcessor.getSearchTerms(ANCHOR)).thenReturn(List.of("A", "B"));
+    lenient().when(shelvingOrderProcessor.getSearchTerms(ANCHOR)).thenReturn(newArrayList("A", "B"));
 
     var precedingResult = BrowseResult.of(1, browseItems("A 11", "A 12"));
     var succeedingResult = BrowseResult.of(1, browseItems("B"));

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -10,6 +10,10 @@ import static java.util.stream.Collectors.toCollection;
 import static org.folio.search.domain.dto.ResourceEventType.CREATE;
 import static org.folio.search.model.metadata.PlainFieldDescription.MULTILANG_FIELD_TYPE;
 import static org.folio.search.model.metadata.PlainFieldDescription.STANDARD_FIELD_TYPE;
+import static org.folio.search.model.types.CallNumberType.DEWEY;
+import static org.folio.search.model.types.CallNumberType.LC;
+import static org.folio.search.model.types.CallNumberType.NLM;
+import static org.folio.search.model.types.CallNumberType.SUDOC;
 import static org.folio.search.model.types.FieldType.OBJECT;
 import static org.folio.search.model.types.FieldType.PLAIN;
 import static org.folio.search.model.types.FieldType.SEARCH;
@@ -45,12 +49,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import org.folio.search.cql.EffectiveShelvingOrderTermProcessor;
+import org.folio.search.cql.SuDocCallNumber;
 import org.folio.search.domain.dto.Authority;
 import org.folio.search.domain.dto.AuthorityBrowseItem;
 import org.folio.search.domain.dto.CallNumberBrowseItem;
@@ -81,6 +87,10 @@ import org.folio.search.model.service.CqlSearchRequest;
 import org.folio.search.model.types.CallNumberType;
 import org.folio.search.model.types.IndexingDataFormat;
 import org.folio.search.model.types.SearchType;
+import org.marc4j.callnum.AbstractCallNumber;
+import org.marc4j.callnum.DeweyCallNumber;
+import org.marc4j.callnum.LCCallNumber;
+import org.marc4j.callnum.NlmCallNumber;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.core.ParseField;
@@ -108,6 +118,13 @@ public class TestUtils {
     new NamedXContentRegistry(TestUtils.elasticsearchClientNamedContentRegistryEntries());
   private static final EffectiveShelvingOrderTermProcessor SHELVING_ORDER_TERM_PROCESSOR =
     new EffectiveShelvingOrderTermProcessor();
+
+  private static final Map<CallNumberType, Function<String, AbstractCallNumber>> SHERVING_ORDER_GENERATORS = Map.of(
+    NLM, callNumber -> new NlmCallNumber(callNumber),
+    LC, callNumber -> new LCCallNumber(callNumber),
+    DEWEY, callNumber -> new DeweyCallNumber(callNumber),
+    SUDOC, callNumber -> new SuDocCallNumber(callNumber)
+  );
 
   @SneakyThrows
   public static String asJsonString(Object value) {
@@ -173,13 +190,12 @@ public class TestUtils {
   }
 
   public static CallNumberBrowseItem cnBrowseItem(Instance instance, String callNumber) {
-    var callNumberType = Optional.ofNullable(instance.getItems().get(0))
-      .flatMap(item -> Optional.ofNullable(item.getEffectiveCallNumberComponents())
-        .map(ItemEffectiveCallNumberComponents::getTypeId));
-    var shelfKey = callNumberType.isEmpty()
-      ? getShelfKeyFromCallNumber(callNumber)
-      : getShelfKeyFromCallNumber(callNumber, callNumberType.get());
-    return cnBrowseItem(instance, shelfKey, callNumber);
+    return cnBrowseItem(instance, callNumber, 0);
+  }
+
+  public static CallNumberBrowseItem cnBrowseItem(Instance instance, String callNumber,
+                                                  Integer itemNumberForCallNumberType) {
+    return cnBrowseItem(instance, callNumber, itemNumberForCallNumberType, null);
   }
 
   public static CallNumberBrowseItem cnBrowseItem(Instance instance, String shelfKey, String callNumber) {
@@ -187,7 +203,17 @@ public class TestUtils {
   }
 
   public static CallNumberBrowseItem cnBrowseItem(Instance instance, String callNumber, boolean isAnchor) {
-    var shelfKey = getShelfKeyFromCallNumber(callNumber);
+    return cnBrowseItem(instance, callNumber, 0, isAnchor);
+  }
+
+  public static CallNumberBrowseItem cnBrowseItem(Instance instance, String callNumber,
+                                                  Integer itemNumberForCallNumberType, Boolean isAnchor) {
+    var callNumberType = Optional.ofNullable(instance.getItems().get(itemNumberForCallNumberType))
+      .flatMap(item -> Optional.ofNullable(item.getEffectiveCallNumberComponents())
+        .map(ItemEffectiveCallNumberComponents::getTypeId));
+    var shelfKey = callNumberType.isEmpty()
+      ? getShelfKeyFromCallNumber(callNumber)
+      : getShelfKeyFromCallNumber(callNumber, callNumberType.get());
     return new CallNumberBrowseItem().fullCallNumber(callNumber).shelfKey(shelfKey)
       .instance(instance).totalRecords(1).isAnchor(isAnchor);
   }
@@ -203,18 +229,32 @@ public class TestUtils {
       .shelfKey(shelfKey).fullCallNumber(callNumber).isAnchor(isAnchor);
   }
 
+  public static CallNumberBrowseItem cnBrowseItemWithNoType(Instance instance, String callNumber) {
+    return cnBrowseItemWithNoType(instance, callNumber, null);
+  }
+
+  public static CallNumberBrowseItem cnBrowseItemWithNoType(Instance instance, String callNumber, Boolean isAnchor) {
+    var shelfKey = shelfKeyForNotTypedCallNumberFunction().apply(callNumber);
+    return new CallNumberBrowseItem().fullCallNumber(callNumber).shelfKey(shelfKey)
+      .instance(instance).totalRecords(1).isAnchor(isAnchor);
+  }
+
+  public static Function<String, String> shelfKeyForNotTypedCallNumberFunction() {
+    return CallNumberUtils::normalizeEffectiveShelvingOrder;
+  }
+
   public static String getShelfKeyFromCallNumber(String callNumber) {
     var terms = SHELVING_ORDER_TERM_PROCESSOR.getSearchTerms(callNumber);
-    return terms.get(terms.size() - 1);
+    return terms.get(0);
   }
 
   public static String getShelfKeyFromCallNumber(String callNumber, String typeId) {
     var callNumberType = CallNumberType.fromId(typeId);
-    if (callNumberType.isEmpty()) {
-      return normalizeEffectiveShelvingOrder(callNumber);
-    }
-
-    return getShelfKeyFromCallNumber(callNumber);
+    return callNumberType.flatMap(numberType -> Optional.ofNullable(SHERVING_ORDER_GENERATORS.get(numberType))
+        .map(generator -> generator.apply(callNumber))
+        .filter(AbstractCallNumber::isValid)
+        .map(AbstractCallNumber::getShelfKey))
+      .orElse(normalizeEffectiveShelvingOrder(callNumber));
   }
 
   public static SubjectBrowseResult subjectBrowseResult(int total, List<SubjectBrowseItem> items) {


### PR DESCRIPTION
## Purpose
Fix browsing for not specified/local call number types
[MSEARCH-569](https://issues.folio.org/browse/MSEARCH-569)

## Approach
- Always add normilized call number to list of possible anchors
- Fix test data for tests by providing proper shelf keys for indexing
- Fix BrowseTypedCallNumberIT by using valid call numbers for types

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
