### PR TITLE
fix(cn-browse): Fix 'folio' source call numbers returnd when browsing for 'local'

### DIFF
--- a/src/main/java/org/folio/search/model/types/CallNumberTypeSource.java
+++ b/src/main/java/org/folio/search/model/types/CallNumberTypeSource.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum CallNumberTypeSource {
   SYSTEM("system"),
-  LOCAL("local");
+  LOCAL("local"),
+  FOLIO("folio");
 
   private final String source;
 

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -39,6 +39,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBrowseItem> {
 
+  static final List<String> FOLIO_CALL_NUMBER_TYPES_SOURCES = Collections.singletonList(FOLIO.getSource());
   private static final int ADDITIONAL_REQUEST_SIZE = 100;
   private static final int ADDITIONAL_REQUEST_SIZE_MAX = 500;
   private final SearchRepository searchRepository;
@@ -47,7 +48,6 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
   private final CallNumberBrowseResultConverter callNumberBrowseResultConverter;
   private final EffectiveShelvingOrderTermProcessor effectiveShelvingOrderTermProcessor;
   private final ReferenceDataService referenceDataService;
-  static final List<String> FOLIO_CALL_NUMBER_TYPES_SOURCES = Collections.singletonList(FOLIO.getSource());
 
   @Override
   protected BrowseResult<CallNumberBrowseItem> browseInOneDirection(BrowseRequest request, BrowseContext context) {

--- a/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIT.java
@@ -1,6 +1,7 @@
 package org.folio.search.controller;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +41,7 @@ class BrowseTypedCallNumberIT extends BaseIntegrationTest {
 
   private static final String LOCAL_TYPE_1 = "6fd29f52-5c9c-44d0-b529-e9c5eb3a0aba";
   private static final String LOCAL_TYPE_2 = "654d7565-b277-4dfa-8b7d-fbf306d9d0cd";
+  private static final String FOLIO_TYPE = "6e4d7565-b277-4dfa-8b7d-fbf306d9d0cd";
   private static final Instance[] INSTANCES = instances();
   private static final Map<String, Instance> INSTANCE_MAP =
     Arrays.stream(INSTANCES).collect(toMap(Instance::getTitle, identity()));
@@ -136,12 +138,14 @@ class BrowseTypedCallNumberIT extends BaseIntegrationTest {
       .param("expandAll", "true")
       .param("precedingRecordsCount", "4");
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
+
+    var multipleItemsInstance = instance("instance #27");
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
       .totalRecords(12).prev("DB 11 A66 SUPPL NO 11").next("F  PR1866.S63 V.1 C.1").items(List.of(
         cnBrowseItem(instance("instance #23"), "DB 11 A66 SUPPL NO 11"),
         cnBrowseItem(instance("instance #35"), "E 12.11 I12 288 D"),
         cnBrowseItem(instance("instance #33"), "E 12.11 I2 298"),
-        cnBrowseItem(instance("instance #27"), "E 211 A506"),
+        cnBrowseItem(instance(multipleItemsInstance, multipleItemsInstance.getItems().get(0)), "E 211 A506"),
         cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1", true)
       )));
   }
@@ -188,15 +192,14 @@ class BrowseTypedCallNumberIT extends BaseIntegrationTest {
 
   @SuppressWarnings("unchecked")
   private static Instance instance(List<Object> data) {
-    var callNumberTypeId = data.get(2).toString();
-    var items = ((List<String>) data.get(1)).stream()
+    var items = ((List<List<String>>) data.get(1)).stream()
       .map(callNumber -> new Item()
         .id(randomId())
         .discoverySuppress(false)
         .effectiveCallNumberComponents(new ItemEffectiveCallNumberComponents()
-          .callNumber(callNumber).typeId(callNumberTypeId))
-        .effectiveShelvingOrder(getShelfKeyFromCallNumber(callNumber, callNumberTypeId))
-        .effectiveLocationId(callNumberTypeId))
+          .callNumber(callNumber.get(0)).typeId(callNumber.get(1)))
+        .effectiveShelvingOrder(getShelfKeyFromCallNumber(callNumber.get(0), callNumber.get(1)))
+        .effectiveLocationId(callNumber.get(1)))
       .toList();
 
     return new Instance()
@@ -215,55 +218,68 @@ class BrowseTypedCallNumberIT extends BaseIntegrationTest {
     return INSTANCE_MAP.get(title);
   }
 
+  private static Instance instance(Instance instance, Item item) {
+    return new Instance()
+      .id(instance.getId())
+      .title(instance.getTitle())
+      .staffSuppress(instance.getStaffSuppress())
+      .discoverySuppress(instance.getDiscoverySuppress())
+      .isBoundWith(instance.getIsBoundWith())
+      .shared(instance.getShared())
+      .tenantId(instance.getTenantId())
+      .items(singletonList(item))
+      .holdings(instance.getHoldings());
+  }
+
   private static List<List<Object>> callNumberBrowseInstanceData() {
     return List.of(
-      List.of("instance #01", List.of("DA 3880 O6 J72"), LC.getId()),
-      List.of("instance #02", List.of("DA 3880 O6 M96"), LC.getId()),
-      List.of("instance #03", List.of("DA 3880 O6 L5 41955"), LC.getId()),
-      List.of("instance #04", List.of("1CE 16 D86 X 41998"), DEWEY.getId()),
-      List.of("instance #05", List.of("DA 3880 O6 M15"), LC.getId()),
-      List.of("instance #06", List.of("DA 3880 O6 L6 V1"), LC.getId()),
-      List.of("instance #07", List.of("DA 3870 H47 41975"), LC.getId()),
-      List.of("instance #08", List.of("AC 11 A67 X 42000"), NLM.getId()),
-      List.of("instance #09", List.of("DA 3700 C95 NO 18"), LC.getId()),
-      List.of("instance #10", List.of("D1.3201 B34 41972"), SUDOC.getId()),
-      List.of("instance #11", List.of("DA 3880 K56 M27 41984"), LC.getId()),
-      List.of("instance #12", List.of("D1.211 N52 VOL 14"), SUDOC.getId()),
-      List.of("instance #13", List.of("DA 3880 O6 M81"), LC.getId()),
-      List.of("instance #14", List.of("DA 3890 A1 I72 41885"), LC.getId()),
-      List.of("instance #15", List.of("DA 3880 O6 L76"), LC.getId()),
-      List.of("instance #16", List.of("P1.44034 B38 41993"), SUDOC.getId()),
-      List.of("instance #17", List.of("G1.16 A63 41581"), SUDOC.getId()),
-      List.of("instance #18", List.of("AC 11 E8 NO 14 P S1487"), NLM.getId()),
-      List.of("instance #19", List.of("DA 3890 A2 F57 42011"), LC.getId()),
-      List.of("instance #20", List.of("DA 3880 O6 L75"), LC.getId()),
-      List.of("instance #21", List.of("FC 17 B89"), OTHER.getId()),
-      List.of("instance #22", List.of("DA 3890 A2 B76 42002"), LC.getId()),
-      List.of("instance #23", List.of("DB 11 A66 SUPPL NO 11"), LOCAL_TYPE_1),
-      List.of("instance #24", List.of("DA 3900 C39 NO 11"), LC.getId()),
-      List.of("instance #25", List.of("AC 11 A4 VOL 235"), NLM.getId()),
-      List.of("instance #26", List.of("PR 17 I55 42006"), LOCAL_TYPE_1),
-      List.of("instance #27", List.of("E 211 A506"), LOCAL_TYPE_1),
-      List.of("instance #28", List.of("DB 11 A31 BD 3124"), LOCAL_TYPE_2),
-      List.of("instance #29", List.of("DA 3880 O6 D5"), LC.getId()),
-      List.of("instance #30", List.of("GA 16 G32 41557 V1"), LOCAL_TYPE_2),
-      List.of("instance #31", List.of("AB 14 C72 NO 220"), LOCAL_TYPE_1),
-      List.of("instance #32", List.of("DA 3880 O5 C3 V1"), LC.getId()),
-      List.of("instance #33", List.of("E 12.11 I2 298"), LOCAL_TYPE_1),
-      List.of("instance #34", List.of("DA 3900 C89 V1"), LC.getId()),
-      List.of("instance #35", List.of("E 12.11 I12 288 D"), LOCAL_TYPE_2),
-      List.of("instance #36", List.of("DA 3700 B91 L79"), LC.getId()),
-      List.of("instance #37", List.of("FC 17 B89"), LOCAL_TYPE_2),
-      List.of("instance #38", List.of("1CE 210 K297 41858"), DEWEY.getId()),
-      List.of("instance #39", List.of("GA 16 D64 41548A"), OTHER.getId()),
-      List.of("instance #40", List.of("PR 213 E5 41999"), LOCAL_TYPE_2),
-      List.of("instance #41", List.of("DA 3870 B55 41868"), LC.getId()),
-      List.of("instance #42", List.of("FA 46252 3977 12 237"), OTHER.getId()),
-      List.of("instance #43", List.of("FA 42010 3546 256"), OTHER.getId()),
-      List.of("instance #44", List.of("1CE 16 B6713 X 41993"), DEWEY.getId()),
-      List.of("instance #45", List.of("1CE 16 B6724 41993"), DEWEY.getId()),
-      List.of("instance #47", List.of("1CE 16 B6724 41993"), DEWEY.getId()),
-      List.of("instance #46", List.of("F  PR1866.S63 V.1 C.1"), LOCAL_TYPE_1)
+      List.of("instance #01", List.of(List.of("DA 3880 O6 J72", LC.getId()))),
+      List.of("instance #02", List.of(List.of("DA 3880 O6 M96", LC.getId()))),
+      List.of("instance #03", List.of(List.of("DA 3880 O6 L5 41955", LC.getId()))),
+      List.of("instance #04", List.of(List.of("1CE 16 D86 X 41998", DEWEY.getId()))),
+      List.of("instance #05", List.of(List.of("DA 3880 O6 M15", LC.getId()))),
+      List.of("instance #06", List.of(List.of("DA 3880 O6 L6 V1", LC.getId()))),
+      List.of("instance #07", List.of(List.of("DA 3870 H47 41975", LC.getId()))),
+      List.of("instance #08", List.of(List.of("AC 11 A67 X 42000", NLM.getId()))),
+      List.of("instance #09", List.of(List.of("DA 3700 C95 NO 18", LC.getId()))),
+      List.of("instance #10", List.of(List.of("D1.3201 B34 41972", SUDOC.getId()))),
+      List.of("instance #11", List.of(List.of("DA 3880 K56 M27 41984", LC.getId()))),
+      List.of("instance #12", List.of(List.of("D1.211 N52 VOL 14", SUDOC.getId()))),
+      List.of("instance #13", List.of(List.of("DA 3880 O6 M81", LC.getId()))),
+      List.of("instance #14", List.of(List.of("DA 3890 A1 I72 41885", LC.getId()))),
+      List.of("instance #15", List.of(List.of("DA 3880 O6 L76", LC.getId()))),
+      List.of("instance #16", List.of(List.of("P1.44034 B38 41993", SUDOC.getId()))),
+      List.of("instance #17", List.of(List.of("G1.16 A63 41581", SUDOC.getId()))),
+      List.of("instance #18", List.of(List.of("AC 11 E8 NO 14 P S1487", NLM.getId()))),
+      List.of("instance #19", List.of(List.of("DA 3890 A2 F57 42011", LC.getId()))),
+      List.of("instance #20", List.of(List.of("DA 3880 O6 L75", LC.getId()))),
+      List.of("instance #21", List.of(List.of("FC 17 B89", OTHER.getId()))),
+      List.of("instance #22", List.of(List.of("DA 3890 A2 B76 42002", LC.getId()))),
+      List.of("instance #23", List.of(List.of("DB 11 A66 SUPPL NO 11", LOCAL_TYPE_1))),
+      List.of("instance #24", List.of(List.of("DA 3900 C39 NO 11", LC.getId()))),
+      List.of("instance #25", List.of(List.of("AC 11 A4 VOL 235", NLM.getId()))),
+      List.of("instance #26", List.of(List.of("PR 17 I55 42006", LOCAL_TYPE_1))),
+      List.of("instance #27", List.of(List.of("E 211 A506", LOCAL_TYPE_1), List.of("E 311 A506", FOLIO_TYPE))),
+      List.of("instance #28", List.of(List.of("DB 11 A31 BD 3124", LOCAL_TYPE_2))),
+      List.of("instance #29", List.of(List.of("DA 3880 O6 D5", LC.getId()))),
+      List.of("instance #30", List.of(List.of("GA 16 G32 41557 V1", LOCAL_TYPE_2))),
+      List.of("instance #31", List.of(List.of("AB 14 C72 NO 220", LOCAL_TYPE_1))),
+      List.of("instance #32", List.of(List.of("DA 3880 O5 C3 V1", LC.getId()))),
+      List.of("instance #33", List.of(List.of("E 12.11 I2 298", LOCAL_TYPE_1))),
+      List.of("instance #34", List.of(List.of("DA 3900 C89 V1", LC.getId()))),
+      List.of("instance #35", List.of(List.of("E 12.11 I12 288 D", LOCAL_TYPE_2))),
+      List.of("instance #36", List.of(List.of("DA 3700 B91 L79", LC.getId()))),
+      List.of("instance #37", List.of(List.of("FC 17 B89", LOCAL_TYPE_2))),
+      List.of("instance #38", List.of(List.of("1CE 210 K297 41858", DEWEY.getId()))),
+      List.of("instance #39", List.of(List.of("GA 16 D64 41548A", OTHER.getId()))),
+      List.of("instance #40", List.of(List.of("PR 213 E5 41999", LOCAL_TYPE_2))),
+      List.of("instance #41", List.of(List.of("DA 3870 B55 41868", LC.getId()))),
+      List.of("instance #42", List.of(List.of("FA 46252 3977 12 237", OTHER.getId()))),
+      List.of("instance #43", List.of(List.of("FA 42010 3546 256", OTHER.getId()))),
+      List.of("instance #44", List.of(List.of("1CE 16 B6713 X 41993", DEWEY.getId()))),
+      List.of("instance #45", List.of(List.of("1CE 16 B6724 41993", DEWEY.getId()))),
+      List.of("instance #46", List.of(List.of("F  PR1866.S63 V.1 C.1", LOCAL_TYPE_1))),
+      List.of("instance #47", List.of(List.of("1CE 16 B6724 41993", DEWEY.getId())))
     );
   }
 }

--- a/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIrrelevantResultIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIrrelevantResultIT.java
@@ -1,6 +1,7 @@
 package org.folio.search.controller;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
@@ -73,7 +74,7 @@ class BrowseTypedCallNumberIrrelevantResultIT extends BaseIntegrationTest {
         cnBrowseItem(instance("instance #02"), "308 H980"),
         cnBrowseItem(instance("instance #08"), "308 H981")
     ));
-    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems("dewey", expected.getItems()));
+    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems("dewey", emptySet(), expected.getItems()));
     assertThat(actual).isEqualTo(expected);
   }
 
@@ -93,7 +94,7 @@ class BrowseTypedCallNumberIrrelevantResultIT extends BaseIntegrationTest {
         cnBrowseItem(instance("instance #02"), "Z669.R360 1976", 1),
         cnBrowseItem(instance("instance #10"), "Z669.R360 1977", 1)
     ));
-    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems("lc", expected.getItems()));
+    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems("lc", emptySet(), expected.getItems()));
     leaveOnlyBasicProps(expected);
     assertThat(actual).isEqualTo(expected);
   }
@@ -126,7 +127,7 @@ class BrowseTypedCallNumberIrrelevantResultIT extends BaseIntegrationTest {
         cnBrowseItem(instance("instance #02"), "308 H980"),
         cnBrowseItem(instance("instance #08"), "308 H981")
       ));
-    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems("dewey", expected.getItems()));
+    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems("dewey", emptySet(), expected.getItems()));
 
     assertThat(result.getItems()).hasSizeLessThanOrEqualTo(limit);
     assertThat(result).isEqualTo(expected);

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
@@ -24,6 +24,7 @@ import org.folio.search.domain.dto.CallNumberBrowseItem;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
+import org.folio.search.integration.ReferenceDataService;
 import org.folio.search.model.BrowseResult;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.model.service.BrowseRequest;
@@ -74,6 +75,8 @@ class CallNumberBrowseServiceTest {
   private SearchSourceBuilder succeedingQuery;
   @Mock
   private CqlSearchQueryConverter cqlSearchQueryConverter;
+  @Mock
+  private ReferenceDataService referenceDataService;
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/org/folio/search/utils/CallNumberUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/CallNumberUtilsTest.java
@@ -1,6 +1,7 @@
 package org.folio.search.utils;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static org.apache.commons.lang3.StringUtils.compareIgnoreCase;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
@@ -117,9 +118,9 @@ class CallNumberUtilsTest {
   @ParameterizedTest(name = "[{index}] callNumber={0}, records={1}, expected={2}")
   @MethodSource("eliminateIrrelevantItemsOnCallNumberBrowsingData")
   void excludeIrrelevantResultItems(String callNumberType, CallNumberBrowseItem given, CallNumberBrowseItem expected) {
-    var items = CallNumberUtils.excludeIrrelevantResultItems(callNumberType, List.of(given));
+    var items = CallNumberUtils.excludeIrrelevantResultItems(callNumberType, emptySet(), List.of(given));
     assertThat(items).isEqualTo(List.of(expected));
-    var unchangedItems = CallNumberUtils.excludeIrrelevantResultItems("", List.of(given));
+    var unchangedItems = CallNumberUtils.excludeIrrelevantResultItems("", emptySet(), List.of(given));
     assertThat(unchangedItems).isEqualTo(List.of(given));
   }
 

--- a/src/test/resources/mappings/inventory.json
+++ b/src/test/resources/mappings/inventory.json
@@ -165,6 +165,27 @@
     },
     {
       "request": {
+        "method": "GET",
+        "url": "/call-number-types?query=source%3D%3D%28%22folio%22%29&limit=100"
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "callNumberTypes": [
+            {
+              "id": "6e4d7565-b277-4dfa-8b7d-fbf306d9d0cd",
+              "name": "Folio control number",
+              "source": "folio"
+            }
+          ]
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
         "method": "POST",
         "url": "/instance-storage/reindex"
       },


### PR DESCRIPTION
## Purpose
Fix 'folio' source call numbers returned when browsing for 'local'
[MSEARCH-570](https://issues.folio.org/browse/MSEARCH-570)

## Approach
- Get call number types with source="folio" from mod-inventory-storage
- Filter browse results not to include "folio" source when browsing for "local"

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
