### PR TITLE
fix(cn-browse): Add filter on not typed call number when browse local

### DIFF
--- a/src/main/java/org/folio/search/utils/CallNumberUtils.java
+++ b/src/main/java/org/folio/search/utils/CallNumberUtils.java
@@ -210,8 +210,10 @@ public class CallNumberUtils {
     var itemCallNumberType = CallNumberType.fromId(itemCallNumberTypeId);
     var requestCallNumberType = CallNumberType.fromName(callNumberType);
     return itemCallNumberType.equals(requestCallNumberType)
-      || itemCallNumberType.isEmpty() && requestCallNumberType.map(cnt -> cnt.equals(CallNumberType.LOCAL))
-      .orElse(false) && !folioCallNumberTypes.contains(itemCallNumberTypeId);
+      || itemCallNumberTypeId != null
+      && itemCallNumberType.isEmpty()
+      && requestCallNumberType.map(cnt -> cnt.equals(CallNumberType.LOCAL)).orElse(false)
+      && !folioCallNumberTypes.contains(itemCallNumberTypeId);
   }
 
   private static String getFullCallNumber(Item item) {


### PR DESCRIPTION
## Purpose
Remove not typed call numbers from "local" call numbers browse result
[MSEARCH-570](https://issues.folio.org/browse/MSEARCH-570)

## Approach
Add filter on not typed call number when browse local

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
