### PR TITLE
fix(cn-browse) Fix local typed call numbers not being indexing because of old cache

### DIFF
--- a/src/main/java/org/folio/search/integration/ReferenceDataService.java
+++ b/src/main/java/org/folio/search/integration/ReferenceDataService.java
@@ -1,7 +1,6 @@
 package org.folio.search.integration;
 
 import static java.util.stream.Collectors.toSet;
-import static org.folio.search.configuration.SearchCacheNames.REFERENCE_DATA_CACHE;
 import static org.folio.search.model.client.CqlQuery.exactMatchAny;
 
 import java.util.Collection;
@@ -13,7 +12,6 @@ import org.folio.search.client.InventoryReferenceDataClient;
 import org.folio.search.client.InventoryReferenceDataClient.ReferenceDataType;
 import org.folio.search.model.client.CqlQueryParam;
 import org.folio.search.model.service.ReferenceRecord;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Log4j2
@@ -25,8 +23,8 @@ public class ReferenceDataService {
 
   private final InventoryReferenceDataClient inventoryReferenceDataClient;
 
-  @Cacheable(cacheNames = REFERENCE_DATA_CACHE, unless = "#result.isEmpty()",
-             key = "@folioExecutionContext.tenantId + ':' + #values + ':' + #type.toString() + ':' + #param.toString()")
+//  @Cacheable(cacheNames = REFERENCE_DATA_CACHE, unless = "#result.isEmpty()",
+//             key = "@folioExecutionContext.tenantId + ':' + #values + ':' + #type.toString() + ':' + #param.toString()")
   public Set<String> fetchReferenceData(ReferenceDataType type, CqlQueryParam param, Collection<String> values) {
     log.info("Fetching reference [type: {}, field: {}, values: {}]", type.toString(), param.toString(), values);
     var uri = type.getUri();

--- a/src/main/java/org/folio/search/integration/ReferenceDataService.java
+++ b/src/main/java/org/folio/search/integration/ReferenceDataService.java
@@ -1,6 +1,7 @@
 package org.folio.search.integration;
 
 import static java.util.stream.Collectors.toSet;
+import static org.folio.search.configuration.SearchCacheNames.REFERENCE_DATA_CACHE;
 import static org.folio.search.model.client.CqlQuery.exactMatchAny;
 
 import java.util.Collection;
@@ -12,6 +13,7 @@ import org.folio.search.client.InventoryReferenceDataClient;
 import org.folio.search.client.InventoryReferenceDataClient.ReferenceDataType;
 import org.folio.search.model.client.CqlQueryParam;
 import org.folio.search.model.service.ReferenceRecord;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Log4j2
@@ -23,8 +25,8 @@ public class ReferenceDataService {
 
   private final InventoryReferenceDataClient inventoryReferenceDataClient;
 
-  //  @Cacheable(cacheNames = REFERENCE_DATA_CACHE, unless = "#result.isEmpty()",
-  //        key = "@folioExecutionContext.tenantId + ':' + #values + ':' + #type.toString() + ':' + #param.toString()")
+  @Cacheable(cacheNames = REFERENCE_DATA_CACHE, unless = "#result.isEmpty()",
+             key = "@folioExecutionContext.tenantId + ':' + #values + ':' + #type.toString() + ':' + #param.toString()")
   public Set<String> fetchReferenceData(ReferenceDataType type, CqlQueryParam param, Collection<String> values) {
     log.info("Fetching reference [type: {}, field: {}, values: {}]", type.toString(), param.toString(), values);
     var uri = type.getUri();

--- a/src/main/java/org/folio/search/integration/ReferenceDataService.java
+++ b/src/main/java/org/folio/search/integration/ReferenceDataService.java
@@ -23,8 +23,8 @@ public class ReferenceDataService {
 
   private final InventoryReferenceDataClient inventoryReferenceDataClient;
 
-//  @Cacheable(cacheNames = REFERENCE_DATA_CACHE, unless = "#result.isEmpty()",
-//             key = "@folioExecutionContext.tenantId + ':' + #values + ':' + #type.toString() + ':' + #param.toString()")
+  //  @Cacheable(cacheNames = REFERENCE_DATA_CACHE, unless = "#result.isEmpty()",
+  //        key = "@folioExecutionContext.tenantId + ':' + #values + ':' + #type.toString() + ':' + #param.toString()")
   public Set<String> fetchReferenceData(ReferenceDataType type, CqlQueryParam param, Collection<String> values) {
     log.info("Fetching reference [type: {}, field: {}, values: {}]", type.toString(), param.toString(), values);
     var uri = type.getUri();

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBrowseItem> {
 
-  static final List<String> FOLIO_CALL_NUMBER_TYPES_SOURCES = Collections.singletonList(FOLIO.getSource());
+  public static final List<String> FOLIO_CALL_NUMBER_TYPES_SOURCES = Collections.singletonList(FOLIO.getSource());
   private static final int ADDITIONAL_REQUEST_SIZE = 100;
   private static final int ADDITIONAL_REQUEST_SIZE_MAX = 500;
   private final SearchRepository searchRepository;

--- a/src/main/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessor.java
@@ -42,9 +42,10 @@ public class ItemTypedCallNumberProcessor implements FieldProcessor<Instance, Se
   }
 
   public Optional<Integer> getCallNumberTypedPrefix(String callNumberTypeId) {
-    boolean isLocal = isLocalCallNumberTypeId(callNumberTypeId);
-    return isLocal ? Optional.of(CallNumberType.LOCAL.getNumber())
-                   : CallNumberType.fromId(callNumberTypeId).map(CallNumberType::getNumber);
+    return CallNumberType.fromId(callNumberTypeId)
+      .map(CallNumberType::getNumber)
+      .or(() -> isLocalCallNumberTypeId(callNumberTypeId)
+        ? Optional.of(CallNumberType.LOCAL.getNumber()) : Optional.empty());
   }
 
   private Long toCallNumberLongRepresentation(Item item) {

--- a/src/main/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessor.java
@@ -3,6 +3,7 @@ package org.folio.search.service.setter.item;
 import static org.folio.search.client.InventoryReferenceDataClient.ReferenceDataType.CALL_NUMBER_TYPES;
 import static org.folio.search.model.client.CqlQueryParam.SOURCE;
 import static org.folio.search.model.types.CallNumberTypeSource.LOCAL;
+import static org.folio.search.service.browse.CallNumberBrowseService.FOLIO_CALL_NUMBER_TYPES_SOURCES;
 import static org.folio.search.utils.CallNumberUtils.getCallNumberAsLong;
 import static org.folio.search.utils.CollectionUtils.toLinkedHashSet;
 import static org.folio.search.utils.CollectionUtils.toStreamSafe;
@@ -61,7 +62,7 @@ public class ItemTypedCallNumberProcessor implements FieldProcessor<Instance, Se
   }
 
   private boolean isLocalCallNumberTypeId(String callNumberTypeId) {
-    return referenceDataService.fetchReferenceData(CALL_NUMBER_TYPES, SOURCE, LOCAL_CALL_NUMBER_TYPES_SOURCES)
+    return !referenceDataService.fetchReferenceData(CALL_NUMBER_TYPES, SOURCE, FOLIO_CALL_NUMBER_TYPES_SOURCES)
       .contains(callNumberTypeId);
   }
 

--- a/src/test/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessorTest.java
@@ -1,13 +1,8 @@
 package org.folio.search.service.setter.item;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.folio.search.client.InventoryReferenceDataClient.ReferenceDataType.CALL_NUMBER_TYPES;
-import static org.folio.search.model.client.CqlQueryParam.SOURCE;
-import static org.folio.search.service.setter.item.ItemTypedCallNumberProcessor.LOCAL_CALL_NUMBER_TYPES_SOURCES;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.folio.search.domain.dto.Instance;
@@ -35,12 +30,8 @@ class ItemTypedCallNumberProcessorTest {
 
   @Test
   void getFieldValue_multipleValue_positive() {
-    var localCnId = UUID.randomUUID().toString();
-
-    when(referenceDataService.fetchReferenceData(CALL_NUMBER_TYPES, SOURCE, LOCAL_CALL_NUMBER_TYPES_SOURCES))
-      .thenReturn(Set.of(localCnId));
     var eventBody = instance(
-      item("HD 11", localCnId),
+      item("HD 11", UUID.randomUUID().toString()),
       item("HD 11", CallNumberType.LC.getId()),
       item("HD 11", CallNumberType.DEWEY.getId()),
       item("HD 11", CallNumberType.NLM.getId()),
@@ -60,13 +51,6 @@ class ItemTypedCallNumberProcessorTest {
   @MethodSource("emptyCallNumberAfterProcessingSource")
   void getFieldValue_emptyCallNumberAfterProcessing(String effectiveShelvingOrder, String callNumberTypeId) {
     var eventBody = instance(item(effectiveShelvingOrder, callNumberTypeId));
-    var actual = processor.getFieldValue(eventBody);
-    assertThat(actual).isEmpty();
-  }
-
-  @Test
-  void getFieldValue_emptyCallNumberIfNotSystemOrNotLocal() {
-    var eventBody = instance(item("AA 123", UUID.randomUUID().toString()));
     var actual = processor.getFieldValue(eventBody);
     assertThat(actual).isEmpty();
   }


### PR DESCRIPTION
## Purpose
Fix local call numbers not shown in result list for browsing by "local" call number type
[MSEARCH-601](https://issues.folio.org/browse/MSEARCH-601)

## Approach
Query "folio" source call numbers and consider call number "local" if absent in list

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
