### PR TITLE
MSEARCH-589 "Exact full match" operator doesn't work for alias fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </sonar.exclusions>
 
     <folio-spring-support.version>7.2.0</folio-spring-support.version>
-    <folio-service-tools.version>3.1.0-SNAPSHOT</folio-service-tools.version>
+    <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <folio-isbn-utils.version>1.5.0</folio-isbn-utils.version>
     <folio-cql2pgjson.version>35.0.6</folio-cql2pgjson.version>
     <opensearch.version>2.9.0</opensearch.version>

--- a/src/main/java/org/folio/search/cql/CqlTermQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlTermQueryConverter.java
@@ -21,6 +21,7 @@ import org.folio.search.exception.ValidationException;
 import org.folio.search.model.metadata.PlainFieldDescription;
 import org.folio.search.service.metadata.LocalSearchFieldProvider;
 import org.folio.search.service.metadata.SearchFieldProvider;
+import org.folio.search.utils.SearchUtils;
 import org.opensearch.index.query.QueryBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
@@ -31,6 +32,7 @@ import org.z3950.zing.cql.Modifier;
 public class CqlTermQueryConverter {
 
   public static final String WILDCARD_OPERATOR = "wildcard";
+  public static final String STRING_MODIFIER = "string";
   private static final String MATCH_ALL_CQL_QUERY = "cql.allRecords = 1";
   private static final String KEYWORD_ALL_CQL_QUERY = "keyword = *";
 
@@ -89,7 +91,16 @@ public class CqlTermQueryConverter {
         "Failed to parse CQL query. Comparator '%s' is not supported.", comparator));
     }
 
+    var modifiers = termNode.getRelation().getModifiers().stream()
+      .map(Modifier::getType)
+      .toList();
+
     if (CollectionUtils.isNotEmpty(fieldsList)) {
+      if (modifiers.contains(STRING_MODIFIER)) {
+        var updatedFieldsList = getUpdatedFields(fieldsList);
+        return termQueryBuilder.getQuery(searchTerm, resource, updatedFieldsList.toArray(String[]::new));
+      }
+
       return termQueryBuilder.getQuery(searchTerm, resource, fieldsList.toArray(String[]::new));
     }
 
@@ -98,13 +109,15 @@ public class CqlTermQueryConverter {
     var index = plainFieldByPath.getIndex();
     validateIndexFormat(index, termNode);
 
-    var modifiers = termNode.getRelation().getModifiers().stream()
-      .map(Modifier::getType)
-      .toList();
-
     return plainFieldByPath.hasFulltextIndex()
            ? termQueryBuilder.getFulltextQuery(searchTerm, fieldName, resource, modifiers)
            : termQueryBuilder.getTermLevelQuery(searchTerm, fieldName, resource, index);
+  }
+
+  private static List<String> getUpdatedFields(List<String> fieldsList) {
+    return fieldsList.stream()
+      .map(SearchUtils::updatePathForTermQueries)
+      .toList();
   }
 
   private Object getSearchTerm(String term, Optional<PlainFieldDescription> plainFieldDescription) {

--- a/src/main/java/org/folio/search/cql/CqlTermQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlTermQueryConverter.java
@@ -21,7 +21,6 @@ import org.folio.search.exception.ValidationException;
 import org.folio.search.model.metadata.PlainFieldDescription;
 import org.folio.search.service.metadata.LocalSearchFieldProvider;
 import org.folio.search.service.metadata.SearchFieldProvider;
-import org.folio.search.utils.SearchUtils;
 import org.opensearch.index.query.QueryBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
@@ -32,7 +31,6 @@ import org.z3950.zing.cql.Modifier;
 public class CqlTermQueryConverter {
 
   public static final String WILDCARD_OPERATOR = "wildcard";
-  public static final String STRING_MODIFIER = "string";
   private static final String MATCH_ALL_CQL_QUERY = "cql.allRecords = 1";
   private static final String KEYWORD_ALL_CQL_QUERY = "keyword = *";
 
@@ -96,12 +94,7 @@ public class CqlTermQueryConverter {
       .toList();
 
     if (CollectionUtils.isNotEmpty(fieldsList)) {
-      if (modifiers.contains(STRING_MODIFIER)) {
-        var updatedFieldsList = getUpdatedFields(fieldsList);
-        return termQueryBuilder.getQuery(searchTerm, resource, updatedFieldsList.toArray(String[]::new));
-      }
-
-      return termQueryBuilder.getQuery(searchTerm, resource, fieldsList.toArray(String[]::new));
+      return termQueryBuilder.getQuery(searchTerm, resource, modifiers, fieldsList.toArray(String[]::new));
     }
 
     var plainFieldByPath = optionalPlainFieldByPath.orElseThrow(() -> new RequestValidationException(
@@ -112,12 +105,6 @@ public class CqlTermQueryConverter {
     return plainFieldByPath.hasFulltextIndex()
            ? termQueryBuilder.getFulltextQuery(searchTerm, fieldName, resource, modifiers)
            : termQueryBuilder.getTermLevelQuery(searchTerm, fieldName, resource, index);
-  }
-
-  private static List<String> getUpdatedFields(List<String> fieldsList) {
-    return fieldsList.stream()
-      .map(SearchUtils::updatePathForTermQueries)
-      .toList();
   }
 
   private Object getSearchTerm(String term, Optional<PlainFieldDescription> plainFieldDescription) {

--- a/src/main/java/org/folio/search/cql/builders/AllTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/AllTermQueryBuilder.java
@@ -21,7 +21,7 @@ public class AllTermQueryBuilder extends FulltextQueryBuilder {
   private static final Pattern SPLITERATOR = Pattern.compile("([^\\s:\\/&]+)");
 
   @Override
-  public QueryBuilder getQuery(Object term, String resource, String... fields) {
+  public QueryBuilder getQuery(Object term, String resource, List<String> modifiers, String... fields) {
     if (term instanceof String stringTerm) {
 
       List<String> terms = new ArrayList<>();
@@ -44,7 +44,7 @@ public class AllTermQueryBuilder extends FulltextQueryBuilder {
 
   @Override
   public QueryBuilder getFulltextQuery(Object term, String fieldName, String resource, List<String> modifiers) {
-    return getQuery(term, resource, updatePathForFulltextQuery(resource, fieldName));
+    return getQuery(term, resource, modifiers, updatePathForFulltextQuery(resource, fieldName));
   }
 
   @Override

--- a/src/main/java/org/folio/search/cql/builders/AnyTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/AnyTermQueryBuilder.java
@@ -12,13 +12,13 @@ import org.springframework.stereotype.Component;
 public class AnyTermQueryBuilder extends FulltextQueryBuilder {
 
   @Override
-  public QueryBuilder getQuery(Object term, String resource, String... fields) {
+  public QueryBuilder getQuery(Object term, String resource, List<String> modifiers, String... fields) {
     return multiMatchQuery(term, fields);
   }
 
   @Override
   public QueryBuilder getFulltextQuery(Object term, String fieldName, String resource, List<String> modifiers) {
-    return getQuery(term, resource, updatePathForFulltextQuery(resource, fieldName));
+    return getQuery(term, resource, modifiers, updatePathForFulltextQuery(resource, fieldName));
   }
 
   @Override

--- a/src/main/java/org/folio/search/cql/builders/EqualTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/EqualTermQueryBuilder.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 public class EqualTermQueryBuilder extends FulltextQueryBuilder {
 
   @Override
-  public QueryBuilder getQuery(Object term, String resource, String... fields) {
+  public QueryBuilder getQuery(Object term, String resource, List<String> modifiers, String... fields) {
     return fields.length == 1 && isEmptyString(term)
            ? existsQuery(updatePathForTermQueries(resource, fields[0]))
            : multiMatchQuery(term, fields).operator(AND).type(CROSS_FIELDS);
@@ -27,7 +27,7 @@ public class EqualTermQueryBuilder extends FulltextQueryBuilder {
   public QueryBuilder getFulltextQuery(Object term, String fieldName, String resource, List<String> modifiers) {
     return isEmptyString(term)
            ? existsQuery(getPathToFulltextPlainValue(fieldName))
-           : getQuery(term, resource, updatePathForFulltextQuery(resource, fieldName));
+           : getQuery(term, resource, modifiers, updatePathForFulltextQuery(resource, fieldName));
   }
 
   @Override

--- a/src/main/java/org/folio/search/cql/builders/GtTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/GtTermQueryBuilder.java
@@ -2,6 +2,7 @@ package org.folio.search.cql.builders;
 
 import static org.opensearch.index.query.QueryBuilders.rangeQuery;
 
+import java.util.List;
 import java.util.Set;
 import org.opensearch.index.query.QueryBuilder;
 import org.springframework.stereotype.Component;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class GtTermQueryBuilder implements RangeTermQueryBuilder {
 
   @Override
-  public QueryBuilder getQuery(Object term, String resource, String... fields) {
+  public QueryBuilder getQuery(Object term, String resource, List<String> modifiers, String... fields) {
     return getRangeQuery(fields).gt(term);
   }
 

--- a/src/main/java/org/folio/search/cql/builders/GteTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/GteTermQueryBuilder.java
@@ -2,6 +2,7 @@ package org.folio.search.cql.builders;
 
 import static org.opensearch.index.query.QueryBuilders.rangeQuery;
 
+import java.util.List;
 import java.util.Set;
 import org.opensearch.index.query.QueryBuilder;
 import org.springframework.stereotype.Component;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class GteTermQueryBuilder implements RangeTermQueryBuilder {
 
   @Override
-  public QueryBuilder getQuery(Object term, String resource, String... fields) {
+  public QueryBuilder getQuery(Object term, String resource, List<String> modifiers, String... fields) {
     return getRangeQuery(fields).gte(term);
   }
 

--- a/src/main/java/org/folio/search/cql/builders/LtTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/LtTermQueryBuilder.java
@@ -2,6 +2,7 @@ package org.folio.search.cql.builders;
 
 import static org.opensearch.index.query.QueryBuilders.rangeQuery;
 
+import java.util.List;
 import java.util.Set;
 import org.opensearch.index.query.QueryBuilder;
 import org.springframework.stereotype.Component;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class LtTermQueryBuilder implements RangeTermQueryBuilder {
 
   @Override
-  public QueryBuilder getQuery(Object term, String resource, String... fields) {
+  public QueryBuilder getQuery(Object term, String resource, List<String> modifiers, String... fields) {
     return getRangeQuery(fields).lt(term);
   }
 

--- a/src/main/java/org/folio/search/cql/builders/LteTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/LteTermQueryBuilder.java
@@ -2,6 +2,7 @@ package org.folio.search.cql.builders;
 
 import static org.opensearch.index.query.QueryBuilders.rangeQuery;
 
+import java.util.List;
 import java.util.Set;
 import org.opensearch.index.query.QueryBuilder;
 import org.springframework.stereotype.Component;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class LteTermQueryBuilder implements RangeTermQueryBuilder {
 
   @Override
-  public QueryBuilder getQuery(Object term, String resource, String... fields) {
+  public QueryBuilder getQuery(Object term, String resource, List<String> modifiers, String... fields) {
     return getRangeQuery(fields).lte(term);
   }
 

--- a/src/main/java/org/folio/search/cql/builders/NotEqualToTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/NotEqualToTermQueryBuilder.java
@@ -15,13 +15,13 @@ import org.springframework.stereotype.Component;
 public class NotEqualToTermQueryBuilder extends FulltextQueryBuilder {
 
   @Override
-  public QueryBuilder getQuery(Object term, String resource, String... fields) {
+  public QueryBuilder getQuery(Object term, String resource, List<String> modifiers, String... fields) {
     return boolQuery().mustNot(multiMatchQuery(term, fields).operator(AND).type(CROSS_FIELDS));
   }
 
   @Override
   public QueryBuilder getFulltextQuery(Object term, String fieldName, String resource, List<String> modifiers) {
-    return getQuery(term, resource, updatePathForFulltextQuery(resource, fieldName));
+    return getQuery(term, resource, modifiers, updatePathForFulltextQuery(resource, fieldName));
   }
 
   @Override

--- a/src/main/java/org/folio/search/cql/builders/TermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/TermQueryBuilder.java
@@ -13,10 +13,11 @@ public interface TermQueryBuilder {
    *
    * @param term     search term as {@link String} object
    * @param resource resource name for querying as {@link String object}
+   * @param modifiers search term modifiers
    * @param fields   resource fields name as {@code array} of {@link String} objects
    * @return Elasticsearch {@link QueryBuilder} object
    */
-  default QueryBuilder getQuery(Object term, String resource, String... fields) {
+  default QueryBuilder getQuery(Object term, String resource, List<String> modifiers, String... fields) {
     throw unsupportedException(fields);
   }
 

--- a/src/main/java/org/folio/search/cql/builders/WildcardTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/WildcardTermQueryBuilder.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class WildcardTermQueryBuilder extends FulltextQueryBuilder {
 
   @Override
-  public QueryBuilder getQuery(Object term, String resource, String... fields) {
+  public QueryBuilder getQuery(Object term, String resource, List<String> modifiers, String... fields) {
     if (fields.length == 1) {
       return getWildcardQuery(term, updatePathForTermQueries(resource, fields[0]));
     }

--- a/src/test/java/org/folio/search/controller/SearchInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceIT.java
@@ -396,6 +396,8 @@ class SearchInstanceIT extends BaseIntegrationTest {
       arguments("(keyword all \"{value}\")", "A semantic web primer : wolves"),
       arguments("(keyword all \"{value}\")", "A semantic web primer & wolves"),
       arguments("(keyword all \"{value}\")", "A semantic web primer / wolves"),
+      arguments("keyword == {value}", "Van Harmelen, Frank"),
+      arguments("keyword ==/string {value}", "0262012103"),
       arguments("(title all \"{value}\")", "A semantic web primer : 0747-0850")
     );
   }

--- a/src/test/java/org/folio/search/cql/CqlTermQueryConverterTest.java
+++ b/src/test/java/org/folio/search/cql/CqlTermQueryConverterTest.java
@@ -3,6 +3,7 @@ package org.folio.search.cql;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.utils.TestConstants.EMPTY_TERM_MODIFIERS;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestUtils.keywordField;
 import static org.folio.search.utils.TestUtils.multilangField;
@@ -73,7 +74,8 @@ class CqlTermQueryConverterTest {
   void getQuery_positive_fieldsGroupMultiMatch() {
     var expectedQuery = multiMatchQuery("book", "title.*", "subjects.*");
     when(searchFieldProvider.getFields(RESOURCE_NAME, "keyword")).thenReturn(List.of("title.*", "subjects.*"));
-    when(termQueryBuilder.getQuery("book", RESOURCE_NAME, "title.*", "subjects.*")).thenReturn(expectedQuery);
+    when(termQueryBuilder.getQuery("book", RESOURCE_NAME,
+      EMPTY_TERM_MODIFIERS, "title.*", "subjects.*")).thenReturn(expectedQuery);
     var actual = cqlTermQueryConverter.getQuery(cqlTermNode("keyword all book"), RESOURCE_NAME);
     assertThat(actual).isEqualTo(expectedQuery);
   }
@@ -82,7 +84,8 @@ class CqlTermQueryConverterTest {
   void getQuery_positive_fieldsGroupWildcardQuery() {
     var expectedQuery = wildcardQuery("plain_title", "book*");
     when(searchFieldProvider.getFields(RESOURCE_NAME, "keyword")).thenReturn(List.of("title.*"));
-    when(wildcardQueryBuilder.getQuery("book*", RESOURCE_NAME, "title.*")).thenReturn(expectedQuery);
+    when(wildcardQueryBuilder.getQuery("book*", RESOURCE_NAME,
+      EMPTY_TERM_MODIFIERS, "title.*")).thenReturn(expectedQuery);
     var actual = cqlTermQueryConverter.getQuery(cqlTermNode("keyword all book*"), RESOURCE_NAME);
     assertThat(actual).isEqualTo(expectedQuery);
   }
@@ -95,7 +98,8 @@ class CqlTermQueryConverterTest {
 
     when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, "callNumber")).thenReturn(Optional.of(fieldDesc));
     when(searchTermProcessor.getSearchTerm("A")).thenReturn(100L);
-    when(termQueryBuilder.getTermLevelQuery(100L, "callNumber", RESOURCE_NAME, "long")).thenReturn(expectedQuery);
+    when(termQueryBuilder.getTermLevelQuery(100L, "callNumber",
+      RESOURCE_NAME, "long")).thenReturn(expectedQuery);
 
     var actual = cqlTermQueryConverter.getQuery(cqlTermNode("callNumber all A"), RESOURCE_NAME);
 
@@ -110,7 +114,8 @@ class CqlTermQueryConverterTest {
     var fieldDesc = plainField("long");
     fieldDesc.setSearchTermProcessor("processor");
 
-    when(termQueryBuilder.getQuery(100L, RESOURCE_NAME, fieldSearchAlias)).thenReturn(expectedQuery);
+    when(termQueryBuilder.getQuery(100L, RESOURCE_NAME,
+      EMPTY_TERM_MODIFIERS, fieldSearchAlias)).thenReturn(expectedQuery);
     when(searchFieldProvider.getFields(RESOURCE_NAME, fieldName)).thenReturn(List.of(fieldSearchAlias));
     when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, fieldSearchAlias)).thenReturn(Optional.of(fieldDesc));
     when(searchTermProcessor.getSearchTerm("value")).thenReturn(100L);
@@ -131,7 +136,8 @@ class CqlTermQueryConverterTest {
   @Test
   void getQuery_positive_singleMultilangField() {
     var expectedQuery = multiMatchQuery("book", "subjects.*");
-    when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, "subjects")).thenReturn(Optional.of(multilangField()));
+    when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME,
+      "subjects")).thenReturn(Optional.of(multilangField()));
     when(termQueryBuilder.getFulltextQuery("book", "subjects", RESOURCE_NAME, emptyList()))
       .thenReturn(expectedQuery);
     var actual = cqlTermQueryConverter.getQuery(cqlTermNode("subjects all book"), RESOURCE_NAME);
@@ -141,8 +147,10 @@ class CqlTermQueryConverterTest {
   @Test
   void getQuery_positive_singleKeywordField() {
     var expectedQuery = termQuery("subjects", "book");
-    when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, "subjects")).thenReturn(Optional.of(keywordField()));
-    when(termQueryBuilder.getTermLevelQuery("book", "subjects", RESOURCE_NAME, "keyword")).thenReturn(expectedQuery);
+    when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME,
+      "subjects")).thenReturn(Optional.of(keywordField()));
+    when(termQueryBuilder.getTermLevelQuery("book", "subjects",
+      RESOURCE_NAME, "keyword")).thenReturn(expectedQuery);
     var actual = cqlTermQueryConverter.getQuery(cqlTermNode("subjects all book"), RESOURCE_NAME);
     assertThat(actual).isEqualTo(expectedQuery);
   }
@@ -153,9 +161,11 @@ class CqlTermQueryConverterTest {
     fieldDescription.setSearchTermProcessor("processor");
     var expectedQuery = termQuery("subjects", "test");
 
-    when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, "subjects")).thenReturn(Optional.of(fieldDescription));
+    when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME,
+      "subjects")).thenReturn(Optional.of(fieldDescription));
     when(searchTermProcessor.getSearchTerm("book")).thenReturn("test");
-    when(termQueryBuilder.getTermLevelQuery("test", "subjects", RESOURCE_NAME, "keyword")).thenReturn(expectedQuery);
+    when(termQueryBuilder.getTermLevelQuery("test", "subjects",
+      RESOURCE_NAME, "keyword")).thenReturn(expectedQuery);
 
     var actual = cqlTermQueryConverter.getQuery(cqlTermNode("subjects all book"), RESOURCE_NAME);
 

--- a/src/test/java/org/folio/search/cql/builders/AllTermQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/cql/builders/AllTermQueryBuilderTest.java
@@ -2,6 +2,7 @@ package org.folio.search.cql.builders;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.TestConstants.EMPTY_TERM_MODIFIERS;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestUtils.multilangField;
 import static org.folio.search.utils.TestUtils.standardField;
@@ -33,7 +34,7 @@ class AllTermQueryBuilderTest {
 
   @Test
   void getQuery_positive() {
-    var actual = queryBuilder.getQuery("value1 value2", RESOURCE_NAME, "f1.*", "f2");
+    var actual = queryBuilder.getQuery("value1 value2", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "f1.*", "f2");
     assertThat(actual).isEqualTo(boolQuery()
       .must(getMultiMatchQuery("value1", "f1.*", "f2"))
       .must(getMultiMatchQuery("value2", "f1.*", "f2")));

--- a/src/test/java/org/folio/search/cql/builders/AnyTermQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/cql/builders/AnyTermQueryBuilderTest.java
@@ -2,6 +2,7 @@ package org.folio.search.cql.builders;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.TestConstants.EMPTY_TERM_MODIFIERS;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestUtils.multilangField;
 import static org.folio.search.utils.TestUtils.standardField;
@@ -29,7 +30,7 @@ class AnyTermQueryBuilderTest {
 
   @Test
   void getQuery_positive() {
-    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, "f1.*", "f2");
+    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "f1.*", "f2");
     assertThat(actual).isEqualTo(multiMatchQuery("value", "f1.*", "f2"));
   }
 

--- a/src/test/java/org/folio/search/cql/builders/EqualTermQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/cql/builders/EqualTermQueryBuilderTest.java
@@ -2,6 +2,7 @@ package org.folio.search.cql.builders;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.TestConstants.EMPTY_TERM_MODIFIERS;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestUtils.keywordField;
 import static org.folio.search.utils.TestUtils.multilangField;
@@ -33,20 +34,20 @@ class EqualTermQueryBuilderTest {
 
   @Test
   void getQuery_positive() {
-    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, "f1.*", "f2");
+    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "f1.*", "f2");
     assertThat(actual).isEqualTo(multiMatchQuery("value", "f1.*", "f2").operator(AND).type(CROSS_FIELDS));
   }
 
   @Test
   void getQuery_positive_emptyValueAndSingleMultilangFieldWithAlias() {
-    var actual = queryBuilder.getQuery("", RESOURCE_NAME, "f1.*");
+    var actual = queryBuilder.getQuery("", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "f1.*");
     assertThat(actual).isEqualTo(existsQuery("plain_f1"));
   }
 
   @Test
   void getQuery_positive_emptyValueAndSingleKeywordField() {
     when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, "field")).thenReturn(Optional.of(keywordField()));
-    var actual = queryBuilder.getQuery("", RESOURCE_NAME, "field");
+    var actual = queryBuilder.getQuery("", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "field");
     assertThat(actual).isEqualTo(existsQuery("field"));
   }
 

--- a/src/test/java/org/folio/search/cql/builders/ExactTermQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/cql/builders/ExactTermQueryBuilderTest.java
@@ -2,7 +2,9 @@ package org.folio.search.cql.builders;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.TestConstants.EMPTY_TERM_MODIFIERS;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
+import static org.folio.search.utils.TestConstants.STRING_TERM_MODIFIERS;
 import static org.folio.search.utils.TestUtils.multilangField;
 import static org.folio.search.utils.TestUtils.standardField;
 import static org.mockito.Mockito.when;
@@ -33,8 +35,14 @@ class ExactTermQueryBuilderTest {
 
   @Test
   void getQuery_positive() {
-    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, "f1.*", "f2");
+    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "f1.*", "f2");
     assertThat(actual).isEqualTo(multiMatchQuery("value", "f1.*", "f2").type(PHRASE));
+  }
+
+  @Test
+  void getQuery_positive_stringModifier() {
+    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, STRING_TERM_MODIFIERS, "f1.*", "f2");
+    assertThat(actual).isEqualTo(multiMatchQuery("value", "plain_f1", "f2").type(PHRASE));
   }
 
   @Test

--- a/src/test/java/org/folio/search/cql/builders/GtTermQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/cql/builders/GtTermQueryBuilderTest.java
@@ -3,6 +3,7 @@ package org.folio.search.cql.builders;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.utils.TestConstants.EMPTY_TERM_MODIFIERS;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.opensearch.index.query.QueryBuilders.rangeQuery;
 
@@ -16,13 +17,13 @@ class GtTermQueryBuilderTest {
 
   @Test
   void getQuery_positive_singleField() {
-    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, "field");
+    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "field");
     assertThat(actual).isEqualTo(rangeQuery("field").gt("value"));
   }
 
   @Test
   void getQuery_positive() {
-    assertThatThrownBy(() -> queryBuilder.getQuery("value", RESOURCE_NAME, "f1.*", "f2"))
+    assertThatThrownBy(() -> queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "f1.*", "f2"))
       .isInstanceOf(UnsupportedOperationException.class)
       .hasMessage("Query is not supported yet [operator(s): [>], field(s): [f1.*, f2]]");
   }

--- a/src/test/java/org/folio/search/cql/builders/GteTermQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/cql/builders/GteTermQueryBuilderTest.java
@@ -3,6 +3,7 @@ package org.folio.search.cql.builders;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.utils.TestConstants.EMPTY_TERM_MODIFIERS;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.opensearch.index.query.QueryBuilders.rangeQuery;
 
@@ -16,13 +17,13 @@ class GteTermQueryBuilderTest {
 
   @Test
   void getQuery_positive_singleField() {
-    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, "field");
+    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "field");
     assertThat(actual).isEqualTo(rangeQuery("field").gte("value"));
   }
 
   @Test
   void getQuery_positive() {
-    assertThatThrownBy(() -> queryBuilder.getQuery("value", RESOURCE_NAME, "f1.*", "f2"))
+    assertThatThrownBy(() -> queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "f1.*", "f2"))
       .isInstanceOf(UnsupportedOperationException.class)
       .hasMessage("Query is not supported yet [operator(s): [>=], field(s): [f1.*, f2]]");
   }

--- a/src/test/java/org/folio/search/cql/builders/LtTermQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/cql/builders/LtTermQueryBuilderTest.java
@@ -3,6 +3,7 @@ package org.folio.search.cql.builders;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.utils.TestConstants.EMPTY_TERM_MODIFIERS;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.opensearch.index.query.QueryBuilders.rangeQuery;
 
@@ -16,13 +17,13 @@ class LtTermQueryBuilderTest {
 
   @Test
   void getQuery_positive_singleField() {
-    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, "field");
+    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "field");
     assertThat(actual).isEqualTo(rangeQuery("field").lt("value"));
   }
 
   @Test
   void getQuery_positive() {
-    assertThatThrownBy(() -> queryBuilder.getQuery("value", RESOURCE_NAME, "f1.*", "f2"))
+    assertThatThrownBy(() -> queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "f1.*", "f2"))
       .isInstanceOf(UnsupportedOperationException.class)
       .hasMessage("Query is not supported yet [operator(s): [<], field(s): [f1.*, f2]]");
   }

--- a/src/test/java/org/folio/search/cql/builders/LteTermQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/cql/builders/LteTermQueryBuilderTest.java
@@ -3,6 +3,7 @@ package org.folio.search.cql.builders;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.utils.TestConstants.EMPTY_TERM_MODIFIERS;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.opensearch.index.query.QueryBuilders.rangeQuery;
 
@@ -16,13 +17,13 @@ class LteTermQueryBuilderTest {
 
   @Test
   void getQuery_positive_singleField() {
-    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, "field");
+    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "field");
     assertThat(actual).isEqualTo(rangeQuery("field").lte("value"));
   }
 
   @Test
   void getQuery_positive() {
-    assertThatThrownBy(() -> queryBuilder.getQuery("value", RESOURCE_NAME, "f1.*", "f2"))
+    assertThatThrownBy(() -> queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "f1.*", "f2"))
       .isInstanceOf(UnsupportedOperationException.class)
       .hasMessage("Query is not supported yet [operator(s): [<=], field(s): [f1.*, f2]]");
   }

--- a/src/test/java/org/folio/search/cql/builders/NotEqualToTermQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/cql/builders/NotEqualToTermQueryBuilderTest.java
@@ -2,6 +2,7 @@ package org.folio.search.cql.builders;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.TestConstants.EMPTY_TERM_MODIFIERS;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestUtils.keywordField;
 import static org.mockito.Mockito.when;
@@ -31,7 +32,7 @@ class NotEqualToTermQueryBuilderTest {
 
   @Test
   void getQuery_positive() {
-    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, "f1.*", "f2");
+    var actual = queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "f1.*", "f2");
     assertThat(actual).isEqualTo(boolQuery()
       .mustNot(multiMatchQuery("value", "f1.*", "f2").operator(AND).type(CROSS_FIELDS)));
   }

--- a/src/test/java/org/folio/search/cql/builders/TermQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/cql/builders/TermQueryBuilderTest.java
@@ -3,6 +3,7 @@ package org.folio.search.cql.builders;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.folio.search.utils.TestConstants.EMPTY_TERM_MODIFIERS;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 
 import java.util.Set;
@@ -16,7 +17,7 @@ class TermQueryBuilderTest {
 
   @Test
   void getQuery_positive() {
-    assertThatThrownBy(() -> queryBuilder.getQuery("value", RESOURCE_NAME, "f1.*", "f2"))
+    assertThatThrownBy(() -> queryBuilder.getQuery("value", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "f1.*", "f2"))
       .isInstanceOf(UnsupportedOperationException.class)
       .hasMessage("Query is not supported yet [operator(s): [op], field(s): [f1.*, f2]]");
   }

--- a/src/test/java/org/folio/search/cql/builders/WildcardTermQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/cql/builders/WildcardTermQueryBuilderTest.java
@@ -3,6 +3,7 @@ package org.folio.search.cql.builders;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.of;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.utils.TestConstants.EMPTY_TERM_MODIFIERS;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestUtils.keywordField;
 import static org.folio.search.utils.TestUtils.standardField;
@@ -34,9 +35,11 @@ class WildcardTermQueryBuilderTest {
 
   @Test
   void getQuery_positive() {
-    when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, "contributors.name")).thenReturn(of(standardField()));
+    when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME,
+      "contributors.name")).thenReturn(of(standardField()));
     when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, "f2")).thenReturn(of(keywordField()));
-    var actual = queryBuilder.getQuery("value*", RESOURCE_NAME, "f1.*", "f2", "contributors.name");
+    var actual = queryBuilder.getQuery("value*", RESOURCE_NAME,
+      EMPTY_TERM_MODIFIERS, "f1.*", "f2", "contributors.name");
     assertThat(actual).isEqualTo(boolQuery()
       .should(wildcardQuery("plain_f1", "value*"))
       .should(wildcardQuery("f2", "value*"))
@@ -45,14 +48,14 @@ class WildcardTermQueryBuilderTest {
 
   @Test
   void getQuery_positive_singleMultilangFieldInGroup() {
-    var actual = queryBuilder.getQuery("*value*", RESOURCE_NAME, "f1.*");
+    var actual = queryBuilder.getQuery("*value*", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "f1.*");
     assertThat(actual).isEqualTo(wildcardQuery("plain_f1", "*value*"));
   }
 
   @Test
   void getQuery_positive_singleStandardFieldInGroup() {
     when(searchFieldProvider.getPlainFieldByPath(RESOURCE_NAME, "field")).thenReturn(of(standardField()));
-    var actual = queryBuilder.getQuery("*value*", RESOURCE_NAME, "field");
+    var actual = queryBuilder.getQuery("*value*", RESOURCE_NAME, EMPTY_TERM_MODIFIERS, "field");
     assertThat(actual).isEqualTo(wildcardQuery("plain_field", "*value*"));
   }
 

--- a/src/test/java/org/folio/search/utils/TestConstants.java
+++ b/src/test/java/org/folio/search/utils/TestConstants.java
@@ -7,6 +7,7 @@ import static org.folio.spring.config.properties.FolioEnvironment.getFolioEnvNam
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.folio.search.utils.TestUtils.TestResource;
@@ -24,6 +25,8 @@ public class TestConstants {
   public static final JsonNode EMPTY_JSON_OBJECT = JsonNodeFactory.instance.objectNode();
   public static final String RESOURCE_NAME = getResourceName(TestResource.class);
   public static final String INDEX_NAME = indexName(TENANT_ID);
+  public static final List<String> EMPTY_TERM_MODIFIERS = List.of();
+  public static final List<String> STRING_TERM_MODIFIERS = List.of("string");
 
   public static final String AUTHORITY_TOPIC = "authorities.authority";
   public static final String CONTRIBUTOR_TOPIC = "search.instance-contributor";


### PR DESCRIPTION
## Purpose
The "Exact full match" operator ( ==/string )doesn't work for alias fields.

## Approach
Alias fields are replaced with a 'plan_' prefix.

### Changes checklist

**Query before changes:**

  "query" : "Sit how you want / Robin Richardson.",
  "fields" : [
  "alternativeTitles.alternativeTitle.*^1.0",
  "contributors.name^1.0",
  "identifiers.value^1.0",
  "indexTitle.*^1.0",
  "series.value.*^1.0",
  "title.*^1.0"
],
"type": "phrase"
}

**Query after changes:**

"multi_match" : {
"query" : "Sit how you want / Robin Richardson.",
"fields" : [
"alternativeTitles.plain_alternativeTitle^1.0",
"contributors.plain_name^1.0",
"identifiers.plain_value^1.0",
"plain_indexTitle^1.0",
"plain_title^1.0",
"series.plain_value^1.0"
],
"type": "phrase"
}


### Learning
https://issues.folio.org/browse/MSEARCH-589