### PR TITLE
fix(cn-browse): Filter browse result based on holdings.tenantId filter

### DIFF
--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -78,7 +78,8 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
     var folioCallNumberTypes = folioCallNumberTypes();
     var browseResult = callNumberBrowseResultConverter.convert(searchResponse, context, isBrowsingForward);
     var records = browseResult.getRecords();
-    browseResult.setRecords(excludeIrrelevantResultItems(request.getRefinedCondition(), folioCallNumberTypes, records));
+    browseResult.setRecords(
+      excludeIrrelevantResultItems(context, request.getRefinedCondition(), folioCallNumberTypes, records));
     return new BrowseResult<CallNumberBrowseItem>()
       .records(trim(records, context, isBrowsingForward))
       .totalRecords(browseResult.getTotalRecords())
@@ -120,13 +121,13 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
 
     var callNumberType = request.getRefinedCondition();
     var folioCallNumberTypes = folioCallNumberTypes();
-    precedingResult.setRecords(excludeIrrelevantResultItems(callNumberType, folioCallNumberTypes,
+    precedingResult.setRecords(excludeIrrelevantResultItems(context, callNumberType, folioCallNumberTypes,
       precedingResult.getRecords()));
-    succeedingResult.setRecords(excludeIrrelevantResultItems(callNumberType, folioCallNumberTypes,
+    succeedingResult.setRecords(excludeIrrelevantResultItems(context, callNumberType, folioCallNumberTypes,
       succeedingResult.getRecords()));
     if (!backwardSucceedingResult.isEmpty()) {
       log.debug("browseAround:: backward succeeding result is not empty: Update preceding result");
-      backwardSucceedingResult.setRecords(excludeIrrelevantResultItems(callNumberType, folioCallNumberTypes,
+      backwardSucceedingResult.setRecords(excludeIrrelevantResultItems(context, callNumberType, folioCallNumberTypes,
         backwardSucceedingResult.getRecords()));
       precedingResult.setRecords(mergeSafelyToList(backwardSucceedingResult.getRecords(), precedingResult.getRecords())
         .stream().distinct().toList());
@@ -208,7 +209,7 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
       }
       var precedingResult = callNumberBrowseResultConverter.convert(searchResponse, context, false);
       var mergedList = mergeSafelyToList(additionalPrecedingRecords, precedingResult.getRecords());
-      additionalPrecedingRecords = CallNumberUtils.excludeIrrelevantResultItems(request.getRefinedCondition(),
+      additionalPrecedingRecords = CallNumberUtils.excludeIrrelevantResultItems(context, request.getRefinedCondition(),
         folioCallNumberTypes, mergedList);
       offset = precedingQuery.from() + precedingQuery.size();
       log.debug("additionalPrecedingRequests:: response have new {} records", precedingResult.getRecords().size());

--- a/src/main/java/org/folio/search/service/consortium/ConsortiumSearchHelper.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumSearchHelper.java
@@ -178,19 +178,17 @@ public class ConsortiumSearchHelper {
   }
 
   private Optional<TermQueryBuilder> getBrowseSharedFilter(BrowseContext context) {
-    return context.getFilters().stream()
-      .map(filter ->
-        filter instanceof TermQueryBuilder termFilter && termFilter.fieldName().equals(BROWSE_SHARED_FILTER_KEY)
-        ? termFilter
-        : null)
-      .filter(Objects::nonNull)
-      .findFirst();
+    return getBrowseFilter(context, BROWSE_SHARED_FILTER_KEY);
   }
 
   private Optional<TermQueryBuilder> getBrowseTenantFilter(BrowseContext context) {
+    return getBrowseFilter(context, BROWSE_TENANT_FILTER_KEY);
+  }
+
+  public static Optional<TermQueryBuilder> getBrowseFilter(BrowseContext context, String filterKey) {
     return context.getFilters().stream()
       .map(filter ->
-        filter instanceof TermQueryBuilder termFilter && termFilter.fieldName().equals(BROWSE_TENANT_FILTER_KEY)
+        filter instanceof TermQueryBuilder termFilter && termFilter.fieldName().equals(filterKey)
         ? termFilter
         : null)
       .filter(Objects::nonNull)

--- a/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIrrelevantResultIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIrrelevantResultIT.java
@@ -23,6 +23,7 @@ import org.folio.search.domain.dto.CallNumberBrowseResult;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
+import org.folio.search.model.service.BrowseContext;
 import org.folio.search.support.base.BaseIntegrationTest;
 import org.folio.search.utils.CallNumberUtils;
 import org.folio.spring.test.type.IntegrationTest;
@@ -36,6 +37,7 @@ class BrowseTypedCallNumberIrrelevantResultIT extends BaseIntegrationTest {
   private static final Instance[] INSTANCES = instances();
   private static final Map<String, Instance> INSTANCE_MAP =
     Arrays.stream(INSTANCES).collect(toMap(Instance::getTitle, identity()));
+  private static final BrowseContext CONTEXT = BrowseContext.builder().build();
 
   @BeforeAll
   static void prepare() {
@@ -74,7 +76,7 @@ class BrowseTypedCallNumberIrrelevantResultIT extends BaseIntegrationTest {
         cnBrowseItem(instance("instance #02"), "308 H980"),
         cnBrowseItem(instance("instance #08"), "308 H981")
     ));
-    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems("dewey", emptySet(), expected.getItems()));
+    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems(CONTEXT, "dewey", emptySet(), expected.getItems()));
     assertThat(actual).isEqualTo(expected);
   }
 
@@ -94,7 +96,7 @@ class BrowseTypedCallNumberIrrelevantResultIT extends BaseIntegrationTest {
         cnBrowseItem(instance("instance #02"), "Z669.R360 1976", 1),
         cnBrowseItem(instance("instance #10"), "Z669.R360 1977", 1)
     ));
-    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems("lc", emptySet(), expected.getItems()));
+    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems(CONTEXT, "lc", emptySet(), expected.getItems()));
     leaveOnlyBasicProps(expected);
     assertThat(actual).isEqualTo(expected);
   }
@@ -127,7 +129,7 @@ class BrowseTypedCallNumberIrrelevantResultIT extends BaseIntegrationTest {
         cnBrowseItem(instance("instance #02"), "308 H980"),
         cnBrowseItem(instance("instance #08"), "308 H981")
       ));
-    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems("dewey", emptySet(), expected.getItems()));
+    expected.setItems(CallNumberUtils.excludeIrrelevantResultItems(CONTEXT, "dewey", emptySet(), expected.getItems()));
 
     assertThat(result.getItems()).hasSizeLessThanOrEqualTo(limit);
     assertThat(result).isEqualTo(expected);

--- a/src/test/java/org/folio/search/service/consortium/ConsortiumSearchHelperTest.java
+++ b/src/test/java/org/folio/search/service/consortium/ConsortiumSearchHelperTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -309,6 +310,18 @@ class ConsortiumSearchHelperTest {
       SubjectResource::getInstances);
 
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void getBrowseFilter_positive() {
+    var filterKey = "filterKey";
+    var expected = new TermQueryBuilder(filterKey, "test");
+    var browseContext = browseContext(null, null);
+    browseContext.getFilters().add(expected);
+
+    var actual = ConsortiumSearchHelper.getBrowseFilter(browseContext, filterKey);
+
+    assertThat(actual).contains(expected);
   }
 
   private BrowseContext browseContext(Boolean sharedFilter, String tenantFilter) {


### PR DESCRIPTION
## Purpose
Don't show browse items from other tenants for "holdings.tenantId" filter
[MSEARCH-603](https://issues.folio.org/browse/MSEARCH-603)

## Approach
Filter browse result based on holdings.tenantId filter

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
