### PR TITLE
fix(cn-browse): Add item.tenantId to show in cn-browse response

### DIFF
--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -270,7 +270,8 @@
           "index": "keyword"
         },
         "tenantId": {
-          "index": "keyword"
+          "index": "keyword",
+          "showInResponse": [ "call-number-browse" ]
         },
         "hrid": {
           "index": "keyword"


### PR DESCRIPTION
## Purpose
Fix local call-number not shown for tenant facet

## Approach
Make tenantId to appear for item in browse result in order to filter by it

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
