### PR TITLE
fix(cn-browse): Fix filtering results for browse in one direction

### DIFF
--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -78,8 +78,7 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
     var folioCallNumberTypes = folioCallNumberTypes();
     var browseResult = callNumberBrowseResultConverter.convert(searchResponse, context, isBrowsingForward);
     var records = browseResult.getRecords();
-    browseResult.setRecords(
-      excludeIrrelevantResultItems(context, request.getRefinedCondition(), folioCallNumberTypes, records));
+    records = excludeIrrelevantResultItems(context, request.getRefinedCondition(), folioCallNumberTypes, records);
     return new BrowseResult<CallNumberBrowseItem>()
       .records(trim(records, context, isBrowsingForward))
       .totalRecords(browseResult.getTotalRecords())

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
@@ -386,8 +386,10 @@ class CallNumberBrowseServiceTest {
     var query = rangeQuery(CALL_NUMBER_BROWSING_FIELD).lt(ANCHOR);
     var context = BrowseContext.builder().precedingQuery(query).precedingLimit(5).anchor(ANCHOR).build();
     var browseItems = browseItems("A1", "A2");
-    browseItems.get(0).getInstance().getItems().get(0).getEffectiveCallNumberComponents().setTypeId(CallNumberType.NLM.getId());
-    browseItems.get(1).getInstance().getItems().get(0).getEffectiveCallNumberComponents().setTypeId(CallNumberType.LC.getId());
+    browseItems.get(0).getInstance().getItems().get(0).getEffectiveCallNumberComponents()
+      .setTypeId(CallNumberType.NLM.getId());
+    browseItems.get(1).getInstance().getItems().get(0).getEffectiveCallNumberComponents()
+      .setTypeId(CallNumberType.LC.getId());
     var browseResult = BrowseResult.of(2, browseItems);
     var expected = BrowseResult.of(2, singletonList(browseItems.get(1))).next("A 12");
 

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
@@ -460,7 +460,7 @@ class CallNumberBrowseServiceTest {
   }
 
   private static BrowseRequest request(String query, boolean highlightMatch) {
-    return request(query, highlightMatch);
+    return request(query, highlightMatch, null);
   }
 
   private static BrowseRequest request(String query, boolean highlightMatch, String callNumberType) {


### PR DESCRIPTION
## Purpose
Fix irrelevant call number types are shown wneh browsing previous pages for typed call numbers

## Approach
Fix result filtering for browse in one direction

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.
