### PR TITLE
MSEARCH-629: Kafka 3.5.1, snappy-java 1.1.10.1 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,9 @@
     <folio-cql2pgjson.version>35.1.0</folio-cql2pgjson.version>
     <opensearch.version>2.9.0</opensearch.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
-    <spring-kafka.version>3.0.12</spring-kafka.version>
+    <!-- bump kafka.version to fix snappy-java vulnerabilities;
+         remove <kafka.version> when using spring-boot-starter-parent >= 3.2 -->
+    <kafka.version>3.5.1</kafka.version>
     <apache-commons-io.version>2.15.0</apache-commons-io.version>
     <apache-commons-collections.version>4.4</apache-commons-collections.version>
     <marc4j.version>2.9.5</marc4j.version>
@@ -101,7 +103,6 @@
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
-      <version>${spring-kafka.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
https://issues.folio.org/browse/MSEARCH-629

Upgrade Kafka from 3.4.1 to 3.5.1.

This indirectly upgrades snappy-java from 1.1.8.4 to 1.1.10.1 fixing security vulnerabilities:
https://security.snyk.io/package/maven/org.xerial.snappy:snappy-java