### PR TITLE
fix(cn-browse): Return result only for desired cn type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Fix secure setup of system users by default ([MSEARCH-608](https://issues.folio.org/browse/MSEARCH-608))
 * Fix result filtering for items.effectiveLocationId ([MSEARCH-615](https://issues.folio.org/browse/MSEARCH-615))
 * Ignore authority shadow copies while indexing ([MSEARCH-638](https://issues.folio.org/browse/MSEARCH-638))
+* Return result only for desired cn type on browse ([MSEARCH-605](https://issues.folio.org/browse/MSEARCH-605))
 
 ### Tech Dept
 * Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))

--- a/src/test/java/org/folio/search/controller/BrowseAroundCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseAroundCallNumberIT.java
@@ -7,9 +7,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.support.base.ApiEndpoints.instanceCallNumberBrowsePath;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.cnBrowseItemWithNoType;
+import static org.folio.search.utils.TestUtils.getShelfKeyFromCallNumber;
 import static org.folio.search.utils.TestUtils.parseResponse;
 import static org.folio.search.utils.TestUtils.randomId;
-import static org.folio.search.utils.TestUtils.shelfKeyForNotTypedCallNumberFunction;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import java.util.Arrays;
@@ -126,7 +126,7 @@ class BrowseAroundCallNumberIT extends BaseIntegrationTest {
         .id(randomId())
         .discoverySuppress(false)
         .effectiveCallNumberComponents(new ItemEffectiveCallNumberComponents().callNumber(callNumber))
-        .effectiveShelvingOrder(shelfKeyForNotTypedCallNumberFunction().apply(callNumber)))
+        .effectiveShelvingOrder(getShelfKeyFromCallNumber(callNumber)))
       .toList();
 
     return new Instance()

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
@@ -70,7 +70,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       .param("precedingRecordsCount", "4");
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
-      .totalRecords(37).prev(null).next("CE 216 B6713 X 541993").items(List.of(
+      .totalRecords(36).prev(null).next("CE 16 B6713 X 41993").items(List.of(
         cnBrowseItem(instance("instance #31"), "AB 14 C72 NO 220"),
         cnBrowseItem(instance("instance #25"), "AC 11 A4 VOL 235"),
         cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
@@ -90,7 +90,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         .param("precedingRecordsCount", "5");
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
-        .totalRecords(32).prev(null).next("CE 216 B6713 X 541993").items(List.of(
+        .totalRecords(32).prev(null).next("CE 16 B6713 X 41993").items(List.of(
             cnBrowseItem(instance("instance #31"), "AB 14 C72 NO 220", true),
             cnBrowseItem(instance("instance #25"), "AC 11 A4 VOL 235"),
             cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
@@ -108,7 +108,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       .param("precedingRecordsCount", "4");
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
     var expected = new CallNumberBrowseResult()
-      .totalRecords(41).prev("GA 216 D64 541548A").next("J 229.29 M54 3990").items(List.of(
+      .totalRecords(41).prev("GA 16 D64 41548A").next("J29.29:M54/990").items(List.of(
         cnBrowseItem(instance("instance #39"), "GA 16 D64 41548A"),
         cnBrowseItem(instance("instance #30"), "GA 16 G32 41557 V1"),
         cnBrowseItem(instance("instance #30"), "GA 16 G32 41557 V2"),
@@ -128,7 +128,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
 
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
-      .totalRecords(37).prev("AC 211 A67 X 542000").next("CE 216 D86 X 541998").items(List.of(
+      .totalRecords(36).prev("AC 11 A67 X 42000").next("CE 16 D86 X 41998").items(List.of(
         cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
         cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
         cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993"),
@@ -148,7 +148,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
 
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
-      .totalRecords(58).prev("DA 43870 B55 541868").next("DA 43880 O6 D5").items(List.of(
+      .totalRecords(49).prev("DA 3870 B55 41868").next("DA 3880 O6 D5").items(List.of(
         cnBrowseItem(instance("instance #41"), "DA 3870 B55 41868"),
         cnBrowseItem(instance("instance #07"), "DA 3870 H47 41975"),
         cnBrowseItem(instance("instance #11"), "DA 3880 K56 M27 41984"),
@@ -176,7 +176,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
     return Stream.of(
       arguments(aroundQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(36).prev("CE 216 B6724 541993").next("DA 43700 C95 NO 218").items(List.of(
+        .totalRecords(36).prev("CE 16 B6724 41993").next("DA 3700 C95 NO 18").items(List.of(
           cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993"),
           cnBrowseItem(instance("instance #04"), "CE 16 D86 X 41998"),
           cnBrowseItem(0, "CE 210 K297 41858", true),
@@ -185,7 +185,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(aroundQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(51).prev("DA 43880 O6 M81").next("DA 43890 A2 B76 542002").items(List.of(
+        .totalRecords(49).prev("DA 3880 O6 M81").next("DA 3890 A2 B76 42002").items(List.of(
           cnBrowseItem(instance("instance #13"), "DA 3880 O6 M81"),
           cnBrowseItem(instance("instance #02"), "DA 3880 O6 M96"),
           cnBrowseItem(0, "DA 3890 A1", true),
@@ -194,7 +194,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(aroundIncludingQuery, firstAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(36).prev("CE 216 B6724 541993").next("DA 43700 C95 NO 218").items(List.of(
+        .totalRecords(36).prev("CE 16 B6724 41993").next("DA 3700 C95 NO 18").items(List.of(
           cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993"),
           cnBrowseItem(instance("instance #04"), "CE 16 D86 X 41998"),
           cnBrowseItem(instance("instance #38"), "CE 210 K297 41858", true),
@@ -203,7 +203,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(aroundIncludingQuery, secondAnchorCallNumber, 5, new CallNumberBrowseResult()
-        .totalRecords(51).prev("DA 43880 O6 M81").next("DA 43890 A2 B76 542002").items(List.of(
+        .totalRecords(49).prev("DA 3880 O6 M81").next("DA 3890 A2 B76 42002").items(List.of(
           cnBrowseItem(instance("instance #13"), "DA 3880 O6 M81"),
           cnBrowseItem(instance("instance #02"), "DA 3880 O6 M96"),
           cnBrowseItem(0, "DA 3890 A1", true),
@@ -213,7 +213,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // checks order of closely placed call-numbers
       arguments(aroundIncludingQuery, secondAnchorCallNumber, 30, new CallNumberBrowseResult()
-        .totalRecords(51).prev("DA 43870 H47 541975").next("E 3211 N52 VOL 214").items(List.of(
+        .totalRecords(49).prev("DA 3870 H47 41975").next("E 211 N52 VOL 14").items(List.of(
           cnBrowseItem(instance("instance #07"), "DA 3870 H47 41975"),
           cnBrowseItem(instance("instance #11"), "DA 3880 K56 M27 41984"),
           cnBrowseItem(instance("instance #32"), "DA 3880 O5 C3 V1"),
@@ -248,7 +248,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // checks if collapsing by the same result works correctly
       arguments(aroundIncludingQuery, "FC", 5, new CallNumberBrowseResult()
-        .totalRecords(40).prev("FA 542010 43546 3256").next("G 545831 S2").items(List.of(
+        .totalRecords(40).prev("FA 42010 3546 256").next("G 45831 S2").items(List.of(
           cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
           cnBrowseItem(instance("instance #42"), "FA 46252 3977 12 237"),
           cnBrowseItem(0, "FC", true),
@@ -258,7 +258,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // checks if collapsing by the same result works correctly
       arguments(aroundIncludingQuery, "fc", 5, new CallNumberBrowseResult()
-        .totalRecords(40).prev("FA 542010 43546 3256").next("G 545831 S2").items(List.of(
+        .totalRecords(40).prev("FA 42010 3546 256").next("G 45831 S2").items(List.of(
           cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
           cnBrowseItem(instance("instance #42"), "FA 46252 3977 12 237"),
           cnBrowseItem(0, "fc", true),
@@ -268,7 +268,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // browsing forward
       arguments(forwardQuery, firstAnchorShelfKey, 5, new CallNumberBrowseResult()
-        .totalRecords(28).prev("DA 43700 B91 L79").next("DA 43880 K56 M27 541984").items(List.of(
+        .totalRecords(28).prev("DA 3700 B91 L79").next("DA 3880 K56 M27 41984").items(List.of(
           cnBrowseItem(instance("instance #36"), "DA 3700 B91 L79"),
           cnBrowseItem(instance("instance #09"), "DA 3700 C95 NO 18"),
           cnBrowseItem(instance("instance #41"), "DA 3870 B55 41868"),
@@ -277,7 +277,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(forwardQuery, secondAnchorShelfKey, 5, new CallNumberBrowseResult()
-        .totalRecords(25).prev("DA 43890 A1 I72 541885").next("DA 43900 C89 V1").items(List.of(
+        .totalRecords(25).prev("DA 3890 A1 I72 41885").next("DA 3900 C89 V1").items(List.of(
           cnBrowseItem(instance("instance #14"), "DA 3890 A1 I72 41885"),
           cnBrowseItem(instance("instance #22"), "DA 3890 A2 B76 42002"),
           cnBrowseItem(instance("instance #19"), "DA 3890 A2 F57 42011"),
@@ -287,7 +287,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // checks if collapsing works in forward direction
       arguments(forwardQuery, "F", 5, new CallNumberBrowseResult()
-        .totalRecords(14).prev("F  PR1866.S63 V.1 C.1").next("FC 217 B89").items(List.of(
+        .totalRecords(14).prev("F  PR1866.S63 V.1 C.1").next("FC 17 B89").items(List.of(
           cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1"),
           cnBrowseItem(instance("instance #27"), "F 43733 L370 41992"),
           cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
@@ -299,7 +299,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         .totalRecords(0).prev(null).next(null).items(emptyList())),
 
       arguments(forwardIncludingQuery, firstAnchorShelfKey, 5, new CallNumberBrowseResult()
-        .totalRecords(28).prev("CE 3210 K297 541858").next("DA 43870 H47 541975").items(List.of(
+        .totalRecords(28).prev("CE 210 K297 41858").next("DA 3870 H47 41975").items(List.of(
           cnBrowseItem(instance("instance #38"), "CE 210 K297 41858"),
           cnBrowseItem(instance("instance #36"), "DA 3700 B91 L79"),
           cnBrowseItem(instance("instance #09"), "DA 3700 C95 NO 18"),
@@ -308,7 +308,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(forwardIncludingQuery, secondAnchorShelfKey, 5, new CallNumberBrowseResult()
-        .totalRecords(25).prev("DA 43890 A1 I72 541885").next("DA 43900 C89 V1").items(List.of(
+        .totalRecords(25).prev("DA 3890 A1 I72 41885").next("DA 3900 C89 V1").items(List.of(
           cnBrowseItem(instance("instance #14"), "DA 3890 A1 I72 41885"),
           cnBrowseItem(instance("instance #22"), "DA 3890 A2 B76 42002"),
           cnBrowseItem(instance("instance #19"), "DA 3890 A2 F57 42011"),
@@ -318,7 +318,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // browsing backward
       arguments(backwardQuery, firstAnchorShelfKey, 5, new CallNumberBrowseResult()
-        .totalRecords(8).prev("AC 211 A67 X 542000").next("CE 216 D86 X 541998").items(List.of(
+        .totalRecords(8).prev("AC 11 A67 X 42000").next("CE 16 D86 X 41998").items(List.of(
           cnBrowseItem(instance("instance #08"), "AC 11 A67 X 42000"),
           cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
           cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993"),
@@ -327,7 +327,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(backwardQuery, secondAnchorShelfKey, 5, new CallNumberBrowseResult()
-        .totalRecords(26).prev("DA 43880 O6 L75").next("DA 43880 O6 M96").items(List.of(
+        .totalRecords(24).prev("DA 3880 O6 L75").next("DA 3880 O6 M96").items(List.of(
           cnBrowseItem(instance("instance #20"), "DA 3880 O6 L75"),
           cnBrowseItem(instance("instance #15"), "DA 3880 O6 L76"),
           cnBrowseItem(instance("instance #05"), "DA 3880 O6 M15"),
@@ -337,7 +337,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
       // check that collapsing works for browsing backward
       arguments(backwardQuery, "G", 5, new CallNumberBrowseResult()
-        .totalRecords(32).prev("F  PR1866.S63 V.1 C.1").next("FC 217 B89").items(List.of(
+        .totalRecords(32).prev("F  PR1866.S63 V.1 C.1").next("FC 17 B89").items(List.of(
           cnBrowseItem(instance("instance #46"), "F  PR1866.S63 V.1 C.1"),
           cnBrowseItem(instance("instance #27"), "F 43733 L370 41992"),
           cnBrowseItem(instance("instance #43"), "FA 42010 3546 256"),
@@ -346,7 +346,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(backwardQuery, "F 11", 5, new CallNumberBrowseResult()
-        .totalRecords(28).prev("E 212.11 I12 3288 D").next("F  PR1866.S63 V.1 C.1").items(List.of(
+        .totalRecords(28).prev("E 12.11 I12 288 D").next("F  PR1866.S63 V.1 C.1").items(List.of(
           cnBrowseItem(instance("instance #35"), "E 12.11 I12 288 D"),
           cnBrowseItem(instance("instance #33"), "E 12.11 I2 298"),
           cnBrowseItem(instance("instance #27"), "E 211 A506"),
@@ -358,7 +358,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         .totalRecords(0).prev(null).next(null).items(emptyList())),
 
       arguments(backwardIncludingQuery, firstAnchorShelfKey, 5, new CallNumberBrowseResult()
-        .totalRecords(8).prev("AC 211 E8 NO 214 P S1487").next("CE 3210 K297 541858").items(List.of(
+        .totalRecords(8).prev("AC 11 E8 NO 14 P S1487").next("CE 210 K297 41858").items(List.of(
           cnBrowseItem(instance("instance #18"), "AC 11 E8 NO 14 P S1487"),
           cnBrowseItem(instance("instance #44"), "CE 16 B6713 X 41993"),
           cnBrowseItem(instance("instance #45"), "CE 16 B6724 41993"),
@@ -367,7 +367,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       arguments(backwardIncludingQuery, secondAnchorShelfKey, 5, new CallNumberBrowseResult()
-        .totalRecords(26).prev("DA 43880 O6 L75").next("DA 43880 O6 M96").items(List.of(
+        .totalRecords(24).prev("DA 3880 O6 L75").next("DA 3880 O6 M96").items(List.of(
           cnBrowseItem(instance("instance #20"), "DA 3880 O6 L75"),
           cnBrowseItem(instance("instance #15"), "DA 3880 O6 L76"),
           cnBrowseItem(instance("instance #05"), "DA 3880 O6 M15"),

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberOtherIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberOtherIT.java
@@ -12,7 +12,6 @@ import static org.folio.search.utils.TestUtils.cnBrowseItemWithNoType;
 import static org.folio.search.utils.TestUtils.cnBrowseResult;
 import static org.folio.search.utils.TestUtils.parseResponse;
 import static org.folio.search.utils.TestUtils.randomId;
-import static org.folio.search.utils.TestUtils.shelfKeyForNotTypedCallNumberFunction;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import java.util.Arrays;
@@ -106,7 +105,7 @@ class BrowseCallNumberOtherIT extends BaseIntegrationTest {
       .param("expandAll", "true");
     var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
     assertThat(actual).isEqualTo(new CallNumberBrowseResult()
-      .totalRecords(13).prev("DA 43880 O6 M96").next("G  SHELF#1").items(List.of(
+      .totalRecords(13).prev("DA 3880 O6 M96").next("G  SHELF#1").items(List.of(
         cnBrowseItem(instance("instance #02"), "DA 3880 O6 M96"),
         cnBrowseItem(instance("instance #09"), "F  PR1866.S63 V.1 C.1"),
         cnBrowseItem(instance("instance #11"), "F-1,452"),
@@ -162,9 +161,13 @@ class BrowseCallNumberOtherIT extends BaseIntegrationTest {
       List.of("instance #08", List.of("PIRANHA 19 _C 11")),
       List.of("instance #09", List.of("F  PR1866.S63 V.1 C.1")),
       //for the case when call number type is not specified by inventory but call number may be parsed into a system one
-      List.of("instance #10", List.of("FA 42010 3546 256"), shelfKeyForNotTypedCallNumberFunction()),
+      List.of("instance #10", List.of("FA 42010 3546 256"), shelfKeyFromCallNumber()),
       List.of("instance #11", List.of("F-1,452")),
       List.of("instance #12", List.of("G (shelf#1)"))
     );
+  }
+
+  private static Function<String, String> shelfKeyFromCallNumber() {
+    return TestUtils::getShelfKeyFromCallNumber;
   }
 }

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
@@ -10,6 +10,7 @@ import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.cnBrowseItem;
 import static org.folio.search.utils.TestUtils.getShelfKeyFromCallNumber;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
@@ -98,7 +99,7 @@ class CallNumberBrowseServiceTest {
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(BrowseResult.of(11, "A 13", "C 12", List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(11, "A3", "C2", List.of(
       cnBrowseItem(instance("A3"), "A3"),
       cnBrowseItem(instance("A4"), "A4"),
       cnBrowseItem(0, "B", true),
@@ -207,6 +208,7 @@ class CallNumberBrowseServiceTest {
     var query = rangeQuery(CALL_NUMBER_BROWSING_FIELD).gte(ANCHOR);
     var context = BrowseContext.builder().succeedingQuery(query).succeedingLimit(5).anchor(ANCHOR).build();
 
+    when(shelvingOrderProcessor.getSearchTerm(any(), any())).thenReturn(context.getAnchor());
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, true)).thenReturn(succeedingQuery);
     when(searchRepository.search(request, succeedingQuery)).thenReturn(succeedingResponse);
@@ -215,7 +217,7 @@ class CallNumberBrowseServiceTest {
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(BrowseResult.of(2, "C 11", null, List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(2, "C1", null, List.of(
       cnBrowseItem(instance("C1"), "C1"), cnBrowseItem(instance("C2"), "C2"))));
   }
 
@@ -227,6 +229,7 @@ class CallNumberBrowseServiceTest {
       .build();
     var context = BrowseContext.builder().succeedingQuery(query).succeedingLimit(5).anchor(ANCHOR).build();
 
+    when(shelvingOrderProcessor.getSearchTerm(any(), any())).thenReturn(multiAnchorContext.getAnchor());
     when(browseContextProvider.get(request)).thenReturn(multiAnchorContext);
     when(browseQueryProvider.get(request, context, true)).thenReturn(succeedingQuery);
     when(searchRepository.search(request, succeedingQuery)).thenReturn(succeedingResponse);
@@ -258,8 +261,9 @@ class CallNumberBrowseServiceTest {
     when(cqlSearchQueryConverter.convertToTermNode(anyString(), anyString()))
       .thenReturn(new CQLTermNode(null, null, "B"));
     lenient().when(shelvingOrderProcessor.getSearchTerms(ANCHOR)).thenReturn(newArrayList("A", "B"));
+    when(shelvingOrderProcessor.getSearchTerm(any(), any())).thenReturn("A");
 
-    var precedingResult = BrowseResult.of(1, browseItems("A 11", "A 12"));
+    var precedingResult = BrowseResult.of(1, browseItems("A1", "A2"));
     var succeedingResult = BrowseResult.of(1, browseItems("B"));
     var contextForNoAnchorInResponse = contextAroundIncluding("A", ANCHOR);
 
@@ -290,8 +294,8 @@ class CallNumberBrowseServiceTest {
     var actual = callNumberBrowseService.browse(request);
 
     assertThat(actual).isEqualTo(BrowseResult.of(2, List.of(
-      cnBrowseItem(instance("A 11"), "A 11"),
-      cnBrowseItem(instance("A 12"), "A 12"),
+      cnBrowseItem(instance("A1"), "A1"),
+      cnBrowseItem(instance("A2"), "A2"),
       cnBrowseItem(instance("B"), "B", true)
     )));
   }
@@ -302,6 +306,7 @@ class CallNumberBrowseServiceTest {
     var query = rangeQuery(CALL_NUMBER_BROWSING_FIELD).gte(ANCHOR);
     var context = BrowseContext.builder().succeedingQuery(query).succeedingLimit(2).anchor(ANCHOR).build();
 
+    when(shelvingOrderProcessor.getSearchTerm(any(), any())).thenReturn(context.getAnchor());
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, true)).thenReturn(succeedingQuery);
     when(searchRepository.search(request, succeedingQuery)).thenReturn(succeedingResponse);
@@ -310,7 +315,7 @@ class CallNumberBrowseServiceTest {
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(BrowseResult.of(5, "C 11", "C 12", List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(5, "C1", "C2", List.of(
       cnBrowseItem(instance("C1"), "C1"), cnBrowseItem(instance("C2"), "C2"))));
   }
 
@@ -320,6 +325,7 @@ class CallNumberBrowseServiceTest {
     var query = rangeQuery(CALL_NUMBER_BROWSING_FIELD).gte(ANCHOR);
     var context = BrowseContext.builder().succeedingQuery(query).succeedingLimit(5).anchor(ANCHOR).build();
 
+    when(shelvingOrderProcessor.getSearchTerm(any(), any())).thenReturn(context.getAnchor());
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, true)).thenReturn(succeedingQuery);
     when(searchRepository.search(request, succeedingQuery)).thenReturn(succeedingResponse);
@@ -336,6 +342,7 @@ class CallNumberBrowseServiceTest {
     var query = rangeQuery(CALL_NUMBER_BROWSING_FIELD).lt(ANCHOR);
     var context = BrowseContext.builder().precedingQuery(query).precedingLimit(5).anchor(ANCHOR).build();
 
+    when(shelvingOrderProcessor.getSearchTerm(any(), any())).thenReturn(context.getAnchor());
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, false)).thenReturn(precedingQuery);
     when(searchRepository.search(request, precedingQuery)).thenReturn(precedingResponse);
@@ -344,7 +351,7 @@ class CallNumberBrowseServiceTest {
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(BrowseResult.of(2, null, "A 12", List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(2, null, "A2", List.of(
       cnBrowseItem(instance("A1"), "A1"), cnBrowseItem(instance("A2"), "A2"))));
   }
 
@@ -354,6 +361,7 @@ class CallNumberBrowseServiceTest {
     var query = rangeQuery(CALL_NUMBER_BROWSING_FIELD).lt(ANCHOR);
     var context = BrowseContext.builder().precedingQuery(query).precedingLimit(2).anchor(ANCHOR).build();
 
+    when(shelvingOrderProcessor.getSearchTerm(any(), any())).thenReturn(context.getAnchor());
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, false)).thenReturn(precedingQuery);
     when(searchRepository.search(request, precedingQuery)).thenReturn(precedingResponse);
@@ -362,7 +370,7 @@ class CallNumberBrowseServiceTest {
 
     var actual = callNumberBrowseService.browse(request);
 
-    assertThat(actual).isEqualTo(BrowseResult.of(5, "A 14", "A 15", List.of(
+    assertThat(actual).isEqualTo(BrowseResult.of(5, "A4", "A5", List.of(
       cnBrowseItem(instance("A4"), "A4"), cnBrowseItem(instance("A5"), "A5"))));
   }
 
@@ -372,6 +380,7 @@ class CallNumberBrowseServiceTest {
     var query = rangeQuery(CALL_NUMBER_BROWSING_FIELD).lt(ANCHOR);
     var context = BrowseContext.builder().precedingQuery(query).precedingLimit(5).anchor(ANCHOR).build();
 
+    when(shelvingOrderProcessor.getSearchTerm(any(), any())).thenReturn(context.getAnchor());
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, false)).thenReturn(precedingQuery);
     when(searchRepository.search(request, precedingQuery)).thenReturn(precedingResponse);
@@ -393,8 +402,9 @@ class CallNumberBrowseServiceTest {
     browseItems.get(1).getInstance().getItems().get(0).getEffectiveCallNumberComponents()
       .setTypeId(CallNumberType.LC.getId());
     var browseResult = BrowseResult.of(2, browseItems);
-    var expected = BrowseResult.of(2, singletonList(browseItems.get(1))).next("A 12");
+    var expected = BrowseResult.of(2, singletonList(browseItems.get(1))).next("A2");
 
+    when(shelvingOrderProcessor.getSearchTerm(any(), any())).thenReturn(context.getAnchor());
     when(browseContextProvider.get(request)).thenReturn(context);
     when(browseQueryProvider.get(request, context, false)).thenReturn(precedingQuery);
     when(searchRepository.search(request, precedingQuery)).thenReturn(precedingResponse);
@@ -411,6 +421,7 @@ class CallNumberBrowseServiceTest {
 
     when(cqlSearchQueryConverter.convertToTermNode(anyString(), anyString()))
       .thenReturn(new CQLTermNode(null, null, "B"));
+    when(shelvingOrderProcessor.getSearchTerm(any(), any())).thenReturn(ANCHOR);
     lenient().when(shelvingOrderProcessor.getSearchTerms(ANCHOR)).thenReturn(newArrayList("B"));
 
     var precedingResult = BrowseResult.of(2, browseItems("A", "A1"));
@@ -447,6 +458,7 @@ class CallNumberBrowseServiceTest {
                                             BrowseResult<CallNumberBrowseItem> precedingResult,
                                             BrowseResult<CallNumberBrowseItem> succeedingResult) {
     when(browseContextProvider.get(request)).thenReturn(context);
+    when(shelvingOrderProcessor.getSearchTerm(any(), any())).thenReturn(context.getAnchor());
     when(browseQueryProvider.get(request, context, false)).thenReturn(precedingQuery);
     when(browseQueryProvider.get(request, context, true)).thenReturn(succeedingQuery);
 

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -241,18 +241,13 @@ public class TestUtils {
   }
 
   public static CallNumberBrowseItem cnBrowseItemWithNoType(Instance instance, String callNumber, Boolean isAnchor) {
-    var shelfKey = shelfKeyForNotTypedCallNumberFunction().apply(callNumber);
+    var shelfKey = getShelfKeyFromCallNumber(callNumber);
     return new CallNumberBrowseItem().fullCallNumber(callNumber).shelfKey(shelfKey)
       .instance(instance).totalRecords(1).isAnchor(isAnchor);
   }
 
-  public static Function<String, String> shelfKeyForNotTypedCallNumberFunction() {
-    return CallNumberUtils::normalizeEffectiveShelvingOrder;
-  }
-
   public static String getShelfKeyFromCallNumber(String callNumber) {
-    var terms = SHELVING_ORDER_TERM_PROCESSOR.getSearchTerms(callNumber);
-    return terms.get(0);
+    return normalizeEffectiveShelvingOrder(callNumber);
   }
 
   public static String getShelfKeyFromCallNumber(String callNumber, String typeId) {


### PR DESCRIPTION
### Purpose
Return result only for desired cn type. Return empty result with shelf key for passed cn type or normalized call number when no exact match.

### Approach
- Browse only for shelving order using desired cn type
- Browse for multiple anchors (shelf keys generated using different algorithms) only if cn type not passed

### Changes Checklist
- [ ] **API Changes**: List any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Specify any database schema changes and their impact.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Note added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **NEWS**: Ensure that the `NEWS` file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-605](https://issues.folio.org/browse/MSEARCH-605)

### Learning
Test case scenario from a task showed a case when browsing for not typed call numbers and empty result returned with shelf key generated using LcCallNumber algorithm and browse result itself was returned for browsing on same shelf key in elasticsearch which is incorrect in a case when no cn is passed. Now when call number is passed we will always look for exact match using one algorithm. When call number type is not passed - we will browse using all cn types and in case of missing the exact match - return browse result for "normalized call number" browse.
