### PR TITLE
refactor(LCCN search): search only by "LCCN" field ("010 $a", "010 $z")

### DIFF
--- a/src/main/java/org/folio/search/service/setter/authority/LccnProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/authority/LccnProcessor.java
@@ -19,7 +19,7 @@ public class LccnProcessor extends AbstractIdentifierProcessor<Authority> {
    * @param referenceDataService {@link ReferenceDataService} bean
    */
   public LccnProcessor(ReferenceDataService referenceDataService) {
-    super(referenceDataService, LCCN_IDENTIFIER_NAMES);
+    super(referenceDataService, LCCN_IDENTIFIER_NAME);
   }
 
   @Override

--- a/src/main/java/org/folio/search/service/setter/authority/LccnProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/authority/LccnProcessor.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class LccnProcessor extends AbstractIdentifierProcessor<Authority> {
 
-  private static final List<String> LCCN_IDENTIFIER_NAMES =
-    List.of("LCCN", "Control number", "Other standard identifier", "System control number");
+  private static final List<String> LCCN_IDENTIFIER_NAME =
+    List.of("LCCN");
 
   /**
    * Used by dependency injection.

--- a/src/test/resources/mappings/inventory.json
+++ b/src/test/resources/mappings/inventory.json
@@ -94,7 +94,7 @@
     {
       "request": {
         "method": "GET",
-        "url": "/identifier-types?query=name%3D%3D%28%22LCCN%22%20or%20%22Control%20number%22%20or%20%22Other%20standard%20identifier%22%20or%20%22System%20control%20number%22%29&limit=100"
+        "url": "/identifier-types?query=name%3D%3D%28%22LCCN%22%29&limit=100"
       },
       "response": {
         "status": 200,


### PR DESCRIPTION
### Purpose
"LCCN" option should search only by "LCCN" field ("010 $a", "010 $z")
 
### Approach
Removed additional identifier types: "Control number", "Other standard identifier", "System control number"
 
### Changes Checklist
Updated LccnProcessor to populate lccn field with only "LCCN" identifier type
 
### Learning and Resources (if applicable)
https://issues.folio.org/browse/MSEARCH-630