### PR TITLE
fix(cn-browse): Trim search term for typed browse

### DIFF
--- a/src/main/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessor.java
@@ -41,7 +41,8 @@ public class EffectiveShelvingOrderTermProcessor implements SearchTermProcessor 
 
     return Optional.ofNullable(CN_TYPE_TO_SHELF_KEY_GENERATOR.get(callNumberTypeName))
       .flatMap(function -> function.apply(inputTerm))
-      .orElse(normalizeEffectiveShelvingOrder(inputTerm));
+      .orElse(normalizeEffectiveShelvingOrder(inputTerm))
+      .trim();
   }
 
   public List<String> getSearchTerms(String inputTerm) {

--- a/src/test/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessorTest.java
@@ -123,6 +123,14 @@ class EffectiveShelvingOrderTermProcessorTest {
     var actual = searchTermProcessor.getSearchTerms(given);
 
     assertThat(actual).isEqualTo(expected);
+  }
 
+  @Test
+  void getSearchTerm_shouldTrim() {
+    var given = "396.300";
+    var expected = "3396.300";
+    var actual = searchTermProcessor.getSearchTerm(given, "dewey");
+
+    assertThat(actual).isEqualTo(expected);
   }
 }

--- a/src/test/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessorTest.java
@@ -126,7 +126,7 @@ class EffectiveShelvingOrderTermProcessorTest {
   }
 
   @Test
-  void getSearchTerm_shouldTrim() {
+  void getSearchTerm_shouldTrimDeweyShelfKey() {
     var given = "396.300";
     var expected = "3396.300";
     var actual = searchTermProcessor.getSearchTerm(given, "dewey");

--- a/src/test/java/org/folio/search/utils/TestUtils.java
+++ b/src/test/java/org/folio/search/utils/TestUtils.java
@@ -256,7 +256,8 @@ public class TestUtils {
         .map(generator -> generator.apply(callNumber))
         .filter(AbstractCallNumber::isValid)
         .map(AbstractCallNumber::getShelfKey))
-      .orElse(normalizeEffectiveShelvingOrder(callNumber));
+      .orElse(normalizeEffectiveShelvingOrder(callNumber))
+      .trim();
   }
 
   public static SubjectBrowseResult subjectBrowseResult(int total, List<SubjectBrowseItem> items) {


### PR DESCRIPTION
### Purpose
Fix no exact match for some of Dewey call numbers

### Approach
Trim search term for typed browse

### Changes Checklist
- [ ] **API Changes**: List any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Specify any database schema changes and their impact.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Note added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **NEWS**: Ensure that the `NEWS` file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-643](https://issues.folio.org/browse/MSEARCH-643)
[MSEARCH-618](https://issues.folio.org/browse/MSEARCH-618) - introduced a problem

### Learning and Resources (if applicable)
New term processor method was introduced in 618 and it was missing term trimming in the end
