### PR TITLE
MSEARCH-685: Fix POST /search/resources/jobs to make it work asynchronously

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 * Fix shared filter for subjects/contributors ([MSEARCH-639](https://issues.folio.org/browse/MSEARCH-639))
 * Fix shadow instance's subjects/contributors indexing ([MSEARCH-647](https://issues.folio.org/browse/MSEARCH-647))
 * Mark all exact matches as anchors if there is more then one match ([MSEARCH-669](https://issues.folio.org/browse/MSEARCH-669))
+* Make POST /search/resources/jobs endpoint to work asynchronously ([MSEARCH-685](https://issues.folio.org/browse/MSEARCH-685))
 
 ### Tech Dept
 * Fix log level and message wording for uniform titles ([MSEARCH-666](https://issues.folio.org/browse/MSEARCH-666))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -141,7 +141,7 @@
     },
     {
       "id": "resource-ids-streaming",
-      "version": "0.3",
+      "version": "0.4",
       "handlers": [
         {
           "methods": [

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -141,7 +141,7 @@
     },
     {
       "id": "resource-ids-streaming",
-      "version": "0.4",
+      "version": "0.3",
       "handlers": [
         {
           "methods": [

--- a/src/main/java/org/folio/search/service/ResourceIdsJobService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdsJobService.java
@@ -37,7 +37,7 @@ public class ResourceIdsJobService {
     log.info("Attempts to create streamJob by [resourceIdsJob: {}]", entity);
     var savedJob = consortiumTenantExecutor.execute(() -> jobRepository.save(entity));
 
-    consortiumTenantExecutor.run(() -> resourceIdService.streamResourceIdsForJob(savedJob, tenantId));
+    consortiumTenantExecutor.runAsync(() -> resourceIdService.streamResourceIdsForJob(savedJob, tenantId));
     return resourceIdsJobMapper.convert(savedJob);
   }
 

--- a/src/main/java/org/folio/search/service/consortium/ConsortiumTenantExecutor.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumTenantExecutor.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.service.SystemUserScopedExecutionService;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Log4j2
@@ -36,6 +37,11 @@ public class ConsortiumTenantExecutor {
       operation.run();
       return null;
     });
+  }
+
+  @Async
+  public void runAsync(Runnable operation) {
+    run(operation);
   }
 
 }

--- a/src/test/java/org/folio/search/controller/StreamResourceIdsIT.java
+++ b/src/test/java/org/folio/search/controller/StreamResourceIdsIT.java
@@ -64,6 +64,7 @@ class StreamResourceIdsIT extends BaseIntegrationTest {
     var postResponse = parseResponse(doPost(ApiEndpoints.resourcesIdsJobPath(), resourceIdsJob)
       .andExpect(jsonPath("$.query", is(query)))
       .andExpect(jsonPath("$.entityType", is(entityType.name())))
+      .andExpect(jsonPath("$.status", is("IN_PROGRESS")))
       .andExpect(jsonPath("$.id", anything())), ResourceIdsJob.class);
 
     await().atMost(Durations.FIVE_SECONDS).until(() -> {


### PR DESCRIPTION
### Purpose
_POST /search/resources/jobs  endpoint takes much time for a query that matches 200k > records_

### Approach
_Make streaming of the resources run in async mode._

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-685](https://folio-org.atlassian.net/browse/MSEARCH-685)