### PR TITLE
fix(browse-classifications): invalidate reference-data cache for classification-type event

### DIFF
--- a/src/main/java/org/folio/search/integration/KafkaMessageListener.java
+++ b/src/main/java/org/folio/search/integration/KafkaMessageListener.java
@@ -3,6 +3,7 @@ package org.folio.search.integration;
 import static org.apache.commons.collections4.MapUtils.getString;
 import static org.apache.commons.lang3.RegExUtils.replaceAll;
 import static org.folio.search.configuration.RetryTemplateConfiguration.KAFKA_RETRY_TEMPLATE_NAME;
+import static org.folio.search.configuration.SearchCacheNames.REFERENCE_DATA_CACHE;
 import static org.folio.search.domain.dto.ResourceEventType.CREATE;
 import static org.folio.search.domain.dto.ResourceEventType.DELETE;
 import static org.folio.search.domain.dto.ResourceEventType.REINDEX;
@@ -33,6 +34,7 @@ import org.folio.search.service.ResourceService;
 import org.folio.search.service.config.ConfigSynchronizationService;
 import org.folio.search.utils.KafkaConstants;
 import org.folio.spring.service.SystemUserScopedExecutionService;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -163,6 +165,7 @@ public class KafkaMessageListener {
     groupId = "#{folioKafkaProperties.listener['classification-type'].groupId}",
     concurrency = "#{folioKafkaProperties.listener['classification-type'].concurrency}",
     topicPattern = "#{folioKafkaProperties.listener['classification-type'].topicPattern}")
+  @CacheEvict(cacheNames = REFERENCE_DATA_CACHE, allEntries = true)
   public void handleClassificationTypeEvents(List<ConsumerRecord<String, ResourceEvent>> consumerRecords) {
     log.info("Processing classification-type events from Kafka [number of events: {}]", consumerRecords.size());
     var batch = consumerRecords.stream()

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -76,6 +76,7 @@ public abstract class BaseIntegrationTest {
   protected static KafkaTemplate<String, ResourceEvent> kafkaTemplate;
   protected static OkapiConfiguration okapi;
   protected static RestHighLevelClient elasticClient;
+  protected static CacheManager cacheManager;
 
   @RegisterExtension
   static OkapiExtension okapiExtension =
@@ -85,12 +86,14 @@ public abstract class BaseIntegrationTest {
   static void setUpDefaultTenant(
     @Autowired MockMvc mockMvc,
     @Autowired KafkaTemplate<String, ResourceEvent> kafkaTemplate,
-    @Autowired RestHighLevelClient restHighLevelClient) {
+    @Autowired RestHighLevelClient restHighLevelClient,
+    @Autowired CacheManager cacheManager) {
     setEnvProperty("folio-test");
     BaseIntegrationTest.mockMvc = mockMvc;
     BaseIntegrationTest.kafkaTemplate = kafkaTemplate;
     BaseIntegrationTest.inventoryApi = new InventoryApi(kafkaTemplate);
     BaseIntegrationTest.elasticClient = restHighLevelClient;
+    BaseIntegrationTest.cacheManager = cacheManager;
   }
 
   @BeforeAll


### PR DESCRIPTION
### Purpose
Reference data cache should be invalidated on receiving classification-type domain event.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MSEARCH-683
