### PR TITLE
fix(cn-browse): Fix browsing in one direction by shelving order

### DIFF
--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -11,6 +11,7 @@ import static org.folio.search.model.client.CqlQueryParam.SOURCE;
 import static org.folio.search.model.types.CallNumberTypeSource.FOLIO;
 import static org.folio.search.utils.CallNumberUtils.excludeIrrelevantResultItems;
 import static org.folio.search.utils.CollectionUtils.mergeSafelyToList;
+import static org.folio.search.utils.SearchUtils.SHELVING_ORDER_BROWSING_FIELD;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,7 +58,9 @@ public class CallNumberBrowseService extends AbstractBrowseService<CallNumberBro
     log.debug("browseInOneDirection:: by: [request: {}]", request);
 
     var callNumber = callNumberFromRequest(request);
-    var initialAnchor = effectiveShelvingOrderTermProcessor.getSearchTerm(callNumber, request.getRefinedCondition());
+    var initialAnchor = request.getQuery().contains(SHELVING_ORDER_BROWSING_FIELD)
+      ? context.getAnchor()
+      : effectiveShelvingOrderTermProcessor.getSearchTerm(callNumber, request.getRefinedCondition());
     if (!initialAnchor.equals(context.getAnchor())) {
       context = buildBrowseContext(context, initialAnchor);
     }

--- a/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseTypedCallNumberIT.java
@@ -110,6 +110,23 @@ class BrowseTypedCallNumberIT extends BaseIntegrationTest {
   }
 
   @Test
+  void browseByShelfKeyDewey_backward() {
+    var request = get(instanceCallNumberBrowsePath())
+      .param("query", prepareQuery("itemEffectiveShelvingOrder < {value}", "\"A 3123.4\""))
+      .param("callNumberType", "dewey")
+      .param("limit", "5")
+      .param("expandAll", "true");
+    var actual = parseResponse(doGet(request), CallNumberBrowseResult.class);
+    assertThat(actual).isEqualTo(new CallNumberBrowseResult()
+      .totalRecords(6).prev(null).next("11 CE 3210 K 3297 541858").items(List.of(
+        cnBrowseItem(instance("instance #44"), "1CE 16 B6713 X 41993"),
+        cnBrowseItem(DEWEY, "1CE 16 B6724 41993", 2, null),
+        cnBrowseItem(instance("instance #04"), "1CE 16 D86 X 41998"),
+        cnBrowseItem(instance("instance #38"), "1CE 210 K297 41858")
+      )));
+  }
+
+  @Test
   void browseByCallNumberNlm_browsingAroundWhenPrecedingRecordsCountIsSpecified() {
     var request = get(instanceCallNumberBrowsePath())
       .param("query",

--- a/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/CallNumberBrowseServiceTest.java
@@ -6,6 +6,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.lucene.search.TotalHits.Relation.EQUAL_TO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.search.utils.SearchUtils.CALL_NUMBER_BROWSING_FIELD;
+import static org.folio.search.utils.SearchUtils.SHELVING_ORDER_BROWSING_FIELD;
 import static org.folio.search.utils.TestConstants.RESOURCE_NAME;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.folio.search.utils.TestUtils.cnBrowseItem;
@@ -15,6 +16,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.opensearch.index.query.QueryBuilders.rangeQuery;
 
@@ -360,6 +362,27 @@ class CallNumberBrowseServiceTest {
   }
 
   @Test
+  void browse_positive_backwardShelvingOrderTyped() {
+    var request = request("itemEffectiveShelvingOrder < B", SHELVING_ORDER_BROWSING_FIELD, false, "lc");
+    var query = rangeQuery(SHELVING_ORDER_BROWSING_FIELD).lt(ANCHOR);
+    var context = BrowseContext.builder().precedingQuery(query).precedingLimit(5).anchor(ANCHOR).build();
+    var browseItems = browseItems("A1", "A2");
+    browseItems.forEach(browseItem -> browseItem.getInstance().getItems().get(0).getEffectiveCallNumberComponents()
+      .setTypeId(CallNumberType.LC.getId()));
+    var browseResult = BrowseResult.of(2, browseItems).next("A2");
+
+    when(browseContextProvider.get(request)).thenReturn(context);
+    when(browseQueryProvider.get(request, context, false)).thenReturn(precedingQuery);
+    when(searchRepository.search(request, precedingQuery)).thenReturn(precedingResponse);
+    when(browseResultConverter.convert(precedingResponse, context, false)).thenReturn(browseResult);
+
+    var actual = callNumberBrowseService.browse(request);
+
+    assertThat(actual).isEqualTo(browseResult);
+    verifyNoInteractions(shelvingOrderProcessor);
+  }
+
+  @Test
   void browse_positive_backwardWithPrevValue() {
     var request = request("callNumber < B", false);
     var query = rangeQuery(CALL_NUMBER_BROWSING_FIELD).lt(ANCHOR);
@@ -517,24 +540,29 @@ class CallNumberBrowseServiceTest {
   }
 
   private static BrowseRequest request(String query, boolean highlightMatch) {
-    return request(query, highlightMatch, null, 1, 2);
+    return request(query, CALL_NUMBER_BROWSING_FIELD, highlightMatch, null, 1, 2);
   }
 
   private static BrowseRequest request(String query, boolean highlightMatch, String callNumberType) {
-    return request(query, highlightMatch, callNumberType, 1, 2);
+    return request(query, CALL_NUMBER_BROWSING_FIELD, highlightMatch, callNumberType, 1, 2);
+  }
+
+  private static BrowseRequest request(String query, String browsingField, boolean highlightMatch,
+                                       String callNumberType) {
+    return request(query, browsingField, highlightMatch, callNumberType, 1, 2);
   }
 
   private static BrowseRequest request(String query, boolean highlightMatch, int precedingCount, int limit) {
-    return request(query, highlightMatch, null, precedingCount, limit);
+    return request(query, CALL_NUMBER_BROWSING_FIELD, highlightMatch, null, precedingCount, limit);
   }
 
-  private static BrowseRequest request(String query, boolean highlightMatch, String callNumberType, int precedingCount,
-                                       int limit) {
+  private static BrowseRequest request(String query, String browsingField, boolean highlightMatch,
+                                       String callNumberType, int precedingCount, int limit) {
     return BrowseRequest.builder().tenantId(TENANT_ID).resource(RESOURCE_NAME)
       .query(query)
       .highlightMatch(highlightMatch)
       .expandAll(false)
-      .targetField(CALL_NUMBER_BROWSING_FIELD)
+      .targetField(browsingField)
       .precedingRecordsCount(precedingCount)
       .limit(limit)
       .refinedCondition(callNumberType)


### PR DESCRIPTION
### Purpose
Fix a problem of not being able to go to the previous page

### Approach
Do not construct a shelf key from anchor if anchor is already a shelf key

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-704](https://folio-org.atlassian.net/browse/MSEARCH-704)

### Screenshots (if applicable)
Create 6 Dewey call numbers, browse for "Slava pag 6", not existing
![image](https://github.com/folio-org/mod-search/assets/94473337/33d5d1cb-b7a6-4de3-857e-1f57650ec7c9)
Click on "Previous" button
Result before fix, all created call numbers displayed:
![image](https://github.com/folio-org/mod-search/assets/94473337/f7fe5fa5-a049-4588-a471-24560e2dc3c9)
Result after fix, only numbers preceding first result of the browse page are displayed:
![image](https://github.com/folio-org/mod-search/assets/94473337/cb4e30fb-ba84-426e-87e5-c33f8919f9d7)

