### PR TITLE
fix(search-locations): mark location index as not supported by reindex

### DIFF
--- a/src/main/resources/model/location.json
+++ b/src/main/resources/model/location.json
@@ -1,7 +1,7 @@
 {
   "name": "location",
   "eventBodyJavaClass": "org.folio.search.model.dto.LocationDto",
-  "reindexSupported": true,
+  "reindexSupported": false,
   "fields": {
     "id": {
       "index": "keyword_lowercase",


### PR DESCRIPTION
### Purpose
mark location index as not supported by reindex

### Approach
As reindex for location is not supported yet, it should be disabled.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MSEARCH-703
