### PR TITLE
fix: do not delete kafka topics if collection topic is enabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,23 +1,23 @@
 ## v3.3.0 YYYY-mm-DD
 ### Breaking changes
-* Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))
+* Description ([ISSUE_NUMBER](https://folio-org.atlassian.net/browse/ISSUE_NUMBER))
 
 ### New APIs versions
 * Provides `indices v0.7`
 * Requires `locations v3.0`
 
 ### Features
-* Create location index and process location events ([MSEARCH-703](https://issues.folio.org/browse/MSEARCH-703))
-* Implement reindexing of locations ([MSEARCH-702](https://issues.folio.org/browse/MSEARCH-702))
-* Modify diacritics handling in search, browse and sorting ([MSEARCH-690](https://issues.folio.org/browse/MSEARCH-690))
-* Instance search: add search option that search instances by normalized classification number ([MSEARCH-697](https://issues.folio.org/browse/MSEARCH-697))
-* Instance search: make "all" search field option to search by full-text fields ([MSEARCH-606](https://issues.folio.org/browse/MSEARCH-606))
+* Create location index and process location events ([MSEARCH-703](https://folio-org.atlassian.net/browse/MSEARCH-703))
+* Implement reindexing of locations ([MSEARCH-702](https://folio-org.atlassian.net/browse/MSEARCH-702))
+* Modify diacritics handling in search, browse and sorting ([MSEARCH-690](https://folio-org.atlassian.net/browse/MSEARCH-690))
+* Instance search: add search option that search instances by normalized classification number ([MSEARCH-697](https://folio-org.atlassian.net/browse/MSEARCH-697))
+* Instance search: make "all" search field option to search by full-text fields ([MSEARCH-606](https://folio-org.atlassian.net/browse/MSEARCH-606))
 
 ### Bug fixes
-* Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))
+* Do not delete kafka topics if collection topic is enabled ([MSEARCH-725](https://folio-org.atlassian.net/browse/MSEARCH-725))
 
 ### Tech Dept
-* Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))
+* Description ([ISSUE_NUMBER](https://folio-org.atlassian.net/browse/ISSUE_NUMBER))
 
 ### Dependencies
 * Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
       src/main/java/org/folio/search/configuration/properties/**
     </sonar.exclusions>
 
-    <folio-spring-support.version>8.1.0</folio-spring-support.version>
-    <folio-service-tools.version>4.0.0</folio-service-tools.version>
-    <folio-isbn-utils.version>1.6.0</folio-isbn-utils.version>
+    <folio-spring-support.version>8.2.0-SNAPSHOT</folio-spring-support.version>
+    <folio-service-tools.version>4.1.0-SNAPSHOT</folio-service-tools.version>
+    <folio-isbn-utils.version>1.7.0-SNAPSHOT</folio-isbn-utils.version>
     <folio-cql2pgjson.version>35.2.0</folio-cql2pgjson.version>
     <opensearch.version>2.13.0</opensearch.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>


### PR DESCRIPTION
## Purpose
Do not delete kafka topics if tenant collection topic feature is enabled

### Approach
Update to newest folio-service-tools version

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MSEARCH-725
