### PR TITLE
feat(search-instances-authorities): Remove ability to match on LCCN searches without a prefix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Instance search: make "all" search field option to search by full-text fields ([MSEARCH-606](https://issues.folio.org/browse/MSEARCH-606))
 * Facets: add support for instance classification facets ([MSEARCH-606](https://issues.folio.org/browse/MSEARCH-606))
 * Return Unified List of Inventory Locations in a Consortium ([MSEARCH-681](https://folio-org.atlassian.net/browse/MSEARCH-681))
+* Remove ability to match on LCCN searches without a prefix ([MSEARCH-752](https://folio-org.atlassian.net/browse/MSEARCH-752))
 
 ### Bug fixes
 * Do not delete kafka topics if collection topic is enabled ([MSEARCH-725](https://folio-org.atlassian.net/browse/MSEARCH-725))

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,7 @@ _How does this change fulfill the purpose? Provide a high-level overview of the 
 
 ### Related Issues
 _List any Jira issues related to this pull request._
+[MSEARCH-XXX](https://folio-org.atlassian.net/browse/MSEARCH-XXX)
 
 ### Learning and Resources (if applicable)
 _Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

--- a/src/main/java/org/folio/search/service/setter/AbstractLccnProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/AbstractLccnProcessor.java
@@ -1,16 +1,13 @@
 package org.folio.search.service.setter;
 
-import static org.folio.search.utils.SearchUtils.extractLccnNumericPart;
-import static org.folio.search.utils.SearchUtils.normalizeLccn;
-
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.folio.search.domain.dto.Identifier;
 import org.folio.search.integration.ReferenceDataService;
+import org.folio.search.utils.SearchUtils;
 
 public abstract class AbstractLccnProcessor<T> extends AbstractIdentifierProcessor<T> {
 
@@ -23,7 +20,7 @@ public abstract class AbstractLccnProcessor<T> extends AbstractIdentifierProcess
   @Override
   public Set<String> getFieldValue(T entity) {
     return filterIdentifiersValue(getIdentifiers(entity)).stream()
-      .flatMap(value -> Stream.of(normalizeLccn(value), extractLccnNumericPart(value)))
+      .map(SearchUtils::normalizeLccn)
       .filter(Objects::nonNull)
       .collect(Collectors.toCollection(LinkedHashSet::new));
   }

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -360,21 +360,6 @@ public class SearchUtils {
       .orElse(null);
   }
 
-  /**
-   * Extracts numeric part (digits starting with non-zero) of LCCN String value.
-   *
-   * @param value LCCN string value
-   * @return if exists, returns string of numeric part of LCCN value, otherwise returns null
-   */
-  public static String extractLccnNumericPart(String value) {
-    if (StringUtils.isBlank(value)) {
-      return null;
-    }
-
-    var matcher = LCCN_NUMERIC_PART_REGEX.matcher(value);
-    return matcher.find() ? matcher.group(0) : null;
-  }
-
   private static Object getMultilangValueObject(Object value) {
     return value instanceof MultilangValue v ? v.getMultilangValues() : value;
   }

--- a/src/test/java/org/folio/search/service/setter/authority/LccnAuthorityProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/authority/LccnAuthorityProcessorTest.java
@@ -61,13 +61,13 @@ class LccnAuthorityProcessorTest {
       arguments("all empty fields", new Authority(), emptySet()),
       arguments("lccn identifier=null", authorityWithIdentifiers(lccn(null), lccn("  ")), emptySet()),
       arguments("lccn identifier='  nbc  79021425 '",
-        authorityWithIdentifiers(lccn("  nbc  79021425 ")), Set.of("nbc79021425", "79021425")),
+        authorityWithIdentifiers(lccn("  nbc  79021425 ")), Set.of("nbc79021425")),
       arguments("lccn identifier='79021425'",
         authorityWithIdentifiers(lccn("79021425"), lccn("79021425")), Set.of("79021425")),
       arguments("lccn identifier='N79021425'",
-        authorityWithIdentifiers(lccn("N79021425")), Set.of("n79021425", "79021425")),
+        authorityWithIdentifiers(lccn("N79021425")), Set.of("n79021425")),
       arguments("lccn identifier='*79021425*'",
-        authorityWithIdentifiers(lccn("*1425"), lccn("7902*")), Set.of("*1425", "1425", "7902*", "7902"))
+        authorityWithIdentifiers(lccn("*1425"), lccn("7902*")), Set.of("*1425", "7902*"))
     );
   }
 

--- a/src/test/java/org/folio/search/service/setter/instance/LccnInstanceProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/instance/LccnInstanceProcessorTest.java
@@ -64,11 +64,11 @@ class LccnInstanceProcessorTest {
       arguments("all empty fields", new Instance(), emptySet()),
       arguments("lccn identifier=null", instanceWithIdentifiers(lccn(null), lccn("  ")), emptySet()),
       arguments("lccn identifier='  n  79021425 '",
-        instanceWithIdentifiers(lccn("  n  79021425 ")), Set.of("79021425", "n79021425")),
+        instanceWithIdentifiers(lccn("  n  79021425 ")), Set.of("n79021425")),
       arguments("lccn identifier='79021425'",
         instanceWithIdentifiers(lccn("79021425"), lccn("79021425")), Set.of("79021425")),
       arguments("lccn identifier='N79021425'",
-        instanceWithIdentifiers(lccn("N79021425")), Set.of("79021425", "n79021425"))
+        instanceWithIdentifiers(lccn("N79021425")), Set.of("n79021425"))
     );
   }
 

--- a/src/test/java/org/folio/search/utils/SearchUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchUtilsTest.java
@@ -8,7 +8,6 @@ import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.folio.search.model.metadata.PlainFieldDescription.STANDARD_FIELD_TYPE;
 import static org.folio.search.utils.CollectionUtils.mergeSafelyToSet;
 import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
-import static org.folio.search.utils.SearchUtils.extractLccnNumericPart;
 import static org.folio.search.utils.SearchUtils.getIndexName;
 import static org.folio.search.utils.SearchUtils.getResourceName;
 import static org.folio.search.utils.SearchUtils.getTotalPages;
@@ -98,14 +97,6 @@ class SearchUtilsTest {
   void getLccnNormalized_parameterized(String value, String expected) {
     var normalized = normalizeLccn(value);
     assertThat(normalized).isEqualTo(expected);
-  }
-
-  @DisplayName("LCCN value numeric part")
-  @CsvSource({"nbc 1234,1234", "nbc1234,1234", "  N  1234 ,1234", "*1234,1234", "1234*,1234"})
-  @ParameterizedTest(name = "[{index}] value={0}, expected={1}")
-  void extractLccnNumericPart_parameterized(String value, String expected) {
-    var numericPart = extractLccnNumericPart(value);
-    assertThat(numericPart).isEqualTo(expected);
   }
 
   @CsvSource({


### PR DESCRIPTION
### Purpose
Remove ability to match on LCCN searches without a prefix

### Approach
- Remove additional numeric token creation in lccn processor

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-752](https://folio-org.atlassian.net/browse/MSEARCH-752)