### PR TITLE
fix(search-ids): keep right context in resource-id thread

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 
 ### Bug fixes
 * Do not delete kafka topics if collection topic is enabled ([MSEARCH-725](https://folio-org.atlassian.net/browse/MSEARCH-725))
+* Keep right context in resource-id thread ([MSEARCH-754](https://folio-org.atlassian.net/browse/MSEARCH-754))
 
 ### Tech Dept
 * Description ([ISSUE_NUMBER](https://folio-org.atlassian.net/browse/ISSUE_NUMBER))

--- a/src/main/java/org/folio/search/configuration/AsyncConfig.java
+++ b/src/main/java/org/folio/search/configuration/AsyncConfig.java
@@ -3,6 +3,7 @@ package org.folio.search.configuration;
 import java.util.concurrent.Executor;
 import lombok.RequiredArgsConstructor;
 import org.folio.search.configuration.properties.StreamIdsProperties;
+import org.folio.spring.scope.FolioExecutionScopeExecutionContextManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -15,13 +16,14 @@ public class AsyncConfig {
 
   private final StreamIdsProperties streamIdsProperties;
 
-  @Bean
-  public Executor taskExecutor() {
+  @Bean("streamIdsExecutor")
+  public Executor streamIdsExecutor() {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(streamIdsProperties.getCorePoolSize());
     executor.setMaxPoolSize(streamIdsProperties.getMaxPoolSize());
     executor.setQueueCapacity(streamIdsProperties.getQueueCapacity());
     executor.setThreadNamePrefix("StreamResourceIds-");
+    executor.setTaskDecorator(FolioExecutionScopeExecutionContextManager::getRunnableWithCurrentFolioContext);
     executor.initialize();
     return executor;
   }

--- a/src/main/java/org/folio/search/service/ResourceIdsJobService.java
+++ b/src/main/java/org/folio/search/service/ResourceIdsJobService.java
@@ -2,11 +2,13 @@ package org.folio.search.service;
 
 import java.security.SecureRandom;
 import java.util.Date;
+import java.util.concurrent.Executor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.folio.search.converter.ResourceIdsJobMapper;
 import org.folio.search.domain.dto.ResourceIdsJob;
+import org.folio.search.model.streamids.ResourceIdsJobEntity;
 import org.folio.search.model.types.StreamJobStatus;
 import org.folio.search.repository.ResourceIdsJobRepository;
 import org.folio.search.service.consortium.ConsortiumTenantExecutor;
@@ -21,6 +23,7 @@ public class ResourceIdsJobService {
   private final ResourceIdsJobRepository jobRepository;
   private final ResourceIdsJobMapper resourceIdsJobMapper;
   private final ResourceIdService resourceIdService;
+  private final Executor streamIdsExecutor;
 
   public ResourceIdsJob getJobById(String id) {
     var jobEntity = consortiumTenantExecutor.execute(() -> jobRepository.getReferenceById(id));
@@ -35,10 +38,15 @@ public class ResourceIdsJobService {
     entity.setTemporaryTableName(generateTemporaryTableName());
 
     log.info("Attempts to create streamJob by [resourceIdsJob: {}]", entity);
-    var savedJob = consortiumTenantExecutor.execute(() -> jobRepository.save(entity));
+    var savedJob = consortiumTenantExecutor.execute(() -> saveAndRun(entity, tenantId));
 
-    consortiumTenantExecutor.runAsync(() -> resourceIdService.streamResourceIdsForJob(savedJob, tenantId));
     return resourceIdsJobMapper.convert(savedJob);
+  }
+
+  private ResourceIdsJobEntity saveAndRun(ResourceIdsJobEntity entity, String tenantId) {
+    var job = jobRepository.save(entity);
+    streamIdsExecutor.execute(() -> resourceIdService.streamResourceIdsForJob(job, tenantId));
+    return job;
   }
 
   private String generateTemporaryTableName() {

--- a/src/main/java/org/folio/search/service/consortium/ConsortiumTenantExecutor.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumTenantExecutor.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.service.SystemUserScopedExecutionService;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Log4j2
@@ -37,11 +36,6 @@ public class ConsortiumTenantExecutor {
       operation.run();
       return null;
     });
-  }
-
-  @Async
-  public void runAsync(Runnable operation) {
-    run(operation);
   }
 
 }

--- a/src/test/java/org/folio/search/service/ResourceIdServiceTest.java
+++ b/src/test/java/org/folio/search/service/ResourceIdServiceTest.java
@@ -12,7 +12,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.opensearch.index.query.QueryBuilders.termQuery;
@@ -21,7 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import org.folio.search.configuration.properties.StreamIdsProperties;
 import org.folio.search.cql.CqlSearchQueryConverter;
@@ -33,9 +31,7 @@ import org.folio.search.model.streamids.ResourceIdsJobEntity;
 import org.folio.search.model.types.StreamJobStatus;
 import org.folio.search.repository.ResourceIdsJobRepository;
 import org.folio.search.repository.SearchRepository;
-import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.folio.spring.testing.type.UnitTest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -65,16 +61,8 @@ class ResourceIdServiceTest {
   private StreamIdsProperties properties;
   @Mock
   private ResourceIdsJobRepository jobRepository;
-  @Mock
-  private SystemUserScopedExecutionService executionService;
   @Spy
   private final ObjectMapper objectMapper = OBJECT_MAPPER;
-
-  @BeforeEach
-  void setUp() {
-    lenient().when(executionService.executeSystemUserScoped(any(), any()))
-      .thenAnswer(invocation -> ((Callable<?>) invocation.getArgument(1)).call());
-  }
 
   @Test
   void streamResourceIds() throws IOException {


### PR DESCRIPTION
### Purpose
Fix issues when the ids job is never completed. 

### Approach
Keep context in the stream id thread.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-754](https://folio-org.atlassian.net/browse/MSEARCH-754)
