### PR TITLE
fix: use truncate instead delete for db table clean-up

### DIFF
--- a/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceRepository.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceRepository.java
@@ -28,7 +28,7 @@ public class ConsortiumInstanceRepository {
 
   private static final String SELECT_BY_ID_SQL = "SELECT * FROM %s WHERE instance_id IN (%s)";
   private static final String DELETE_BY_TENANT_AND_ID_SQL = "DELETE FROM %s WHERE tenant_id = ? AND instance_id = ?;";
-  private static final String DELETE_ALL_SQL = "DELETE FROM %s;";
+  private static final String DELETE_ALL_SQL = "TRUNCATE TABLE %s;";
   private static final String UPSERT_SQL = """
       INSERT INTO %s (tenant_id, instance_id, json, created_date, updated_date)
       VALUES (?, ?, ?::json, ?, ?)
@@ -114,7 +114,8 @@ public class ConsortiumInstanceRepository {
   }
 
   public void deleteAll() {
-    jdbcTemplate.update(DELETE_ALL_SQL.formatted(getTableName()));
+    log.debug("deleteAll::consortium instances");
+    jdbcTemplate.execute(DELETE_ALL_SQL.formatted(getTableName()));
   }
 
   private ConsortiumInstance toConsortiumInstance(ResultSet rs) throws SQLException {

--- a/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceService.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceService.java
@@ -109,6 +109,7 @@ public class ConsortiumInstanceService {
   }
 
   public void deleteAll() {
+    log.info("Truncate consortium instances table");
     consortiumTenantExecutor.run(repository::deleteAll);
   }
 


### PR DESCRIPTION
### Purpose
Clean-up is too long

### Approach
use truncate instead delete for db table clean-up 

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-744](https://folio-org.atlassian.net/browse/MSEARCH-744)

### Learning and Resources (if applicable)
https://www.geeksforgeeks.org/difference-between-delete-and-truncate/
