### PR TITLE
fix(browse): duplicate results in exact match with diacritics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 * Do not delete kafka topics if collection topic is enabled ([MSEARCH-725](https://folio-org.atlassian.net/browse/MSEARCH-725))
 * Do additional search request on browse before getting backward succeeding in order to find preceding results ([MSEARCH-705](https://folio-org.atlassian.net/browse/MSEARCH-705))
 * Keep right context in resource-id thread ([MSEARCH-754](https://folio-org.atlassian.net/browse/MSEARCH-754))
+* Browse: Duplicate results in exact match with diacritics ([MSEARCH-751](https://folio-org.atlassian.net/browse/MSEARCH-751))
 
 ### Tech Dept
 * Re-Index: delete all records from consortium_instance on full re-index ([MSEARCH-744](https://folio-org.atlassian.net/browse/MSEARCH-744))

--- a/src/main/java/org/folio/search/service/browse/AuthorityBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/AuthorityBrowseService.java
@@ -86,6 +86,7 @@ public class AuthorityBrowseService extends AbstractBrowseServiceBySearchAfter<A
       .query(query)
       .from(0)
       .size(ctx.getLimit(ctx.isBrowsingForward()))
+      .sort(fieldSort(request.getTargetField()))
       .fetchSource(getIncludedSourceFields(request), null);
   }
 

--- a/src/main/java/org/folio/search/service/browse/ContributorBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/ContributorBrowseService.java
@@ -46,6 +46,10 @@ public class ContributorBrowseService extends
     context.getFilters().forEach(boolQuery::filter);
     var query = consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(context, boolQuery, request.getResource());
     return searchSource().query(query)
+      .sort(fieldSort(request.getTargetField()))
+      .sort(fieldSort(AUTHORITY_ID_FIELD).missing(MISSING_LAST_PROP))
+      .sort(fieldSort(CONTRIBUTOR_NAME_TYPE_ID_FIELD).missing(MISSING_LAST_PROP))
+      .sort(fieldSort(CONTRIBUTOR_TYPE_ID_FIELD).missing(MISSING_LAST_PROP).sortMode(SortMode.MAX))
       .size(context.getLimit(context.isBrowsingForward()))
       .from(0);
   }

--- a/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
@@ -43,6 +43,7 @@ public class SubjectBrowseService extends AbstractBrowseServiceBySearchAfter<Sub
     var query = consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(context,
       termQuery(request.getTargetField(), context.getAnchor()), request.getResource());
     return searchSource().query(query)
+      .sort(fieldSort(request.getTargetField()))
       .size(context.getLimit(context.isBrowsingForward()))
       .from(0);
   }

--- a/src/test/java/org/folio/search/controller/BrowseAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseAuthorityIT.java
@@ -57,7 +57,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
                                    + "and isTitleHeadingRef==false "
                                    + "and tenantId==" + TENANT_ID + " "
                                    + "and shared==false "
-                                   + "and headingType==(\"Personal Name\")", "\"James Rollins\""))
+                                   + "and headingType==(\"Personal Name\")", "\"James Röllins\""))
       .param("limit", "7")
       .param("precedingRecordsCount", "2");
     var actual = parseResponse(doGet(request), AuthorityBrowseResult.class);
@@ -65,15 +65,31 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
       .totalRecords(2).prev(null).next(null)
       .items(List.of(
         authorityBrowseItem("Brian K. Vaughan", 22, "Personal Name", AUTHORIZED, 0),
-        emptyAuthorityBrowseItem("James Rollins"),
+        emptyAuthorityBrowseItem("James Röllins"),
         authorityBrowseItem("Zappa Frank", 23, "Personal Name", AUTHORIZED, 0)
+      )));
+  }
+
+  @Test
+  void browseByAuthority_browsingAroundWithDiacritics() {
+    var request = get(authorityBrowsePath())
+      .param("query", prepareQuery("(headingRef>={value} or headingRef<{value})", "\"James Röllins\""))
+      .param("limit", "3")
+      .param("precedingRecordsCount", "2");
+    var actual = parseResponse(doGet(request), AuthorityBrowseResult.class);
+    assertThat(actual).isEqualTo(new AuthorityBrowseResult()
+      .totalRecords(17).prev("Fantasy").next("James Röllins")
+      .items(List.of(
+        authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
+        authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
+        authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null).isAnchor(true)
       )));
   }
 
   @Test
   void browseByAuthority_browsingAroundWithPrecedingRecordsCount() {
     var request = get(authorityBrowsePath())
-      .param("query", prepareQuery("headingRef < {value} or headingRef >= {value}", "\"James Rollins\""))
+      .param("query", prepareQuery("headingRef < {value} or headingRef >= {value}", "\"James Röllins\""))
       .param("limit", "7")
       .param("precedingRecordsCount", "2");
     var actual = parseResponse(doGet(request), AuthorityBrowseResult.class);
@@ -82,7 +98,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
       .items(List.of(
         authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
         authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-        authorityBrowseItem("James Rollins", 2, "Personal Name", REFERENCE, null).isAnchor(true),
+        authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null).isAnchor(true),
         authorityBrowseItem("North America", 11, "Geographic Name", REFERENCE, null),
         authorityBrowseItem("Novel", 19, "Genre", AUTHORIZED, 0),
         authorityBrowseItem("Poetry", 20, "Genre", REFERENCE, null),
@@ -113,13 +129,13 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
     var actual = parseResponse(doGet(request), AuthorityBrowseResult.class);
 
     assertThat(actual).isEqualTo(new AuthorityBrowseResult()
-      .totalRecords(17).prev("Comic-Con").next("James Rollins")
+      .totalRecords(17).prev("Comic-Con").next("James Röllins")
       .items(List.of(
         authorityBrowseItem("Comic-Con", 7, "Conference Name", AUTHORIZED, 0),
         authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED, 0),
         authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
         authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-        authorityBrowseItem("James Rollins", 2, "Personal Name", REFERENCE, null))));
+        authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null))));
   }
 
   private static Stream<Arguments> authorityBrowsingDataProvider() {
@@ -141,13 +157,13 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
           authorityBrowseItem("Comic-Con", 7, "Conference Name", AUTHORIZED, 0)))),
 
       arguments(aroundQuery, "harry", 5, new AuthorityBrowseResult()
-        .totalRecords(17).prev("Disney").next("James Rollins")
+        .totalRecords(17).prev("Disney").next("James Röllins")
         .items(List.of(
           authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED, 0),
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
           emptyAuthorityBrowseItem("harry"),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Rollins", 2, "Personal Name", REFERENCE, null)))),
+          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null)))),
 
       arguments(aroundQuery, "a", 5, new AuthorityBrowseResult()
         .totalRecords(17).prev(null).next("Biomedical Symposium")
@@ -173,19 +189,19 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
           authorityBrowseItem("Comic-Con", 7, "Conference Name", AUTHORIZED, 0)))),
 
       arguments(aroundIncludingQuery, "harry", 5, new AuthorityBrowseResult()
-        .totalRecords(17).prev("Disney").next("James Rollins")
+        .totalRecords(17).prev("Disney").next("James Röllins")
         .items(List.of(
           authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED, 0),
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
           emptyAuthorityBrowseItem("harry"),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Rollins", 2, "Personal Name", REFERENCE, null)))),
+          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null)))),
 
       arguments(aroundIncludingQuery, "music", 5, new AuthorityBrowseResult()
         .totalRecords(17).prev("Harry Potter").next("Novel")
         .items(List.of(
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Rollins", 2, "Personal Name", REFERENCE, null),
+          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null),
           emptyAuthorityBrowseItem("music"),
           authorityBrowseItem("North America", 11, "Geographic Name", REFERENCE, null),
           authorityBrowseItem("Novel", 19, "Genre", AUTHORIZED, 0)))),
@@ -202,7 +218,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
           authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED, 0),
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Rollins", 2, "Personal Name", REFERENCE, null),
+          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null),
           emptyAuthorityBrowseItem("music"),
           authorityBrowseItem("North America", 11, "Geographic Name", REFERENCE, null),
           authorityBrowseItem("Novel", 19, "Genre", AUTHORIZED, 0),
@@ -220,7 +236,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
           authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED, 0),
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Rollins", 2, "Personal Name", REFERENCE, null),
+          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null),
           emptyAuthorityBrowseItem("music"),
           authorityBrowseItem("North America", 11, "Geographic Name", REFERENCE, null),
           authorityBrowseItem("Novel", 19, "Genre", AUTHORIZED, 0),
@@ -229,13 +245,13 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
           authorityBrowseItem("War and Peace", 14, "Uniform Title", REFERENCE, null)))),
 
       arguments(aroundIncludingQuery, "FC", 5, new AuthorityBrowseResult()
-        .totalRecords(17).prev("Disney").next("James Rollins")
+        .totalRecords(17).prev("Disney").next("James Röllins")
         .items(List.of(
           authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED, 0),
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
           emptyAuthorityBrowseItem("FC"),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Rollins", 2, "Personal Name", REFERENCE, null)))),
+          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null)))),
 
       // browsing forward
       arguments(forwardQuery, "Brian K. Vaughan", 5, new AuthorityBrowseResult()
@@ -262,7 +278,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
         .items(List.of(
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Rollins", 2, "Personal Name", REFERENCE, null),
+          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null),
           authorityBrowseItem("North America", 11, "Geographic Name", REFERENCE, null),
           authorityBrowseItem("Novel", 19, "Genre", AUTHORIZED, 0)))),
 
@@ -341,7 +357,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
     return new Authority[]
       {
         authority(1).personalNameTitle("Brian K. Vaughan Title"),
-        authority(2).sftPersonalNameTitle(List.of("James Rollins")),
+        authority(2).sftPersonalNameTitle(List.of("James Röllins")),
         authority(3).saftPersonalNameTitle(List.of("Brad Thor")),
         authority(4).corporateNameTitle("Disney"),
         authority(5).sftCorporateNameTitle(List.of("Blumberg Green Beauty")),

--- a/src/test/java/org/folio/search/controller/BrowseContributorConsortiumIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorConsortiumIT.java
@@ -105,9 +105,9 @@ class BrowseContributorConsortiumIT extends BaseConsortiumIntegrationTest {
       List.of(
         contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0]),
         contributorBrowseItem(1, "Anthony Kiedis", NAME_TYPE_IDS[1], AUTHORITY_IDS[1], TYPE_IDS[2]),
-        contributorBrowseItem(1, true, "Bon Jovi", NAME_TYPE_IDS[1], AUTHORITY_IDS[1],
-          TYPE_IDS[0]),
         contributorBrowseItem(1, true, "Bon Jovi", NAME_TYPE_IDS[0], AUTHORITY_IDS[0],
+          TYPE_IDS[0]),
+        contributorBrowseItem(1, true, "Bon Jovi", NAME_TYPE_IDS[1], AUTHORITY_IDS[1],
           TYPE_IDS[0]),
         contributorBrowseItem(2, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0],
           TYPE_IDS[1])));

--- a/src/test/java/org/folio/search/controller/BrowseContributorIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseContributorIT.java
@@ -109,8 +109,8 @@ class BrowseContributorIT extends BaseIntegrationTest {
         new ContributorBrowseResult().totalRecords(12).prev("John Lennon").next("Paul McCartney").items(List.of(
           contributorBrowseItem(1, "John Lennon", NAME_TYPE_IDS[2], null, TYPE_IDS[0]),
           contributorBrowseItem(2, "John Lennon", NAME_TYPE_IDS[2], AUTHORITY_IDS[1], TYPE_IDS[0]),
-          contributorBrowseItem(2, true, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
           contributorBrowseItem(1, true, "Klaus Meine", NAME_TYPE_IDS[1], AUTHORITY_IDS[0]),
+          contributorBrowseItem(2, true, "Klaus Meine", NAME_TYPE_IDS[0], AUTHORITY_IDS[1], TYPE_IDS[0], TYPE_IDS[1]),
           contributorBrowseItem(2, "Paul McCartney", NAME_TYPE_IDS[0], AUTHORITY_IDS[0], TYPE_IDS[0], TYPE_IDS[1])))),
 
       arguments(aroundIncludingQuery, "Zak", 25,

--- a/src/test/java/org/folio/search/service/browse/AuthorityBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/AuthorityBrowseServiceTest.java
@@ -256,11 +256,13 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), anchorSearchSource("s0", 3)),
+      List.of(anchorSearchSource("s0", 3)),
+      List.of(searchResult(authority("s0"))));
+    mockMultiSearchRequest(request,
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)),
       List.of(
         SearchResult.of(10, authorities("r2", "r1", "r0")),
-        searchResult(authorities("s1", "s2", "s3", "s4")),
-        searchResult(authority("s0"))));
+        searchResult(authorities("s1", "s2", "s3", "s4"))));
 
     var actual = authorityBrowseService.browse(request);
     assertThat(actual).isEqualTo(BrowseResult.of(10, "r1", "s2", List.of(
@@ -274,11 +276,13 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), anchorSearchSource("s0", 3)),
+      List.of(anchorSearchSource("s0", 3)),
+      List.of(searchResult(authority("s0"))));
+    mockMultiSearchRequest(request,
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)),
       List.of(
         SearchResult.of(10, authorities("r2", "r1")),
-        searchResult(authorities("s1", "s2", "s3", "s4")),
-        searchResult(authority("s0"))));
+        searchResult(authorities("s1", "s2", "s3", "s4"))));
 
     var actual = authorityBrowseService.browse(request);
     assertThat(actual).isEqualTo(BrowseResult.of(10, null, "s2", List.of(
@@ -292,11 +296,13 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), anchorSearchSource("s0", 3)),
+      List.of(anchorSearchSource("s0", 3)),
+      List.of(SearchResult.empty()));
+    mockMultiSearchRequest(request,
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)),
       List.of(
         SearchResult.of(10, authorities("r2", "r1")),
-        searchResult(authorities("s1", "s2", "s3")),
-        SearchResult.empty()));
+        searchResult(authorities("s1", "s2", "s3"))));
 
     var actual = authorityBrowseService.browse(request);
     assertThat(actual).isEqualTo(BrowseResult.of(10, null, "s2", List.of(
@@ -310,11 +316,13 @@ class AuthorityBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), anchorSearchSource("s0", 3)),
+      List.of(anchorSearchSource("s0", 3)),
+      List.of(SearchResult.empty()));
+    mockMultiSearchRequest(request,
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)),
       List.of(
         SearchResult.of(10, authorities("r2", "r1")),
-        searchResult(authorities("s1", "s2", "s3")),
-        SearchResult.empty()));
+        searchResult(authorities("s1", "s2", "s3"))));
 
     var actual = authorityBrowseService.browse(request);
     assertThat(actual).isEqualTo(BrowseResult.of(10, null, null, List.of(
@@ -359,7 +367,7 @@ class AuthorityBrowseServiceTest {
     var query = boolQuery()
       .filter(termsQuery("authRefType", "Authorized", "Reference"))
       .must(termQuery(TARGET_FIELD, headingRef));
-    return searchSource(query).from(0).size(size).fetchSource((String[]) null, null);
+    return searchSource(query).from(0).size(size).sort(TARGET_FIELD).fetchSource((String[]) null, null);
   }
 
   private void mockMultiSearchRequest(ResourceRequest request,

--- a/src/test/java/org/folio/search/service/browse/SubjectBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/SubjectBrowseServiceTest.java
@@ -269,11 +269,13 @@ class SubjectBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), subjectTermQuery("s0", 3)),
+      List.of(subjectTermQuery("s0", 3)),
+      List.of(searchResult(browseItems("s0"))));
+    mockMultiSearchRequest(request,
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)),
       List.of(
         searchResult(10, browseItems("r2", "r1", "r0")),
-        searchResult(10, browseItems("s1", "s2", "s3")),
-        searchResult(browseItems("s0"))));
+        searchResult(10, browseItems("s1", "s2", "s3"))));
 
     var actual = subjectBrowseService.browse(request);
     assertThat(actual).isEqualTo(BrowseResult.of(10, "r1", "s2", List.of(
@@ -288,11 +290,13 @@ class SubjectBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), subjectTermQuery("s0", 3)),
+      List.of(subjectTermQuery("s0", 3)),
+      List.of(searchResult(browseItems("s0", "s0"))));
+    mockMultiSearchRequest(request,
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)),
       List.of(
         searchResult(10, browseItems("r2", "r1", "r0")),
-        searchResult(10, browseItems("s1", "s2", "s3")),
-        searchResult(browseItems("s0", "s0"))));
+        searchResult(10, browseItems("s1", "s2", "s3"))));
 
     var actual = subjectBrowseService.browse(request);
     assertThat(actual).isEqualTo(BrowseResult.of(10, "r1", "s1", List.of(
@@ -307,11 +311,13 @@ class SubjectBrowseServiceTest {
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), subjectTermQuery("s0", 3)),
+      List.of(subjectTermQuery("s0", 3)),
+      List.of(searchResult(browseItems("s0"))));
+    mockMultiSearchRequest(request,
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)),
       List.of(
         SearchResult.of(10, List.of(browseItems("r2", "r1"))),
-        searchResult(browseItems("s1", "s2", "s3")),
-        searchResult(browseItems("s0"))));
+        searchResult(browseItems("s1", "s2", "s3"))));
 
     var actual = subjectBrowseService.browse(request);
     assertThat(actual).isEqualTo(BrowseResult.of(10, null, "s2", List.of(
@@ -325,12 +331,12 @@ class SubjectBrowseServiceTest {
     var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, true, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
+    mockAnchorEmptyResponse(request);
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), subjectTermQuery("s0", 3)),
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)),
       List.of(
         SearchResult.of(10, List.of(browseItems("r2", "r1", "r0"))),
-        searchResult(browseItems("s1", "s2", "s3", "s4")),
-        SearchResult.empty()));
+        searchResult(browseItems("s1", "s2", "s3", "s4"))));
 
     var actual = subjectBrowseService.browse(request);
     assertThat(actual).isEqualTo(BrowseResult.of(10, "r1", "s2", List.of(
@@ -344,12 +350,12 @@ class SubjectBrowseServiceTest {
     var request = BrowseRequest.of(INSTANCE_SUBJECT, TENANT_ID, query, 5, TARGET_FIELD, null, null, false, 2);
 
     when(browseContextProvider.get(request)).thenReturn(browseContextAround(true));
+    mockAnchorEmptyResponse(request);
     mockMultiSearchRequest(request,
-      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC), subjectTermQuery("s0", 3)),
+      List.of(searchSource("s0", 3, DESC), searchSource("s0", 4, ASC)),
       List.of(
         SearchResult.of(10, List.of(browseItems("r2", "r1", "r0"))),
-        searchResult(browseItems("s1", "s2", "s3", "s4")),
-        SearchResult.empty()));
+        searchResult(browseItems("s1", "s2", "s3", "s4"))));
 
     var actual = subjectBrowseService.browse(request);
     assertThat(actual).isEqualTo(BrowseResult.of(10, "r1", "s3", List.of(
@@ -357,12 +363,18 @@ class SubjectBrowseServiceTest {
       subjectBrowseItem(2, "s2"), subjectBrowseItem(2, "s3"))));
   }
 
+  private void mockAnchorEmptyResponse(BrowseRequest request) {
+    mockMultiSearchRequest(request,
+      List.of(subjectTermQuery("s0", 3)),
+      List.of(SearchResult.empty()));
+  }
+
   private SubjectResource[] browseItems(String... subject) {
     return Arrays.stream(subject).map(sub -> {
       var subjectResource = new SubjectResource();
       subjectResource.setValue(sub);
       subjectResource.setInstances(sub.chars().mapToObj(String::valueOf)
-          .map(s -> InstanceSubResource.builder().instanceId(s).build())
+        .map(s -> InstanceSubResource.builder().instanceId(s).build())
         .collect(Collectors.toSet()));
       return subjectResource;
     }).toArray(SubjectResource[]::new);
@@ -380,7 +392,7 @@ class SubjectBrowseServiceTest {
   }
 
   private SearchSourceBuilder subjectTermQuery(String subjectValue, int size) {
-    return searchSource(termQuery(TARGET_FIELD, subjectValue)).from(0).size(size);
+    return searchSource(termQuery(TARGET_FIELD, subjectValue)).from(0).size(size).sort(TARGET_FIELD);
   }
 
   private BrowseContext browseContextAround(boolean includeAnchor) {


### PR DESCRIPTION
### Purpose
Fix duplicate results in exact match with diacritics while browsing

### Approach
Use `sort` result values from anchor search response as values for `searchAfter`
![image](https://github.com/folio-org/mod-search/assets/5904625/d96793dd-686b-42f9-bb9f-e59c90910ddf)
With this approach we will use already processed by search engine value

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-751](https://folio-org.atlassian.net/browse/MSEARCH-751)
