### PR TITLE
fix(browse): use analyze api to get anchor for browse

### DIFF
--- a/src/main/java/org/folio/search/service/browse/AbstractBrowseServiceBySearchAfter.java
+++ b/src/main/java/org/folio/search/service/browse/AbstractBrowseServiceBySearchAfter.java
@@ -88,6 +88,11 @@ public abstract class AbstractBrowseServiceBySearchAfter<T, R> extends AbstractB
     return createBrowseResult(responses, request, context);
   }
 
+  protected String getAnchorValue(BrowseRequest request, BrowseContext ctx) {
+    return searchRepository.analyze(ctx.getAnchor(), request.getTargetField(), request.getResource(),
+      request.getTenantId());
+  }
+
   /**
    * Provides anchor search query for the given {@link BrowseRequest} and {@link BrowseContext} objects.
    *

--- a/src/main/java/org/folio/search/service/browse/AuthorityBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/AuthorityBrowseService.java
@@ -1,6 +1,5 @@
 package org.folio.search.service.browse;
 
-import static java.util.Locale.ROOT;
 import static org.apache.commons.lang3.BooleanUtils.isFalse;
 import static org.folio.search.model.index.AuthRefType.AUTHORIZED;
 import static org.folio.search.model.index.AuthRefType.REFERENCE;
@@ -67,7 +66,7 @@ public class AuthorityBrowseService extends AbstractBrowseServiceBySearchAfter<A
     ctx.getFilters().forEach(boolQuery::filter);
     var query = consortiumSearchHelper.filterQueryForActiveAffiliation(boolQuery, AUTHORITY_RESOURCE);
     return searchSource().query(query)
-      .searchAfter(new Object[] {ctx.getAnchor().toLowerCase(ROOT)})
+      .searchAfter(new Object[] {getAnchorValue(request, ctx)})
       .sort(fieldSort(request.getTargetField()).order(isBrowsingForward ? ASC : DESC))
       .size(ctx.getLimit(isBrowsingForward) + 1)
       .fetchSource(getIncludedSourceFields(request), null)

--- a/src/main/java/org/folio/search/service/browse/ContributorBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/ContributorBrowseService.java
@@ -1,6 +1,5 @@
 package org.folio.search.service.browse;
 
-import static java.util.Locale.ROOT;
 import static java.util.Objects.nonNull;
 import static org.folio.search.utils.SearchUtils.AUTHORITY_ID_FIELD;
 import static org.opensearch.index.query.QueryBuilders.boolQuery;
@@ -68,7 +67,7 @@ public class ContributorBrowseService extends
     }
     query = consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(ctx, query, req.getResource());
     return searchSource().query(query)
-      .searchAfter(new Object[] {ctx.getAnchor().toLowerCase(ROOT), null, null, null})
+      .searchAfter(new Object[] {getAnchorValue(req, ctx), null, null, null})
       .sort(fieldSort(req.getTargetField()).order(isBrowsingForward ? ASC : DESC))
       .sort(fieldSort(AUTHORITY_ID_FIELD).missing(MISSING_LAST_PROP))
       .sort(fieldSort(CONTRIBUTOR_NAME_TYPE_ID_FIELD).missing(MISSING_LAST_PROP))

--- a/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/SubjectBrowseService.java
@@ -1,6 +1,5 @@
 package org.folio.search.service.browse;
 
-import static java.util.Locale.ROOT;
 import static java.util.Objects.nonNull;
 import static org.opensearch.index.query.QueryBuilders.boolQuery;
 import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
@@ -61,7 +60,7 @@ public class SubjectBrowseService extends AbstractBrowseServiceBySearchAfter<Sub
     }
     query = consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(ctx, query, req.getResource());
     return searchSource().query(query)
-      .searchAfter(new Object[] {ctx.getAnchor().toLowerCase(ROOT)})
+      .searchAfter(new Object[] {getAnchorValue(req, ctx)})
       .sort(fieldSort(req.getTargetField()).order(isBrowsingForward ? ASC : DESC))
       .size(ctx.getLimit(isBrowsingForward) + 1)
       .from(0);

--- a/src/test/java/org/folio/search/controller/BrowseAuthorityIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseAuthorityIT.java
@@ -57,7 +57,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
                                    + "and isTitleHeadingRef==false "
                                    + "and tenantId==" + TENANT_ID + " "
                                    + "and shared==false "
-                                   + "and headingType==(\"Personal Name\")", "\"James Röllins\""))
+                                   + "and headingType==(\"Personal Name\")", "\"Ĵämes Röllins\""))
       .param("limit", "7")
       .param("precedingRecordsCount", "2");
     var actual = parseResponse(doGet(request), AuthorityBrowseResult.class);
@@ -65,7 +65,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
       .totalRecords(2).prev(null).next(null)
       .items(List.of(
         authorityBrowseItem("Brian K. Vaughan", 22, "Personal Name", AUTHORIZED, 0),
-        emptyAuthorityBrowseItem("James Röllins"),
+        emptyAuthorityBrowseItem("Ĵämes Röllins"),
         authorityBrowseItem("Zappa Frank", 23, "Personal Name", AUTHORIZED, 0)
       )));
   }
@@ -73,23 +73,23 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
   @Test
   void browseByAuthority_browsingAroundWithDiacritics() {
     var request = get(authorityBrowsePath())
-      .param("query", prepareQuery("(headingRef>={value} or headingRef<{value})", "\"James Röllins\""))
+      .param("query", prepareQuery("(headingRef>={value} or headingRef<{value})", "\"Ĵämes Röllins test\""))
       .param("limit", "3")
       .param("precedingRecordsCount", "2");
     var actual = parseResponse(doGet(request), AuthorityBrowseResult.class);
     assertThat(actual).isEqualTo(new AuthorityBrowseResult()
-      .totalRecords(17).prev("Fantasy").next("James Röllins")
+      .totalRecords(17).prev("Harry Potter").next("Ĵämes Röllins test")
       .items(List.of(
-        authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
         authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-        authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null).isAnchor(true)
+        authorityBrowseItem("Ĵämes Röllins", 2, "Personal Name", REFERENCE, null),
+        emptyAuthorityBrowseItem("Ĵämes Röllins test")
       )));
   }
 
   @Test
   void browseByAuthority_browsingAroundWithPrecedingRecordsCount() {
     var request = get(authorityBrowsePath())
-      .param("query", prepareQuery("headingRef < {value} or headingRef >= {value}", "\"James Röllins\""))
+      .param("query", prepareQuery("headingRef < {value} or headingRef >= {value}", "\"Ĵämes Röllins\""))
       .param("limit", "7")
       .param("precedingRecordsCount", "2");
     var actual = parseResponse(doGet(request), AuthorityBrowseResult.class);
@@ -98,7 +98,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
       .items(List.of(
         authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
         authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-        authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null).isAnchor(true),
+        authorityBrowseItem("Ĵämes Röllins", 2, "Personal Name", REFERENCE, null).isAnchor(true),
         authorityBrowseItem("North America", 11, "Geographic Name", REFERENCE, null),
         authorityBrowseItem("Novel", 19, "Genre", AUTHORIZED, 0),
         authorityBrowseItem("Poetry", 20, "Genre", REFERENCE, null),
@@ -129,13 +129,13 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
     var actual = parseResponse(doGet(request), AuthorityBrowseResult.class);
 
     assertThat(actual).isEqualTo(new AuthorityBrowseResult()
-      .totalRecords(17).prev("Comic-Con").next("James Röllins")
+      .totalRecords(17).prev("Comic-Con").next("Ĵämes Röllins")
       .items(List.of(
         authorityBrowseItem("Comic-Con", 7, "Conference Name", AUTHORIZED, 0),
         authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED, 0),
         authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
         authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-        authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null))));
+        authorityBrowseItem("Ĵämes Röllins", 2, "Personal Name", REFERENCE, null))));
   }
 
   private static Stream<Arguments> authorityBrowsingDataProvider() {
@@ -157,13 +157,13 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
           authorityBrowseItem("Comic-Con", 7, "Conference Name", AUTHORIZED, 0)))),
 
       arguments(aroundQuery, "harry", 5, new AuthorityBrowseResult()
-        .totalRecords(17).prev("Disney").next("James Röllins")
+        .totalRecords(17).prev("Disney").next("Ĵämes Röllins")
         .items(List.of(
           authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED, 0),
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
           emptyAuthorityBrowseItem("harry"),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null)))),
+          authorityBrowseItem("Ĵämes Röllins", 2, "Personal Name", REFERENCE, null)))),
 
       arguments(aroundQuery, "a", 5, new AuthorityBrowseResult()
         .totalRecords(17).prev(null).next("Biomedical Symposium")
@@ -189,19 +189,19 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
           authorityBrowseItem("Comic-Con", 7, "Conference Name", AUTHORIZED, 0)))),
 
       arguments(aroundIncludingQuery, "harry", 5, new AuthorityBrowseResult()
-        .totalRecords(17).prev("Disney").next("James Röllins")
+        .totalRecords(17).prev("Disney").next("Ĵämes Röllins")
         .items(List.of(
           authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED, 0),
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
           emptyAuthorityBrowseItem("harry"),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null)))),
+          authorityBrowseItem("Ĵämes Röllins", 2, "Personal Name", REFERENCE, null)))),
 
       arguments(aroundIncludingQuery, "music", 5, new AuthorityBrowseResult()
         .totalRecords(17).prev("Harry Potter").next("Novel")
         .items(List.of(
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null),
+          authorityBrowseItem("Ĵämes Röllins", 2, "Personal Name", REFERENCE, null),
           emptyAuthorityBrowseItem("music"),
           authorityBrowseItem("North America", 11, "Geographic Name", REFERENCE, null),
           authorityBrowseItem("Novel", 19, "Genre", AUTHORIZED, 0)))),
@@ -218,7 +218,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
           authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED, 0),
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null),
+          authorityBrowseItem("Ĵämes Röllins", 2, "Personal Name", REFERENCE, null),
           emptyAuthorityBrowseItem("music"),
           authorityBrowseItem("North America", 11, "Geographic Name", REFERENCE, null),
           authorityBrowseItem("Novel", 19, "Genre", AUTHORIZED, 0),
@@ -236,7 +236,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
           authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED, 0),
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null),
+          authorityBrowseItem("Ĵämes Röllins", 2, "Personal Name", REFERENCE, null),
           emptyAuthorityBrowseItem("music"),
           authorityBrowseItem("North America", 11, "Geographic Name", REFERENCE, null),
           authorityBrowseItem("Novel", 19, "Genre", AUTHORIZED, 0),
@@ -245,13 +245,13 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
           authorityBrowseItem("War and Peace", 14, "Uniform Title", REFERENCE, null)))),
 
       arguments(aroundIncludingQuery, "FC", 5, new AuthorityBrowseResult()
-        .totalRecords(17).prev("Disney").next("James Röllins")
+        .totalRecords(17).prev("Disney").next("Ĵämes Röllins")
         .items(List.of(
           authorityBrowseItem("Disney", 4, "Corporate Name", AUTHORIZED, 0),
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
           emptyAuthorityBrowseItem("FC"),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null)))),
+          authorityBrowseItem("Ĵämes Röllins", 2, "Personal Name", REFERENCE, null)))),
 
       // browsing forward
       arguments(forwardQuery, "Brian K. Vaughan", 5, new AuthorityBrowseResult()
@@ -278,7 +278,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
         .items(List.of(
           authorityBrowseItem("Fantasy", 17, "Topical", REFERENCE, null),
           authorityBrowseItem("Harry Potter", 13, "Uniform Title", AUTHORIZED, 0),
-          authorityBrowseItem("James Röllins", 2, "Personal Name", REFERENCE, null),
+          authorityBrowseItem("Ĵämes Röllins", 2, "Personal Name", REFERENCE, null),
           authorityBrowseItem("North America", 11, "Geographic Name", REFERENCE, null),
           authorityBrowseItem("Novel", 19, "Genre", AUTHORIZED, 0)))),
 
@@ -357,7 +357,7 @@ class BrowseAuthorityIT extends BaseIntegrationTest {
     return new Authority[]
       {
         authority(1).personalNameTitle("Brian K. Vaughan Title"),
-        authority(2).sftPersonalNameTitle(List.of("James Röllins")),
+        authority(2).sftPersonalNameTitle(List.of("Ĵämes Röllins")),
         authority(3).saftPersonalNameTitle(List.of("Brad Thor")),
         authority(4).corporateNameTitle("Disney"),
         authority(5).sftCorporateNameTitle(List.of("Blumberg Green Beauty")),

--- a/src/test/java/org/folio/search/service/browse/AuthorityBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/AuthorityBrowseServiceTest.java
@@ -8,6 +8,7 @@ import static org.folio.search.utils.TestUtils.authorityBrowseItem;
 import static org.folio.search.utils.TestUtils.searchResult;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.index.query.QueryBuilders.boolQuery;
@@ -81,6 +82,8 @@ class AuthorityBrowseServiceTest {
     authorityBrowseService.setSearchRepository(searchRepository);
     authorityBrowseService.setBrowseContextProvider(browseContextProvider);
     authorityBrowseService.setSearchResponsePostProcessors(searchResponsePostProcessors);
+    lenient().when(searchRepository.analyze(any(), any(), any(), any()))
+      .thenAnswer(invocation -> invocation.getArgument(0));
   }
 
   @Test

--- a/src/test/java/org/folio/search/service/browse/ContributorBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/ContributorBrowseServiceTest.java
@@ -17,8 +17,10 @@ import org.folio.search.model.index.ContributorResource;
 import org.folio.search.model.index.InstanceSubResource;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.model.service.BrowseRequest;
+import org.folio.search.repository.SearchRepository;
 import org.folio.search.service.consortium.ConsortiumSearchHelper;
 import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,9 +35,16 @@ class ContributorBrowseServiceTest {
 
   @Mock
   private ConsortiumSearchHelper consortiumSearchHelper;
+  @Mock
+  private SearchRepository searchRepository;
 
   @InjectMocks
   private ContributorBrowseService service;
+
+  @BeforeEach
+  void setUp() {
+    service.setSearchRepository(searchRepository);
+  }
 
   @Test
   void mapToBrowseResult_positive() {
@@ -79,6 +88,8 @@ class ContributorBrowseServiceTest {
     var browseContext = BrowseContext.builder().anchor("test").succeedingLimit(1).precedingLimit(1).build();
     var queryMock = disMaxQuery();
 
+    when(searchRepository.analyze(eq(browseContext.getAnchor()), eq(browseRequest.getTargetField()), any(), any()))
+      .thenReturn("test");
     when(consortiumSearchHelper.filterBrowseQueryForActiveAffiliation(eq(browseContext), any(), any()))
       .thenReturn(queryMock);
 

--- a/src/test/java/org/folio/search/service/browse/SubjectBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/SubjectBrowseServiceTest.java
@@ -75,6 +75,8 @@ class SubjectBrowseServiceTest {
       .when(consortiumSearchHelper).filterBrowseQueryForActiveAffiliation(any(), any(), any());
     lenient().doAnswer(invocation -> ((SubjectResource) invocation.getArgument(1)).getInstances())
       .when(consortiumSearchHelper).filterSubResourcesForConsortium(any(), any(), any());
+    lenient().when(searchRepository.analyze(any(), any(), any(), any()))
+      .thenAnswer(invocation -> invocation.getArgument(0));
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Fix browse issue when input term with diacritics are set to the end of the list in case when there is no match.

### Approach
Use analyze api to get anchor for browse

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-751](https://folio-org.atlassian.net/browse/MSEARCH-751)

### Learning and Resources (if applicable)
https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html
