### PR TITLE
MSEARCH-761: Fix Instances count in Shared facet

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,7 @@
 * Do additional search request on browse before getting backward succeeding in order to find preceding results ([MSEARCH-705](https://folio-org.atlassian.net/browse/MSEARCH-705))
 * Keep right context in resource-id thread ([MSEARCH-754](https://folio-org.atlassian.net/browse/MSEARCH-754))
 * Browse: Duplicate results in exact match with diacritics ([MSEARCH-751](https://folio-org.atlassian.net/browse/MSEARCH-751))
-* Fix instances count for Shared Facet ([MSEARCH-761](https://folio-org.atlassian.net/browse/MSEARCH-761))
+* Classification browse: Fix instances count for Shared Facet ([MSEARCH-761](https://folio-org.atlassian.net/browse/MSEARCH-761))
 
 ### Tech Dept
 * Re-Index: delete all records from consortium_instance on full re-index ([MSEARCH-744](https://folio-org.atlassian.net/browse/MSEARCH-744))

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 * Do additional search request on browse before getting backward succeeding in order to find preceding results ([MSEARCH-705](https://folio-org.atlassian.net/browse/MSEARCH-705))
 * Keep right context in resource-id thread ([MSEARCH-754](https://folio-org.atlassian.net/browse/MSEARCH-754))
 * Browse: Duplicate results in exact match with diacritics ([MSEARCH-751](https://folio-org.atlassian.net/browse/MSEARCH-751))
+* Fix instances count for Shared Facet ([MSEARCH-761](https://folio-org.atlassian.net/browse/MSEARCH-761))
 
 ### Tech Dept
 * Re-Index: delete all records from consortium_instance on full re-index ([MSEARCH-744](https://folio-org.atlassian.net/browse/MSEARCH-744))

--- a/src/main/java/org/folio/search/repository/classification/InstanceClassificationJdbcRepository.java
+++ b/src/main/java/org/folio/search/repository/classification/InstanceClassificationJdbcRepository.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.PreparedStatement;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -59,7 +60,7 @@ public class InstanceClassificationJdbcRepository implements InstanceClassificat
     WHERE classification_type_id = ? AND classification_number = ? AND tenant_id = ? AND instance_id = ?;
     """;
   private static final int BATCH_SIZE = 100;
-  private static final TypeReference<Set<InstanceSubResource>> VALUE_TYPE_REF = new TypeReference<>() { };
+  private static final TypeReference<LinkedHashSet<InstanceSubResource>> VALUE_TYPE_REF = new TypeReference<>() { };
 
   private final FolioExecutionContext context;
   private final JdbcTemplate jdbcTemplate;

--- a/src/main/java/org/folio/search/service/converter/preprocessor/InstanceEventPreProcessor.java
+++ b/src/main/java/org/folio/search/service/converter/preprocessor/InstanceEventPreProcessor.java
@@ -3,6 +3,7 @@ package org.folio.search.service.converter.preprocessor;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.apache.commons.collections4.MapUtils.getObject;
+import static org.apache.commons.lang3.StringUtils.removeStart;
 import static org.apache.commons.lang3.StringUtils.startsWith;
 import static org.folio.search.domain.dto.ResourceEventType.UPDATE;
 import static org.folio.search.utils.CollectionUtils.subtract;
@@ -15,7 +16,6 @@ import static org.folio.search.utils.SearchUtils.CLASSIFICATION_NUMBER_FIELD;
 import static org.folio.search.utils.SearchUtils.CLASSIFICATION_TYPE_FIELD;
 import static org.folio.search.utils.SearchUtils.INSTANCE_CLASSIFICATION_RESOURCE;
 import static org.folio.search.utils.SearchUtils.SOURCE_CONSORTIUM_PREFIX;
-import static org.folio.search.utils.SearchUtils.SOURCE_FOLIO;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -79,9 +79,10 @@ public class InstanceEventPreProcessor implements EventPreProcessor {
   }
 
   private boolean isUpdateForInstanceSharing(ResourceEvent event) {
+    var newSource = getResourceSource(getNewAsMap(event));
     return event.getType() == UPDATE
-      && startsWith(getResourceSource(getNewAsMap(event)), SOURCE_CONSORTIUM_PREFIX)
-      && SOURCE_FOLIO.equals(getResourceSource(getOldAsMap(event)));
+      && startsWith(newSource, SOURCE_CONSORTIUM_PREFIX)
+      && Objects.equals(getResourceSource(getOldAsMap(event)), removeStart(newSource, SOURCE_CONSORTIUM_PREFIX));
   }
 
   private List<ResourceEvent> prepareClassificationEventsOnInstanceSharing(ResourceEvent event) {

--- a/src/main/java/org/folio/search/service/converter/preprocessor/InstanceEventPreProcessor.java
+++ b/src/main/java/org/folio/search/service/converter/preprocessor/InstanceEventPreProcessor.java
@@ -59,7 +59,6 @@ public class InstanceEventPreProcessor implements EventPreProcessor {
     if (log.isDebugEnabled()) {
       log.debug("preProcess::Starting instance event pre-processing [{}]", event);
     }
-    log.info("event: {}", event);
 
     List<ResourceEvent> events;
 
@@ -139,13 +138,9 @@ public class InstanceEventPreProcessor implements EventPreProcessor {
     var entityAggList = instanceClassificationRepository.fetchAggregatedByClassifications(entitiesForFetch);
     var list = getResourceEventsForDeletion(entitiesForDelete, entityAggList, tenant);
 
-    log.info("deletion events: ");
-    list.forEach(ev -> log.info("del-event: {}", ev));
     var list1 = entityAggList.stream()
       .map(entities -> toResourceCreateEvent(entities, tenant))
       .toList();
-    log.info("creation events: ");
-    list1.forEach(ev -> log.info("cr-event: {}", ev));
     return CollectionUtils.mergeSafelyToList(list, list1);
   }
 
@@ -176,13 +171,13 @@ public class InstanceEventPreProcessor implements EventPreProcessor {
     for (var classification : entitiesForDelete) {
       for (InstanceClassificationEntityAgg agg : aggregatedEntities) {
         if (agg.number().equals(classification.number()) && Objects.equals(agg.typeId(), classification.typeId())) {
-          var subInstance = InstanceSubResource.builder()
+          var subResource = InstanceSubResource.builder()
             .instanceId(classification.instanceId())
             .shared(classification.shared())
             .tenantId(tenant)
             .typeId(classification.typeId())
             .build();
-          agg.instances().remove(subInstance);
+          agg.instances().remove(subResource);
           break;
         }
       }

--- a/src/main/java/org/folio/search/service/converter/preprocessor/InstanceEventPreProcessor.java
+++ b/src/main/java/org/folio/search/service/converter/preprocessor/InstanceEventPreProcessor.java
@@ -61,6 +61,7 @@ public class InstanceEventPreProcessor implements EventPreProcessor {
       return List.of(event);
     }
 
+    log.info("event: {}", event);
     var events = prepareClassificationEvents(event);
 
     log.info("preProcess::Finished instance event pre-processing");
@@ -101,9 +102,13 @@ public class InstanceEventPreProcessor implements EventPreProcessor {
     var entityAggList = instanceClassificationRepository.fetchAggregatedByClassifications(entitiesForFetch);
     var list = getResourceEventsForDeletion(entitiesForDelete, entityAggList, tenant);
 
+    log.info("deletion events: ");
+    list.forEach(ev -> log.info("del-event: {}", ev));
     var list1 = entityAggList.stream()
       .map(entities -> toResourceCreateEvent(entities, tenant))
       .toList();
+    log.info("creation events: ");
+    list1.forEach(ev -> log.info("cr-event: {}", ev));
     return CollectionUtils.mergeSafelyToList(list, list1);
   }
 

--- a/src/main/java/org/folio/search/utils/SearchUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchUtils.java
@@ -65,6 +65,7 @@ public class SearchUtils {
   public static final String CLASSIFICATION_TYPE_FIELD = "classificationTypeId";
   public static final String SUBJECT_AGGREGATION_NAME = "subjects.value";
   public static final String SOURCE_CONSORTIUM_PREFIX = "CONSORTIUM-";
+  public static final String SOURCE_FOLIO = "FOLIO";
 
   public static final String CQL_META_FIELD_PREFIX = "cql.";
   public static final String MULTILANG_SOURCE_SUBFIELD = "src";
@@ -103,7 +104,6 @@ public class SearchUtils {
     """;
   //CHECKSTYLE.OFF: LineLength
 
-  private static final Pattern LCCN_NUMERIC_PART_REGEX = Pattern.compile("([1-9]\\d+)");
   private static final Pattern NON_ALPHA_NUMERIC_CHARS_PATTERN = Pattern.compile("[^a-zA-Z0-9]");
 
   /**


### PR DESCRIPTION
### Purpose
_Shared facet shows incorrect count for the shared/non shared instances_

### Approach
_Handle the instance update event for sharing the instance appropriately_

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-761](https://folio-org.atlassian.net/browse/MSEARCH-761)