### PR TITLE
fix(consortium-search): Limit number of ids passed to consortium batch items/holdings apis

### DIFF
--- a/src/main/resources/swagger.api/parameters/batchIdsDto.yaml
+++ b/src/main/resources/swagger.api/parameters/batchIdsDto.yaml
@@ -4,7 +4,7 @@ properties:
   ids:
     description: Entity IDs
     type: array
-    maxItems: 1024
+    maxItems: 1000
     items:
       type: string
       format: uuid

--- a/src/main/resources/swagger.api/parameters/batchIdsDto.yaml
+++ b/src/main/resources/swagger.api/parameters/batchIdsDto.yaml
@@ -4,6 +4,7 @@ properties:
   ids:
     description: Entity IDs
     type: array
+    maxItems: 1024
     items:
       type: string
       format: uuid

--- a/src/test/java/org/folio/search/controller/ConsortiumSearchHoldingsIT.java
+++ b/src/test/java/org/folio/search/controller/ConsortiumSearchHoldingsIT.java
@@ -1,6 +1,7 @@
 package org.folio.search.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.search.controller.ConsortiumSearchItemsIT.WRONG_SIZE_MSG;
 import static org.folio.search.controller.SearchConsortiumController.REQUEST_NOT_ALLOWED_MSG;
 import static org.folio.search.model.Pair.pair;
 import static org.folio.search.sample.SampleInstances.getSemanticWeb;
@@ -19,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.folio.search.domain.dto.BatchIdsDto;
 import org.folio.search.domain.dto.ConsortiumHolding;
 import org.folio.search.domain.dto.ConsortiumHoldingCollection;
@@ -139,6 +141,23 @@ class ConsortiumSearchHoldingsIT extends BaseConsortiumIntegrationTest {
       .andExpect(jsonPath("$.errors[0].code", is("validation_error")))
       .andExpect(jsonPath("$.errors[0].parameters[0].key", is("x-okapi-tenant")))
       .andExpect(jsonPath("$.errors[0].parameters[0].value", is(MEMBER_TENANT_ID)));
+  }
+
+  @Test
+  void tryGetConsortiumBatchHoldings_returns400_whenMoreIdsThanLimit() throws Exception {
+    var request = new BatchIdsDto()
+      .ids(
+        Stream.iterate(0, i -> i < 1025, i -> ++i)
+          .map(i -> UUID.randomUUID())
+          .toList()
+      );
+
+    tryPost(consortiumBatchHoldingsSearchPath(), request)
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.errors[0].message", is(WRONG_SIZE_MSG)))
+      .andExpect(jsonPath("$.errors[0].type", is("MethodArgumentNotValidException")))
+      .andExpect(jsonPath("$.errors[0].code", is("validation_error")))
+      .andExpect(jsonPath("$.errors[0].parameters[0].key", is("ids")));
   }
 
   private ConsortiumHolding[] getExpectedHoldings() {

--- a/src/test/java/org/folio/search/controller/ConsortiumSearchHoldingsIT.java
+++ b/src/test/java/org/folio/search/controller/ConsortiumSearchHoldingsIT.java
@@ -147,7 +147,7 @@ class ConsortiumSearchHoldingsIT extends BaseConsortiumIntegrationTest {
   void tryGetConsortiumBatchHoldings_returns400_whenMoreIdsThanLimit() throws Exception {
     var request = new BatchIdsDto()
       .ids(
-        Stream.iterate(0, i -> i < 1025, i -> ++i)
+        Stream.iterate(0, i -> i < 1001, i -> ++i)
           .map(i -> UUID.randomUUID())
           .toList()
       );

--- a/src/test/java/org/folio/search/controller/ConsortiumSearchItemsIT.java
+++ b/src/test/java/org/folio/search/controller/ConsortiumSearchItemsIT.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 class ConsortiumSearchItemsIT extends BaseConsortiumIntegrationTest {
 
   static final String WRONG_SIZE_MSG =
-    "size must be between 0 and 1024";
+    "size must be between 0 and 1000";
 
   @BeforeAll
   static void prepare() {
@@ -153,7 +153,7 @@ class ConsortiumSearchItemsIT extends BaseConsortiumIntegrationTest {
   void tryGetConsortiumBatchItems_returns400_whenMoreIdsThanLimit() throws Exception {
     var request = new BatchIdsDto()
       .ids(
-        Stream.iterate(0, i -> i < 1025, i -> ++i)
+        Stream.iterate(0, i -> i < 1001, i -> ++i)
           .map(i -> UUID.randomUUID())
           .toList()
       );


### PR DESCRIPTION
### Purpose
Limit number of ids passed to consortium batch items/holdings apis

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-759](https://folio-org.atlassian.net/browse/MSEARCH-759)

### Learning and Resources (if applicable)
[search-settings](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/search-settings.html)