### PR TITLE
[DO NOT MERGE] get instances from streaming inventory view endpoint

### DIFF
--- a/src/main/java/org/folio/search/client/StreamingInventoryViewClient.java
+++ b/src/main/java/org/folio/search/client/StreamingInventoryViewClient.java
@@ -1,0 +1,35 @@
+package org.folio.search.client;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.folio.search.configuration.StreamingFeignClientConfiguration;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(value = "inventory-view-stream", url = "inventory-view",
+  configuration = StreamingFeignClientConfiguration.class)
+public interface StreamingInventoryViewClient {
+
+  /**
+   * Retrieves resources by ids from inventory service.
+   *
+   * <p>Instances are retrieved as map to collect all fields that can be ignored by mod-search, but still can be
+   * required to implement specific features, like searching by all fields.</p>
+   */
+  @PostMapping(path = "/instances", consumes = APPLICATION_JSON_VALUE)
+  Stream<String> getInstances(@RequestBody IdInput ids);
+
+  @Data
+  @AllArgsConstructor
+  @NoArgsConstructor
+  class IdInput {
+    private List<String> ids;
+  }
+
+}

--- a/src/main/java/org/folio/search/configuration/StreamingFeignClientConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/StreamingFeignClientConfiguration.java
@@ -1,0 +1,36 @@
+package org.folio.search.configuration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import feign.Feign;
+import feign.codec.Decoder;
+import feign.optionals.OptionalDecoder;
+import feign.stream.StreamDecoder;
+import java.io.BufferedReader;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.cloud.openfeign.support.HttpMessageConverterCustomizer;
+import org.springframework.cloud.openfeign.support.ResponseEntityDecoder;
+import org.springframework.cloud.openfeign.support.SpringDecoder;
+import org.springframework.context.annotation.Bean;
+
+public class StreamingFeignClientConfiguration {
+
+  @Bean
+  public Decoder feignDecoder(ObjectProvider<HttpMessageConverterCustomizer> customizers,
+                              ObjectFactory<HttpMessageConverters> messageConverters) {
+    return StreamDecoder.create((r, t) -> {
+        BufferedReader bufferedReader = new BufferedReader(r.body().asReader(UTF_8));
+        return bufferedReader.lines().iterator();
+      },
+      new OptionalDecoder(new ResponseEntityDecoder(new SpringDecoder(messageConverters, customizers)))
+    );
+  }
+
+  @Bean
+  public Feign.Builder builder() {
+    return Feign.builder()
+      .doNotCloseAfterDecode();
+  }
+}


### PR DESCRIPTION
### Purpose
Spike to validate retrieval of instance objects from mod-inventory-storage via a streaming endpoint.

### Approach
Use an alternate Feign configuration to allow streaming. 

We should confirm that the response object from Feign is closed.

Spike PR creating the streaming endpoint in mod-inventory-storage is [here](https://github.com/folio-org/mod-inventory-storage/pull/1037)
