### PR TITLE
[MSEARCH-809] Extend batch holdings search endpoint with filtering by instanceId

### DIFF
--- a/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceSearchService.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceSearchService.java
@@ -178,7 +178,7 @@ public class ConsortiumInstanceSearchService {
         .map(holding -> toConsortiumHolding(instance.getId(), holding))
         .distinct()
         .toList();
-    } else if (identifierType == IdentifierTypeEnum.INSTANCE_HRID) {
+    } else if (identifierType == IdentifierTypeEnum.INSTANCE_HRID || identifierType == IdentifierTypeEnum.INSTANCE_ID) {
       return instance.getHoldings()
         .stream()
         .map(holding -> toConsortiumHolding(instance.getId(), holding))

--- a/src/main/java/org/folio/search/utils/IdentifierUtils.java
+++ b/src/main/java/org/folio/search/utils/IdentifierUtils.java
@@ -24,6 +24,7 @@ public class IdentifierUtils {
     return switch (identifierType) {
       case ITEM_BARCODE -> "items.barcode";
       case INSTANCE_HRID -> "hrid";
+      case INSTANCE_ID -> "id";
       default -> format(VALUE_PATTERN, INSTANCE_HOLDING_FIELD_NAME, identifierType.getValue());
     };
   }

--- a/src/main/resources/swagger.api/parameters/batchIdsDto.yaml
+++ b/src/main/resources/swagger.api/parameters/batchIdsDto.yaml
@@ -11,6 +11,7 @@ properties:
       - "formerIds"
       - "barcode"
       - "holdingsRecordId"
+      - "instanceId"
       - "instanceHrid"
       - "itemBarcode"
   identifierValues:

--- a/src/test/java/org/folio/search/controller/ConsortiumSearchHoldingsIT.java
+++ b/src/test/java/org/folio/search/controller/ConsortiumSearchHoldingsIT.java
@@ -179,6 +179,21 @@ class ConsortiumSearchHoldingsIT extends BaseConsortiumIntegrationTest {
   }
 
   @Test
+  void doGetConsortiumBatchHoldingsByInstanceId_returns200AndRecords() {
+    var instance = getSemanticWeb();
+    var instanceId = instance.getId();
+    var holdings = getExpectedConsolidatedHoldings();
+    var request = new BatchIdsDto()
+      .identifierType(BatchIdsDto.IdentifierTypeEnum.INSTANCE_ID)
+      .identifierValues(List.of(instanceId));
+    var result = doPost(consortiumBatchHoldingsSearchPath(), CENTRAL_TENANT_ID, request);
+    var actual = parseResponse(result, ConsortiumHoldingCollection.class);
+
+    assertThat(actual.getTotalRecords()).isEqualTo(holdings.length);
+    assertThat(actual.getHoldings()).containsExactlyInAnyOrder(holdings);
+  }
+
+  @Test
   void tryGetConsortiumBatchHoldings_returns400_whenRequestedForNotCentralTenant() throws Exception {
     tryPost(consortiumBatchHoldingsSearchPath(),
       new BatchIdsDto().identifierType(BatchIdsDto.IdentifierTypeEnum.ID)


### PR DESCRIPTION
### Purpose
[[MSEARCH-809] Extend batch holdings search endpoint with filtering by instanceId](https://folio-org.atlassian.net/browse/MSEARCH-809)

### Approach
- Add instanceId as an identifier type

### Resources
Verification in Jira comment: https://folio-org.atlassian.net/browse/MSEARCH-809?focusedCommentId=223845