### PR TITLE
[MSEARCH-819] Add module permissions for linked-data APIs

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -112,6 +112,9 @@
           "pathPattern": "/search/linked-data/works",
           "permissionsRequired": [
             "search.linked-data.work.collection.get"
+          ],
+          "modulePermissions": [
+            "user-tenants.collection.get"
           ]
         },
         {
@@ -121,6 +124,9 @@
           "pathPattern": "/search/linked-data/authorities",
           "permissionsRequired": [
             "search.linked-data.authority.collection.get"
+          ],
+          "modulePermissions": [
+            "user-tenants.collection.get"
           ]
         },
         {


### PR DESCRIPTION
### Purpose
Searching for linked data resources fails due to HTTP 403 error in Beta test environment. From the logs it is clear that the ```user-tenants.collection.get``` permission is required.

### Approach
Module permission ```user-tenants.collection.get``` has been added for the following two APIs in mod-search’s Module descriptor:

- /search/linked-data/works
- /search/linked-data/authorities

### Related Issues
[MSEARCH-819](https://folio-org.atlassian.net/browse/MSEARCH-819)
