### PR TITLE
feat: add indices recreation possibility for linked-data-work and linked-data-authority

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Provides `consortium-search v1.2`
 
 ### Features
+* Implement indices recreation of linked-data-work and linked-data-authority ([MSEARCH-820](https://issues.folio.org/browse/MSEARCH-820))
 * Extension of mod-search consortium items/holdings API ([MSEARCH-788](https://issues.folio.org/browse/MSEARCH-788))
 * Create location index and process location events ([MSEARCH-703](https://issues.folio.org/browse/MSEARCH-703))
 * Implement reindexing of locations ([MSEARCH-702](https://issues.folio.org/browse/MSEARCH-702))

--- a/README.md
+++ b/README.md
@@ -334,11 +334,13 @@ x-okapi-token: [JWT_TOKEN]
 }
 ```
 
-* `resourceName` parameter is optional and equal to `instance` by default. Possible values: `instance`, `authority`, `locations`
-  Please note that `locations` reindex is synchronous
+* `resourceName` parameter is optional and equal to `instance` by default. Possible values: `instance`, `authority`, `locations`,
+  `linked-data-work`, `linked-data-authority`. Please note that `locations` reindex is synchronous.
 * `recreateIndex` parameter is optional and equal to `false` by default. If it is equal to `true` then mod-search
   will drop existing indices for tenant and resource, creating them again. Executing request with this parameter
   equal to `true` in query will erase all the tenant data in mod-search.
+* Please note that for `linked-data-work` and `linked-data-authority` resources the endpoint is used only for index recreation
+  purpose and actual reindex operation is triggered through mod-linked-data.
 
 ### Monitoring reindex process
 

--- a/src/main/java/org/folio/search/service/IndexService.java
+++ b/src/main/java/org/folio/search/service/IndexService.java
@@ -2,6 +2,8 @@ package org.folio.search.service;
 
 import static java.lang.Boolean.TRUE;
 import static org.folio.search.utils.SearchUtils.INSTANCE_RESOURCE;
+import static org.folio.search.utils.SearchUtils.LINKED_DATA_AUTHORITY_RESOURCE;
+import static org.folio.search.utils.SearchUtils.LINKED_DATA_WORK_RESOURCE;
 import static org.folio.search.utils.SearchUtils.LOCATION_RESOURCE;
 import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
 
@@ -156,6 +158,8 @@ public class IndexService {
 
     if (LOCATION_RESOURCE.equals(resource)) {
       return reindexInventoryLocations(tenantId, resources);
+    } else if (isLinkedDataResource(resource)) {
+      return new ReindexJob();
     } else {
       return reindexInventoryAsync(resource);
     }
@@ -287,5 +291,9 @@ public class IndexService {
 
   private static String normalizeResourceName(String url) {
     return url.replace("_", "-");
+  }
+
+  private boolean isLinkedDataResource(String resource) {
+    return LINKED_DATA_WORK_RESOURCE.equals(resource) || LINKED_DATA_AUTHORITY_RESOURCE.equals(resource);
   }
 }

--- a/src/main/resources/model/linked_data_authority.json
+++ b/src/main/resources/model/linked_data_authority.json
@@ -1,7 +1,7 @@
 {
   "name": "linked-data-authority",
   "eventBodyJavaClass": "org.folio.search.domain.dto.LinkedDataAuthority",
-  "reindexSupported": false,
+  "reindexSupported": true,
   "fields": {
     "id": {
       "index": "keyword"

--- a/src/main/resources/model/linked_data_work.json
+++ b/src/main/resources/model/linked_data_work.json
@@ -1,6 +1,7 @@
 {
   "name": "linked-data-work",
   "eventBodyJavaClass": "org.folio.search.domain.dto.LinkedDataWork",
+  "reindexSupported": true,
   "languageSourcePaths": [ "$.languages" ],
   "fields": {
     "id": {

--- a/src/main/resources/swagger.api/schemas/request/reindexRequest.yaml
+++ b/src/main/resources/swagger.api/schemas/request/reindexRequest.yaml
@@ -13,6 +13,8 @@ properties:
       - instance
       - authority
       - location
+      - linked-data-work
+      - linked-data-authority
   indexSettings:
     description: Index settings to apply for index
     $ref: "../../schemas/entity/indexSettings.yaml"

--- a/src/test/java/org/folio/search/controller/IndexManagementIT.java
+++ b/src/test/java/org/folio/search/controller/IndexManagementIT.java
@@ -5,24 +5,32 @@ import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.FIVE_SECONDS;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
 import static org.folio.search.domain.dto.ReindexRequest.ResourceNameEnum.AUTHORITY;
+import static org.folio.search.domain.dto.ReindexRequest.ResourceNameEnum.LINKED_DATA_WORK;
 import static org.folio.search.domain.dto.ReindexRequest.ResourceNameEnum.LOCATION;
 import static org.folio.search.utils.SearchUtils.CAMPUS_RESOURCE;
 import static org.folio.search.utils.SearchUtils.INSTITUTION_RESOURCE;
 import static org.folio.search.utils.SearchUtils.LIBRARY_RESOURCE;
+import static org.folio.search.utils.SearchUtils.LINKED_DATA_WORK_RESOURCE;
 import static org.folio.search.utils.SearchUtils.LOCATION_RESOURCE;
 import static org.folio.search.utils.SearchUtils.getResourceName;
+import static org.folio.search.utils.TestConstants.MEMBER_TENANT_ID;
 import static org.folio.search.utils.TestUtils.asJsonString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.stream.Stream;
 import org.folio.search.domain.dto.Authority;
 import org.folio.search.domain.dto.IndexDynamicSettings;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.ReindexRequest;
+import org.folio.search.domain.dto.ReindexRequest.ResourceNameEnum;
 import org.folio.search.domain.dto.UpdateIndexDynamicSettingsRequest;
 import org.folio.search.support.base.ApiEndpoints;
 import org.folio.search.support.base.BaseIntegrationTest;
@@ -31,7 +39,12 @@ import org.folio.spring.testing.type.IntegrationTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.RequestBuilder;
 
 @IntegrationTest
 class IndexManagementIT extends BaseIntegrationTest {
@@ -114,6 +127,41 @@ class IndexManagementIT extends BaseIntegrationTest {
     });
   }
 
+  @ParameterizedTest
+  @EnumSource(value = ResourceNameEnum.class, names = {"LINKED_DATA_WORK", "LINKED_DATA_AUTHORITY"})
+  void runReindex_shouldRecreate_linkedDataResourcesIndexes(ResourceNameEnum resourceNameEnum) throws Exception {
+    var resourceName = resourceNameEnum.getValue();
+    var request = post(ApiEndpoints.reindexPath())
+      .content(asJsonString(new ReindexRequest().resourceName(resourceNameEnum).recreateIndex(true)))
+      .headers(defaultHeaders())
+      .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
+      .contentType(MediaType.APPLICATION_JSON);
+    var indexIdBeforeReindex = getIndexId(resourceName);
+
+    mockMvc.perform(request)
+      .andExpect(status().isOk());
+
+    await().atMost(FIVE_SECONDS)
+      .pollInterval(ONE_HUNDRED_MILLISECONDS)
+      .untilAsserted(() -> {
+        assertNotEquals(indexIdBeforeReindex, getIndexId(resourceName));
+        assertThat(countDefaultIndexDocument(resourceName)).isEqualTo(0);
+      });
+  }
+
+  @ParameterizedTest
+  @MethodSource("requestBuilderDataProvider")
+  void runReindex_shouldNotRecreate_linkedDataResourcesIndexes(RequestBuilder requestBuilder) throws Exception {
+    var indexIdBeforeReindex = getIndexId(LINKED_DATA_WORK_RESOURCE);
+
+    mockMvc.perform(requestBuilder)
+      .andExpect(status().isOk());
+
+    await().atMost(FIVE_SECONDS)
+      .pollInterval(ONE_HUNDRED_MILLISECONDS)
+      .untilAsserted(() -> assertEquals(indexIdBeforeReindex, getIndexId(LINKED_DATA_WORK_RESOURCE)));
+  }
+
   @Test
   void runReindex_negative_instanceSubject() throws Exception {
     var resource = "instance_subject";
@@ -189,6 +237,32 @@ class IndexManagementIT extends BaseIntegrationTest {
 
   private static String reindexUnexpectedResource(String resource) {
     return REINDEX_UNEXPECTED_RESOURCE.formatted(resource);
+  }
+
+  private static Stream<Arguments> requestBuilderDataProvider() {
+    return Stream.of(
+      arguments(
+        post(ApiEndpoints.reindexPath())
+          .content(asJsonString(new ReindexRequest().resourceName(LINKED_DATA_WORK)))
+          .headers(defaultHeaders())
+          .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
+          .contentType(MediaType.APPLICATION_JSON)
+      ),
+      arguments(
+        post(ApiEndpoints.reindexPath())
+          .content(asJsonString(new ReindexRequest().resourceName(LINKED_DATA_WORK).recreateIndex(true)))
+          .headers(defaultHeaders(MEMBER_TENANT_ID))
+          .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
+          .contentType(MediaType.APPLICATION_JSON)
+      ),
+      arguments(
+        post(ApiEndpoints.reindexPath())
+          .content(asJsonString(new ReindexRequest().resourceName(AUTHORITY).recreateIndex(true)))
+          .headers(defaultHeaders())
+          .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
+          .contentType(MediaType.APPLICATION_JSON)
+      )
+    );
   }
 
 }

--- a/src/test/java/org/folio/search/controller/IndexManagementIT.java
+++ b/src/test/java/org/folio/search/controller/IndexManagementIT.java
@@ -82,11 +82,7 @@ class IndexManagementIT extends BaseIntegrationTest {
 
   @Test
   void runReindex_positive_authority() throws Exception {
-    var request = post(ApiEndpoints.reindexPath())
-      .content(asJsonString(new ReindexRequest().resourceName(AUTHORITY)))
-      .headers(defaultHeaders())
-      .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
-      .contentType(MediaType.APPLICATION_JSON);
+    var request = getReindexRequestBuilder(asJsonString(new ReindexRequest().resourceName(AUTHORITY)));
 
     mockMvc.perform(request)
       .andExpect(status().isOk())
@@ -97,11 +93,7 @@ class IndexManagementIT extends BaseIntegrationTest {
 
   @Test
   void runReindex_positive_locations() throws Exception {
-    var request = post(ApiEndpoints.reindexPath())
-      .content(asJsonString(new ReindexRequest().resourceName(LOCATION)))
-      .headers(defaultHeaders())
-      .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
-      .contentType(MediaType.APPLICATION_JSON);
+    var request = getReindexRequestBuilder(asJsonString(new ReindexRequest().resourceName(LOCATION)));
 
     assertThat(countDefaultIndexDocument(LOCATION_RESOURCE)).isZero();
     assertThat(countDefaultIndexDocument(CAMPUS_RESOURCE)).isZero();
@@ -131,11 +123,8 @@ class IndexManagementIT extends BaseIntegrationTest {
   @EnumSource(value = ResourceNameEnum.class, names = {"LINKED_DATA_WORK", "LINKED_DATA_AUTHORITY"})
   void runReindex_shouldRecreate_linkedDataResourcesIndexes(ResourceNameEnum resourceNameEnum) throws Exception {
     var resourceName = resourceNameEnum.getValue();
-    var request = post(ApiEndpoints.reindexPath())
-      .content(asJsonString(new ReindexRequest().resourceName(resourceNameEnum).recreateIndex(true)))
-      .headers(defaultHeaders())
-      .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
-      .contentType(MediaType.APPLICATION_JSON);
+    var request =
+      getReindexRequestBuilder(asJsonString(new ReindexRequest().resourceName(resourceNameEnum).recreateIndex(true)));
     var indexIdBeforeReindex = getIndexId(resourceName);
 
     mockMvc.perform(request)
@@ -165,11 +154,7 @@ class IndexManagementIT extends BaseIntegrationTest {
   @Test
   void runReindex_negative_instanceSubject() throws Exception {
     var resource = "instance_subject";
-    var request = post(ApiEndpoints.reindexPath())
-      .content(reindexRequestJson(resource))
-      .headers(defaultHeaders())
-      .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
-      .contentType(MediaType.APPLICATION_JSON);
+    var request = getReindexRequestBuilder(reindexRequestJson(resource));
 
     mockMvc.perform(request)
       .andExpect(status().isBadRequest())
@@ -182,11 +167,7 @@ class IndexManagementIT extends BaseIntegrationTest {
   @Test
   void runReindex_negative_contributor() throws Exception {
     var resource = "contributor";
-    var request = post(ApiEndpoints.reindexPath())
-      .content(reindexRequestJson(resource))
-      .headers(defaultHeaders())
-      .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
-      .contentType(MediaType.APPLICATION_JSON);
+    var request = getReindexRequestBuilder(reindexRequestJson(resource));
 
     mockMvc.perform(request)
       .andExpect(status().isBadRequest())
@@ -242,11 +223,7 @@ class IndexManagementIT extends BaseIntegrationTest {
   private static Stream<Arguments> requestBuilderDataProvider() {
     return Stream.of(
       arguments(
-        post(ApiEndpoints.reindexPath())
-          .content(asJsonString(new ReindexRequest().resourceName(LINKED_DATA_WORK)))
-          .headers(defaultHeaders())
-          .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
-          .contentType(MediaType.APPLICATION_JSON)
+        getReindexRequestBuilder(asJsonString(new ReindexRequest().resourceName(LINKED_DATA_WORK)))
       ),
       arguments(
         post(ApiEndpoints.reindexPath())
@@ -256,13 +233,17 @@ class IndexManagementIT extends BaseIntegrationTest {
           .contentType(MediaType.APPLICATION_JSON)
       ),
       arguments(
-        post(ApiEndpoints.reindexPath())
-          .content(asJsonString(new ReindexRequest().resourceName(AUTHORITY).recreateIndex(true)))
-          .headers(defaultHeaders())
-          .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
-          .contentType(MediaType.APPLICATION_JSON)
+        getReindexRequestBuilder(asJsonString(new ReindexRequest().resourceName(AUTHORITY).recreateIndex(true)))
       )
     );
+  }
+
+  private static RequestBuilder getReindexRequestBuilder(String content) {
+    return post(ApiEndpoints.reindexPath())
+      .content(content)
+      .headers(defaultHeaders())
+      .header(XOkapiHeaders.URL, okapi.getOkapiUrl())
+      .contentType(MediaType.APPLICATION_JSON);
   }
 
 }

--- a/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/search/support/base/BaseIntegrationTest.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -194,6 +195,11 @@ public abstract class BaseIntegrationTest {
       .indices(getIndexName(resource, tenantId));
     var searchResponse = elasticClient.search(searchRequest, RequestOptions.DEFAULT);
     return searchResponse.getHits().getTotalHits().value;
+  }
+
+  protected static String getIndexId(String resource) throws IOException {
+    var getIndexResponse = elasticClient.indices().get(new GetIndexRequest(getIndexName(resource, TENANT_ID)), DEFAULT);
+    return getIndexResponse.getSetting(getIndexResponse.getIndices()[0], "index.uuid");
   }
 
   protected static long countDefaultIndexDocument(String resource) throws IOException {


### PR DESCRIPTION
… and linked-data-authority

### Purpose
The purpose of this pull request is to incorporate the indices recreation functionality into the Linked Data module. The Linked Data module needs the ability to reset its indexes in scenarios where a change to the system requires re-indexing the data graph, so that the indices reflect that changes introduced into the application.

### Approach
```POST [OKAPI_URL]/search/index/inventory/reindex``` endpoint is being used to recreate ```linked-data-work``` and ```linked-data-authority``` resources' indices.

### Changes Checklist
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-820](https://folio-org.atlassian.net/browse/MSEARCH-820)
