### PR TITLE
fix(search-instances): Fix range query convertions when other filters present

### DIFF
--- a/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
+++ b/src/test/java/org/folio/search/controller/SearchInstanceFilterIT.java
@@ -279,6 +279,9 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
         List.of(IDS[0])),
       arguments("(holdings.metadata.createdDate>=2016-01-01 and holdings.metadata.createdDate<=2018-12-12) "
         + "sortby title", List.of()),
+      arguments("(staffSuppress==false "
+        + "and holdings.metadata.createdDate>=2016-01-01 and holdings.metadata.createdDate<=2018-12-12) "
+        + "sortby title", List.of()),
 
       arguments("(holdings.metadata.updatedDate >= 2021-03-14) sortby title", List.of(IDS[3])),
       arguments("(holdings.metadata.updatedDate > 2021-03-01) sortby title", List.of(IDS[0], IDS[1], IDS[3])),
@@ -337,6 +340,9 @@ class SearchInstanceFilterIT extends BaseIntegrationTest {
       arguments("(items.metadata.createdDate>= 2021-03-01 and metadata.createdDate < 2021-03-10) sortby title",
         List.of(IDS[0], IDS[2])),
       arguments("(items.metadata.createdDate>=2016-01-01 and items.metadata.createdDate<=2018-12-12) sortby title",
+        List.of()),
+      arguments("(staffSuppress==false "
+          + "and items.metadata.createdDate>=2016-01-01 and items.metadata.createdDate<=2018-12-12) sortby title",
         List.of()),
 
       arguments("(items.metadata.updatedDate >= 2021-03-14) sortby title", List.of(IDS[2], IDS[3])),


### PR DESCRIPTION
### Purpose
Fix range query convertions when other filters present

### Approach
Move range query collapsing on the latest stage of conversion, iterate through all range queries to find ones suitable for collapsing

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-845](https://folio-org.atlassian.net/browse/MSEARCH-845)
