### PR TITLE
fix(cn-browse): remove shelving order calculation for local types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Bug fixes
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Remove shelving order calculation for local call-number types
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessor.java
@@ -1,15 +1,9 @@
 package org.folio.search.service.setter.item;
 
-import static org.folio.search.client.InventoryReferenceDataClient.ReferenceDataType.CALL_NUMBER_TYPES;
-import static org.folio.search.model.client.CqlQueryParam.SOURCE;
-import static org.folio.search.model.types.CallNumberTypeSource.LOCAL;
-import static org.folio.search.service.browse.CallNumberBrowseService.FOLIO_CALL_NUMBER_TYPES_SOURCES;
 import static org.folio.search.utils.CallNumberUtils.getCallNumberAsLong;
 import static org.folio.search.utils.CollectionUtils.toLinkedHashSet;
 import static org.folio.search.utils.CollectionUtils.toStreamSafe;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -18,7 +12,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;
-import org.folio.search.integration.folio.ReferenceDataService;
 import org.folio.search.model.types.CallNumberType;
 import org.folio.search.service.setter.FieldProcessor;
 import org.folio.search.utils.CallNumberUtils;
@@ -27,10 +20,6 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class ItemTypedCallNumberProcessor implements FieldProcessor<Instance, Set<Long>> {
-
-  static final List<String> LOCAL_CALL_NUMBER_TYPES_SOURCES = Collections.singletonList(LOCAL.getSource());
-
-  private final ReferenceDataService referenceDataService;
 
   @Override
   public Set<Long> getFieldValue(Instance instance) {
@@ -44,9 +33,7 @@ public class ItemTypedCallNumberProcessor implements FieldProcessor<Instance, Se
 
   public Optional<Integer> getCallNumberTypedPrefix(String callNumberTypeId) {
     return CallNumberType.fromId(callNumberTypeId)
-      .map(CallNumberType::getNumber)
-      .or(() -> isLocalCallNumberTypeId(callNumberTypeId)
-        ? Optional.of(CallNumberType.LOCAL.getNumber()) : Optional.empty());
+      .map(CallNumberType::getNumber);
   }
 
   private Long toCallNumberLongRepresentation(Item item) {
@@ -61,11 +48,6 @@ public class ItemTypedCallNumberProcessor implements FieldProcessor<Instance, Se
         .map(integer -> getCallNumberAsLong(effectiveShelvingOrder, integer))
         .orElse(null);
     }
-  }
-
-  private boolean isLocalCallNumberTypeId(String callNumberTypeId) {
-    return !referenceDataService.fetchReferenceData(CALL_NUMBER_TYPES, SOURCE, FOLIO_CALL_NUMBER_TYPES_SOURCES)
-      .contains(callNumberTypeId);
   }
 
 }

--- a/src/test/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/item/ItemTypedCallNumberProcessorTest.java
@@ -43,8 +43,7 @@ class ItemTypedCallNumberProcessorTest {
       373897542542740736L,
       518452648491797760L,
       663007754440854784L,
-      807562860389911808L,
-      952117966338968832L);
+      807562860389911808L);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
### Purpose
Remove shelving order calculation for local types. It may slowdown indexing on ECS setup.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related issue
https://folio-org.atlassian.net/browse/MSEARCH-878

