### PR TITLE
fix(deps): MSEARCH-889: opensearch 2.18.0 fixing protobuf-java vuln (CVE-2024-7254)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,7 @@
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Dependencies
-* Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`
+* Bump `opensearch` from `2.17.1` to `2.18.0` fixing protobuf-java CVE-2024-7254 ([MSEARCH-889](https://folio-org.atlassian.net/browse/MSEARCH-889))
 * Add `LIB_NAME VERSION`
 * Remove `LIB_NAME`
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <folio-service-tools.version>4.2.0-SNAPSHOT</folio-service-tools.version>
     <folio-isbn-utils.version>1.7.0-SNAPSHOT</folio-isbn-utils.version>
     <folio-cql2pgjson.version>35.3.0</folio-cql2pgjson.version>
-    <opensearch.version>2.17.1</opensearch.version>
+    <opensearch.version>2.18.0</opensearch.version>
     <mapstruct.version>1.6.2</mapstruct.version>
     <apache-commons-io.version>2.17.0</apache-commons-io.version>
     <apache-commons-collections.version>4.4</apache-commons-collections.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MSEARCH-889

Upgrade opensearch from 2.17.1 to 2.18.0.

This indirectly upgrades protobuf-java from 3.22.3 to 3.25.5 fixing infinite recursion stack overflow.

* https://www.cve.org/CVERecord?id=CVE-2024-7254

### Purpose
Fix vulnerability.

### Approach
Bump opensearch version in pom.xml.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [x] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-889](https://folio-org.atlassian.net/browse/MSEARCH-889)