### PR TITLE
fix(browse): Fix old browse config returned on get after upsert

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Use keyword_icu instead of keyword_lowercase for fulltext fields plain values ([MSEARCH-857](https://folio-org.atlassian.net/browse/MSEARCH-857))
 * Populate typeId and sourceId on subjects re-indexing ([MSEARCH-891](https://folio-org.atlassian.net/browse/MSEARCH-891))
 * Change browse_config type_ids column type from varchar to array ([MSEARCH-890](https://folio-org.atlassian.net/browse/MSEARCH-890))
+* Fix old browse config returned on get after upsert ([MSEARCH-897](https://folio-org.atlassian.net/browse/MSEARCH-897))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/search/service/config/BrowseConfigService.java
+++ b/src/main/java/org/folio/search/service/config/BrowseConfigService.java
@@ -59,8 +59,7 @@ public class BrowseConfigService {
         "Config for %s type %s must be present in database".formatted(typeValue, optionTypeValue)));
   }
 
-  @CacheEvict(cacheNames = BROWSE_CONFIG_CACHE,
-              key = "@folioExecutionContext.tenantId + ':' + #type.value + ':' + #optionType.value")
+  @CacheEvict(cacheNames = BROWSE_CONFIG_CACHE, allEntries = true)
   public void upsertConfig(@NonNull BrowseType type,
                            @NonNull BrowseOptionType optionType,
                            @NonNull BrowseConfig config) {


### PR DESCRIPTION
### Purpose
Fix inconsistent classification browse on browse config update

### Approach
Delete all browse config cache keys  on browse config upsert

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-897](https://folio-org.atlassian.net/browse/MSEARCH-897)

