### PR TITLE
fix(change-ownership) fix "Invalid reference" appears after updating …

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * Fix old browse config returned on get after upsert ([MSEARCH-897](https://folio-org.atlassian.net/browse/MSEARCH-897))
 * Fix generation of IDs ranges in Reindex Upload for Subject, Classification and Contributor ([MSEARCH-907](https://folio-org.atlassian.net/browse/MSEARCH-907))
 * Remove browse config caching ([MSEARCH-897](https://folio-org.atlassian.net/browse/MSEARCH-897))
+* Fix the "Invalid reference" appears after updating ownership ([MSEARCH-915](https://folio-org.atlassian.net/browse/MSEARCH-915))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/search/integration/message/interceptor/PopulateInstanceBatchInterceptor.java
+++ b/src/main/java/org/folio/search/integration/message/interceptor/PopulateInstanceBatchInterceptor.java
@@ -116,15 +116,22 @@ public class PopulateInstanceBatchInterceptor implements BatchInterceptor<String
           .map(ResourceEvent::getId)
           .toList();
         if (!idsToDrop.isEmpty()) {
-          repository.deleteEntities(idsToDrop, tenant);
+          deleteEntities(tenant, recordCollection.getKey(), repository, idsToDrop);
         }
-
         if (ResourceType.INSTANCE.getName().equals(recordCollection.getKey())) {
           var noShadowCopiesInstanceEvents = recordByOperation.values().stream().flatMap(Collection::stream).toList();
           instanceChildrenResourceService.persistChildren(tenant, noShadowCopiesInstanceEvents);
         }
       }
 
+    }
+  }
+
+  private void deleteEntities(String tenant, String resourceType, MergeRangeRepository repository, List<String> ids) {
+    if (ResourceType.HOLDINGS.getName().equals(resourceType) || ResourceType.ITEM.getName().equals(resourceType)) {
+      repository.deleteEntitiesForTenant(ids, tenant);
+    } else {
+      repository.deleteEntities(ids);
     }
   }
 

--- a/src/main/java/org/folio/search/integration/message/interceptor/PopulateInstanceBatchInterceptor.java
+++ b/src/main/java/org/folio/search/integration/message/interceptor/PopulateInstanceBatchInterceptor.java
@@ -116,7 +116,7 @@ public class PopulateInstanceBatchInterceptor implements BatchInterceptor<String
           .map(ResourceEvent::getId)
           .toList();
         if (!idsToDrop.isEmpty()) {
-          repository.deleteEntities(idsToDrop);
+          repository.deleteEntities(idsToDrop, tenant);
         }
 
         if (ResourceType.INSTANCE.getName().equals(recordCollection.getKey())) {

--- a/src/main/java/org/folio/search/service/reindex/jdbc/MergeInstanceRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/MergeInstanceRepository.java
@@ -1,7 +1,6 @@
 package org.folio.search.service.reindex.jdbc;
 
 import static org.folio.search.utils.JdbcUtils.getFullTableName;
-import static org.folio.search.utils.JdbcUtils.getParamPlaceholderForUuid;
 
 import java.util.List;
 import java.util.Map;
@@ -31,11 +30,6 @@ public class MergeInstanceRepository extends MergeRangeRepository {
   private static final String UPDATE_BOUND_WITH_SQL = """
     UPDATE %s SET is_bound_with = ? WHERE id = ?::uuid;
     """;
-
-  private static final String DELETE_SQL = """
-    DELETE FROM %s WHERE id IN (%s);
-    """;
-
   private final ConsortiumTenantProvider consortiumTenantProvider;
 
   public MergeInstanceRepository(JdbcTemplate jdbcTemplate, JsonConverter jsonConverter, FolioExecutionContext context,
@@ -86,13 +80,5 @@ public class MergeInstanceRepository extends MergeRangeRepository {
     var fullTableName = getFullTableName(context, entityTable());
     var sql = UPDATE_BOUND_WITH_SQL.formatted(fullTableName);
     jdbcTemplate.update(sql, bound /*? "true" : "false"*/, id);
-  }
-
-  @Override
-  public void deleteEntities(List<String> ids, String tenantId) {
-    var fullTableName = getFullTableName(context, entityTable());
-    var sql = DELETE_SQL.formatted(fullTableName, getParamPlaceholderForUuid(ids.size()));
-
-    jdbcTemplate.update(sql, ids.toArray());
   }
 }

--- a/src/main/java/org/folio/search/service/reindex/jdbc/MergeInstanceRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/MergeInstanceRepository.java
@@ -1,6 +1,7 @@
 package org.folio.search.service.reindex.jdbc;
 
 import static org.folio.search.utils.JdbcUtils.getFullTableName;
+import static org.folio.search.utils.JdbcUtils.getParamPlaceholderForUuid;
 
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,11 @@ public class MergeInstanceRepository extends MergeRangeRepository {
   private static final String UPDATE_BOUND_WITH_SQL = """
     UPDATE %s SET is_bound_with = ? WHERE id = ?::uuid;
     """;
+
+  private static final String DELETE_SQL = """
+    DELETE FROM %s WHERE id IN (%s);
+    """;
+
   private final ConsortiumTenantProvider consortiumTenantProvider;
 
   public MergeInstanceRepository(JdbcTemplate jdbcTemplate, JsonConverter jsonConverter, FolioExecutionContext context,
@@ -80,5 +86,13 @@ public class MergeInstanceRepository extends MergeRangeRepository {
     var fullTableName = getFullTableName(context, entityTable());
     var sql = UPDATE_BOUND_WITH_SQL.formatted(fullTableName);
     jdbcTemplate.update(sql, bound /*? "true" : "false"*/, id);
+  }
+
+  @Override
+  public void deleteEntities(List<String> ids, String tenantId) {
+    var fullTableName = getFullTableName(context, entityTable());
+    var sql = DELETE_SQL.formatted(fullTableName, getParamPlaceholderForUuid(ids.size()));
+
+    jdbcTemplate.update(sql, ids.toArray());
   }
 }

--- a/src/main/java/org/folio/search/service/reindex/jdbc/MergeRangeRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/MergeRangeRepository.java
@@ -2,8 +2,9 @@ package org.folio.search.service.reindex.jdbc;
 
 import static org.folio.search.service.reindex.ReindexConstants.MERGE_RANGE_TABLE;
 import static org.folio.search.utils.JdbcUtils.getFullTableName;
-import static org.folio.search.utils.JdbcUtils.getParamPlaceholderForUuid;
+import static org.folio.search.utils.JdbcUtils.getParamPlaceholderForUuidArray;
 
+import jakarta.persistence.GenerationType;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -18,8 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 public abstract class MergeRangeRepository extends ReindexJdbcRepository {
 
-  protected static final String DELETE_SQL = """
-    DELETE FROM %s WHERE id IN (%s);
+  private static final String DELETE_SQL = """
+    DELETE FROM %s WHERE id = ANY (%s) AND tenant_id = ?;
     """;
   private static final String INSERT_MERGE_RANGE_SQL = """
       INSERT INTO %s (id, entity_type, tenant_id, lower, upper, created_at, finished_at)
@@ -66,11 +67,15 @@ public abstract class MergeRangeRepository extends ReindexJdbcRepository {
 
   public abstract void saveEntities(String tenantId, List<Map<String, Object>> entities);
 
-  public void deleteEntities(List<String> ids) {
+  public void deleteEntities(List<String> ids, String tenantId) {
     var fullTableName = getFullTableName(context, entityTable());
-    var sql = DELETE_SQL.formatted(fullTableName, getParamPlaceholderForUuid(ids.size()));
+    var paramPlaceholder = getParamPlaceholderForUuidArray(ids.size(), GenerationType.UUID.name());
+    var sql = DELETE_SQL.formatted(fullTableName, paramPlaceholder);
 
-    jdbcTemplate.update(sql, ids.toArray());
+    jdbcTemplate.update(sql, statement -> {
+      statement.setArray(1, statement.getConnection().createArrayOf(GenerationType.UUID.name(), ids.toArray()));
+      statement.setString(2, tenantId);
+    });
   }
 
   public void updateBoundWith(String tenantId, String id, boolean bound) {

--- a/src/main/java/org/folio/search/utils/JdbcUtils.java
+++ b/src/main/java/org/folio/search/utils/JdbcUtils.java
@@ -23,6 +23,10 @@ public class JdbcUtils {
     return getParamPlaceholder(size, "uuid");
   }
 
+  public static String getParamPlaceholderForUuidArray(int size, String cast) {
+    return String.join(",", nCopies(size, "?" + (cast == null ? "" : "::" + cast + "[]")));
+  }
+
   public static String getParamPlaceholder(int size) {
     return getParamPlaceholder(size, null);
   }

--- a/src/test/java/org/folio/search/service/reindex/jdbc/MergeRangeRepositoriesIT.java
+++ b/src/test/java/org/folio/search/service/reindex/jdbc/MergeRangeRepositoriesIT.java
@@ -2,6 +2,7 @@ package org.folio.search.service.reindex.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.folio.search.utils.TestConstants.MEMBER_TENANT_ID;
 import static org.folio.search.utils.TestConstants.TENANT_ID;
 import static org.mockito.Mockito.when;
 
@@ -177,6 +178,48 @@ class MergeRangeRepositoriesIT {
       .hasSize(2);
     assertThat(extractMapValues(instanceHoldings))
       .contains(mainInstanceId.toString(), holdingId1.toString(), holdingId2.toString());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void deleteEntities() {
+    // given
+    var instanceId = UUID.randomUUID();
+    var holdingId1 = UUID.randomUUID();
+    var holdingId2 = UUID.randomUUID();
+    var itemId1 = UUID.randomUUID();
+    var itemId2 = UUID.randomUUID();
+
+    var instances = List.of(Map.<String, Object>of("id", instanceId));
+    var holdings = List.of(
+      Map.<String, Object>of("id", holdingId1, "instanceId", instanceId),
+      Map.<String, Object>of("id", holdingId2, "instanceId", instanceId));
+    var items = List.of(
+      Map.<String, Object>of("id", itemId1, "instanceId", instanceId, "holdingsRecordId", holdingId1),
+      Map.<String, Object>of("id", itemId2, "instanceId", instanceId, "holdingsRecordId", holdingId2));
+
+    // act
+    instanceRepository.saveEntities(TENANT_ID, instances);
+    holdingRepository.saveEntities(TENANT_ID, holdings);
+    itemRepository.saveEntities(TENANT_ID, items);
+
+    //save the same entities for the "member_tenant" tenant
+    holdingRepository.saveEntities(MEMBER_TENANT_ID, holdings);
+    itemRepository.saveEntities(MEMBER_TENANT_ID, items);
+
+    // assert
+    assertThat(instanceRepository.countEntities()).isEqualTo(1);
+    assertThat(List.of(holdingRepository.countEntities(), itemRepository.countEntities()))
+      .allMatch(count -> count == 4);
+
+    //act
+    holdingRepository.deleteEntitiesForTenant(List.of(holdingId1.toString()), TENANT_ID);
+    itemRepository.deleteEntitiesForTenant(List.of(itemId1.toString()), TENANT_ID);
+
+    // assert
+    assertThat(instanceRepository.countEntities()).isEqualTo(1);
+    assertThat(List.of(holdingRepository.countEntities(), itemRepository.countEntities()))
+      .allMatch(count -> count == 3);
   }
 
   private List<String> extractMapValues(List<Map<String, Object>> maps) {


### PR DESCRIPTION
### Purpose
[MSEARCH-915](https://folio-org.atlassian.net/browse/MSEARCH-915) The "Invalid reference" appears in the Location section for Holding after updating ownership.
When changing ownership the several events are generated:
-create holding/item for new tenant
-delete holding/item for old tenant.
Need to avoid deletion of all records with the same id for old and new tenant in the holding/item tables.

### Approach
- add tenant id to holding/item entity delete sql query.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/26c78295-1c8d-474c-9d14-4337114ebdb7)
