### PR TITLE
fix(cn-browse): adjust populating shared field to be based on instance tenant id 

### DIFF
--- a/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
@@ -74,9 +74,9 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
   @MethodSource("callNumberBrowsingDataProvider")
   @DisplayName("browseByCallNumber_parameterized")
-  @ParameterizedTest(name = "[{index}] query={0}, option={1}, value=''{2}'', limit={3}")
-  void browseByCallNumber_parameterized(String query, BrowseOptionType optionType, String input, Integer limit,
-                                        CallNumberBrowseResult expected) {
+  @ParameterizedTest(name = "[{0}] query={1}, option={2}, value=''{3}'', limit={4}")
+  void browseByCallNumber_parameterized(int index, String query, BrowseOptionType optionType, String input,
+                                        Integer limit, CallNumberBrowseResult expected) {
     var request = get(instanceCallNumberBrowsePath(optionType))
       .param("expandAll", "true")
       .param("query", prepareQuery(query, '"' + input + '"'))
@@ -121,7 +121,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
     return Stream.of(
       // anchor call number appears in the middle of the result set
-      arguments(aroundQuery, BrowseOptionType.ALL, callNumbers.get(1).fullCallNumber(), 5,
+      arguments(1, aroundQuery, BrowseOptionType.ALL, callNumbers.get(1).fullCallNumber(), 5,
         cnBrowseResult(callNumbers.get(91).fullCallNumber(), callNumbers.get(68).fullCallNumber(), 100, List.of(
           cnBrowseItem(callNumbers.get(91), 1),
           cnBrowseItem(callNumbers.get(25), 1),
@@ -131,7 +131,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       // not existed anchor call number appears in the middle of the result set
-      arguments(aroundQuery, BrowseOptionType.ALL, "TA357 .A78 2011", 5,
+      arguments(2, aroundQuery, BrowseOptionType.ALL, "TA357 .A78 2011", 5,
         cnBrowseResult(callNumbers.get(25).fullCallNumber(), callNumbers.get(68).fullCallNumber(), 100, List.of(
           cnBrowseItem(callNumbers.get(25), 1),
           cnBrowseItem(callNumbers.get(1), 3),
@@ -141,7 +141,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       // anchor call number appears first in the result set
-      arguments(aroundQuery, BrowseOptionType.ALL, callNumbers.get(50).fullCallNumber(), 5,
+      arguments(3, aroundQuery, BrowseOptionType.ALL, callNumbers.get(50).fullCallNumber(), 5,
         cnBrowseResult(null, callNumbers.get(95).fullCallNumber(), 100, List.of(
           cnBrowseItem(callNumbers.get(50), 1, true),
           cnBrowseItem(callNumbers.get(97), 1),
@@ -149,7 +149,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       // not existed anchor call number appears first in the result set
-      arguments(aroundQuery, BrowseOptionType.ALL, "0.0", 5,
+      arguments(4, aroundQuery, BrowseOptionType.ALL, "0.0", 5,
         cnBrowseResult(null, callNumbers.get(97).fullCallNumber(), 100, List.of(
           cnEmptyBrowseItem("0.0"),
           cnBrowseItem(callNumbers.get(50), 1),
@@ -157,7 +157,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       // anchor call number appears last in the result set
-      arguments(aroundQuery, BrowseOptionType.ALL, callNumbers.get(11).fullCallNumber(), 5,
+      arguments(5, aroundQuery, BrowseOptionType.ALL, callNumbers.get(11).fullCallNumber(), 5,
         cnBrowseResult(callNumbers.get(49).fullCallNumber(), null, 100, List.of(
           cnBrowseItem(callNumbers.get(49), 1),
           cnBrowseItem(callNumbers.get(44), 1),
@@ -165,7 +165,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       // not existed anchor call number appears last in the result set
-      arguments(aroundQuery, BrowseOptionType.ALL, "ZZ", 5,
+      arguments(6, aroundQuery, BrowseOptionType.ALL, "ZZ", 5,
         cnBrowseResult(callNumbers.get(44).fullCallNumber(), null, 100, List.of(
           cnBrowseItem(callNumbers.get(44), 1),
           cnBrowseItem(callNumbers.get(11), 1),
@@ -173,7 +173,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       // anchor call number appears in the middle of the result set when filtering by type
-      arguments(aroundQuery, BrowseOptionType.LC, callNumbers.get(46).fullCallNumber(), 5,
+      arguments(7, aroundQuery, BrowseOptionType.LC, callNumbers.get(46).fullCallNumber(), 5,
         cnBrowseResult(callNumbers.get(66).fullCallNumber(), callNumbers.get(21).fullCallNumber(), 20, List.of(
           cnBrowseItem(callNumbers.get(66), 1),
           cnBrowseItem(callNumbers.get(96), 1),
@@ -183,7 +183,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       // forward browsing from the middle of the result set
-      arguments(forwardQuery, BrowseOptionType.ALL, callNumbers.get(22).fullCallNumber(), 5,
+      arguments(8, forwardQuery, BrowseOptionType.ALL, callNumbers.get(22).fullCallNumber(), 5,
         cnBrowseResult(callNumbers.get(47).fullCallNumber(), callNumbers.get(32).fullCallNumber(), 100, List.of(
           cnBrowseItem(callNumbers.get(47), 1),
           cnBrowseItem(callNumbers.get(62), 1),
@@ -193,11 +193,11 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       // forward browsing from the end of the result set
-      arguments(forwardQuery, BrowseOptionType.ALL, callNumbers.get(11).fullCallNumber(), 5,
+      arguments(9, forwardQuery, BrowseOptionType.ALL, callNumbers.get(11).fullCallNumber(), 5,
         cnBrowseResult(null, null, 100, emptyList())),
 
       // backward browsing from the middle of the result set
-      arguments(backwardQuery, BrowseOptionType.ALL, callNumbers.get(22).fullCallNumber(), 5,
+      arguments(10, backwardQuery, BrowseOptionType.ALL, callNumbers.get(22).fullCallNumber(), 5,
         cnBrowseResult(callNumbers.get(92).fullCallNumber(), callNumbers.get(90).fullCallNumber(), 100, List.of(
           cnBrowseItem(callNumbers.get(92), 1),
           cnBrowseItem(callNumbers.get(17), 1),
@@ -207,7 +207,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
         ))),
 
       // backward browsing from the end of the result set
-      arguments(backwardQuery, BrowseOptionType.ALL, callNumbers.get(50).fullCallNumber(), 5,
+      arguments(11, backwardQuery, BrowseOptionType.ALL, callNumbers.get(50).fullCallNumber(), 5,
         cnBrowseResult(null, null, 100, emptyList()))
     );
   }

--- a/src/test/resources/sql/populate-call-numbers.sql
+++ b/src/test/resources/sql/populate-call-numbers.sql
@@ -15,14 +15,14 @@ VALUES
 -- Insert data into 'instance_call_number' table with varied location and count
 INSERT INTO instance_call_number (call_number_id, item_id, instance_id, tenant_id, location_id)
 VALUES
-    ('cn1', 'b1703fff-6fdb-45d5-bd9e-d5596658a5c5', '43e1b37b-b3aa-438b-bf3a-2ca4c93ab045', 'tenant1', 'b0a5b238-243b-4f66-afa6-20b605cc58cb'),
-    ('cn1', 'd13e75e0-632e-4d24-b689-a5c7012ddfd7', '43e1b37b-b3aa-438b-bf3a-2ca4c93ab045', 'tenant2', '51f4b5b6-74a3-431b-97e1-5e3b1c6b6e9a'),
-    ('cn2', 'e4b506e4-8ec3-4f7b-9e5f-8140370e5498', '6780c3a5-e16c-4a0a-8598-5b0f0a2c5473', 'tenant1', '731d865a-4719-4c34-893b-09f7069f4ace'),
-    ('cn3', 'f1a14562-c929-4b21-86eb-786f4076b728', '809857a8-2554-4a58-b3bf-350c9b3a2f0e', 'tenant2', 'e89befb2-c947-4b25-b488-d3a1dc0e5032'),
-    ('cn3', '0739eca6-23d8-490a-afe4-4886aeb04746', '809857a8-2554-4a58-b3bf-350c9b3a2f0e', 'tenant1', '4e2f5e0e-a8df-45d0-a036-ef9e90b1e8f3'),
-    ('cn4', '4da99244-268f-4027-ad33-507c3213c3b3', '96c561c2-8dfd-4a57-91ae-da831e0daa9e', 'tenant1', '3ec83352-e8fa-4c58-ab7f-12fcdc0a7f70'),
-    ('cn5', '22d7b090-b4af-49d3-999f-ca7b78b3c565', '1c146d78-5ba9-4878-b639-30c05fe850b8', 'tenant2', '89216ffe-439d-4c88-b07c-3a4da24e6b11'),
-    ('cn7', '306afa59-3b12-4601-9f34-43f7db3acb5d', '2ad5b301-4b8d-4c7e-a96f-7688b8fee1a9', 'tenant1', '8bc5bf56-d9a0-4e65-83a5-95d190ffb803'),
-    ('cn8', '7e5eca0f-9a92-4a8e-a792-be9b0dd8f1ee', '63bb3e28-da97-46aa-a5b9-8e7d2180cf6b', 'tenant1', '59583815-e8ae-41d4-ac83-52b8f0a50f61'),
-    ('cna', '921b3eb4-06f7-41f5-aabc-3c334337a121', '7fb0e775-badc-4916-92e4-e202b340d580', 'tenant1', '9b743643-d7ab-477b-3175-249a50b3191e'),
-    ('cna', 'bace7c12-f1be-4d6f-a385-4d2075db9a55', '7fb0e775-badc-4916-92e4-e202b340d580', 'tenant1', '17ac3b08-5472-4ea7-a8f8-8820f83368ba');
+    ('cn1', 'b1703fff-6fdb-45d5-bd9e-d5596658a5c5', '9f8febd1-e96c-46c4-a5f4-84a45cc499a2', 'tenant1', 'b0a5b238-243b-4f66-afa6-20b605cc58cb'),
+    ('cn1', 'd13e75e0-632e-4d24-b689-a5c7012ddfd7', '9f8febd1-e96c-46c4-a5f4-84a45cc499a2', 'tenant2', '51f4b5b6-74a3-431b-97e1-5e3b1c6b6e9a'),
+    ('cn2', 'e4b506e4-8ec3-4f7b-9e5f-8140370e5498', '9f8febd1-e96c-46c4-a5f4-84a45cc499a2', 'tenant1', '731d865a-4719-4c34-893b-09f7069f4ace'),
+    ('cn3', 'f1a14562-c929-4b21-86eb-786f4076b728', '9f8febd1-e96c-46c4-a5f4-84a45cc499a2', 'tenant2', 'e89befb2-c947-4b25-b488-d3a1dc0e5032'),
+    ('cn3', '0739eca6-23d8-490a-afe4-4886aeb04746', '9f8febd1-e96c-46c4-a5f4-84a45cc499a2', 'tenant1', '4e2f5e0e-a8df-45d0-a036-ef9e90b1e8f3'),
+    ('cn4', '4da99244-268f-4027-ad33-507c3213c3b3', '9f8febd1-e96c-46c4-a5f4-84a45cc499a2', 'tenant1', '3ec83352-e8fa-4c58-ab7f-12fcdc0a7f70'),
+    ('cn5', '22d7b090-b4af-49d3-999f-ca7b78b3c565', '9f8febd1-e96c-46c4-a5f4-84a45cc499a2', 'tenant2', '89216ffe-439d-4c88-b07c-3a4da24e6b11'),
+    ('cn7', '306afa59-3b12-4601-9f34-43f7db3acb5d', '9f8febd1-e96c-46c4-a5f4-84a45cc499a2', 'tenant1', '8bc5bf56-d9a0-4e65-83a5-95d190ffb803'),
+    ('cn8', '7e5eca0f-9a92-4a8e-a792-be9b0dd8f1ee', '9f8febd1-e96c-46c4-a5f4-84a45cc499a2', 'tenant1', '59583815-e8ae-41d4-ac83-52b8f0a50f61'),
+    ('cna', '921b3eb4-06f7-41f5-aabc-3c334337a121', '9f8febd1-e96c-46c4-a5f4-84a45cc499a2', 'tenant1', '9b743643-d7ab-477b-3175-249a50b3191e'),
+    ('cna', 'bace7c12-f1be-4d6f-a385-4d2075db9a55', '9f8febd1-e96c-46c4-a5f4-84a45cc499a2', 'tenant1', '17ac3b08-5472-4ea7-a8f8-8820f83368ba');


### PR DESCRIPTION
### Purpose

- User should see call numbers on shared instances (should see call-numbers from items that are connected to shared instances)
- User should see call numbers on both shared and local instances

### Approach
adjust populating shared field to be based on instance tenant id

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MSEARCH-939
