### PR TITLE
feat(cn-browse): support aliases for callNumberTypeId filters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Call Numbers Browse: Implement Call Number Browse Config ([MSEARCH-863](https://folio-org.atlassian.net/browse/MSEARCH-863))
 * Call Numbers Browse: Implement Indexing and Re-indexing Mechanisms for Call-Numbers ([MSEARCH-864](https://folio-org.atlassian.net/browse/MSEARCH-864))
 * Call Numbers Browse: Implement Browsing Endpoint for Call-Numbers ([MSEARCH-865](https://folio-org.atlassian.net/browse/MSEARCH-865))
+* Call Numbers Browse: Support aliases for callNumberTypeId filters ([MSEARCH-942](https://folio-org.atlassian.net/browse/MSEARCH-942))
 
 ### Bug fixes
 * Remove shelving order calculation for local call-number types

--- a/README.md
+++ b/README.md
@@ -778,6 +778,12 @@ does not produce any values, so the following search options will return an empt
 |:------------------------|:----:|:------------------------------------|:------------------------------------------------|
 | `contributorNameTypeId` | term | `contributorNameTypeId == "123456"` | Matches contributors with `123456` name type id |
 
+##### Call-numbers search options
+
+| Option             | Type | Example                        | Description                                                                                                                     |
+|:-------------------|:----:|:-------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
+| `callNumberTypeId` | term | `callNumberTypeId == "123456"` | Matches call-numbers with `123456` call-number type id. Support aliases by call-number browse options: `callNumberTypeId == lc` |
+
 #### Search Facets
 
 Facets can be retrieved by using following API `GET /{recordType}/facets`. It consumes following request parameters:
@@ -875,6 +881,14 @@ GET /instances/facets?query=title all book&facet=source:5,discoverySuppress:2
 |:---------------------|:----:|:------------------------------|
 | `instances.tenantId` | term | Requests a tenantId facet     |
 | `instances.shared`   | term | Requests a shared/local facet |
+
+##### Classifications facets
+
+| Option                 | Type | Description                   |
+|:-----------------------|:----:|:------------------------------|
+| `instances.locationId` | term | Requests a location facet     |
+| `instances.tenantId`   | term | Requests a tenantId facet     |
+| `instances.shared`     | term | Requests a shared/local facet |
 
 #### Sorting results
 

--- a/src/main/java/org/folio/search/cql/CqlTermQueryConverter.java
+++ b/src/main/java/org/folio/search/cql/CqlTermQueryConverter.java
@@ -16,6 +16,7 @@ import java.util.StringJoiner;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.folio.search.cql.builders.TermQueryBuilder;
+import org.folio.search.cql.searchterm.SearchTermProcessor;
 import org.folio.search.exception.RequestValidationException;
 import org.folio.search.exception.ValidationException;
 import org.folio.search.model.metadata.PlainFieldDescription;

--- a/src/main/java/org/folio/search/cql/builders/ExactTermQueryBuilder.java
+++ b/src/main/java/org/folio/search/cql/builders/ExactTermQueryBuilder.java
@@ -7,6 +7,7 @@ import static org.opensearch.index.query.MultiMatchQueryBuilder.Type.PHRASE;
 import static org.opensearch.index.query.QueryBuilders.multiMatchQuery;
 import static org.opensearch.index.query.QueryBuilders.scriptQuery;
 import static org.opensearch.index.query.QueryBuilders.termQuery;
+import static org.opensearch.index.query.QueryBuilders.termsQuery;
 
 import java.util.Arrays;
 import java.util.List;
@@ -46,6 +47,9 @@ public class ExactTermQueryBuilder extends FulltextQueryBuilder {
 
   @Override
   public QueryBuilder getTermLevelQuery(Object term, String fieldName, ResourceType resource, String fieldIndex) {
+    if (term instanceof String[] termArray) {
+      return termArray.length > 1 ? termsQuery(fieldName, termArray) : termQuery(fieldName, termArray[0]);
+    }
     return EMPTY_ARRAY.equals(term) && KEYWORD_FIELD_INDEX.equals(fieldIndex)
            ? getEmptyArrayScriptQuery(fieldName)
            : termQuery(fieldName, term);

--- a/src/main/java/org/folio/search/cql/searchterm/CallNumberSearchTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/searchterm/CallNumberSearchTermProcessor.java
@@ -1,4 +1,4 @@
-package org.folio.search.cql;
+package org.folio.search.cql.searchterm;
 
 import static org.folio.search.utils.CallNumberUtils.normalizeCallNumberComponents;
 import static org.folio.search.utils.SearchUtils.ASTERISKS_SIGN;

--- a/src/main/java/org/folio/search/cql/searchterm/CallNumberTypeIdSearchTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/searchterm/CallNumberTypeIdSearchTermProcessor.java
@@ -1,0 +1,25 @@
+package org.folio.search.cql.searchterm;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.search.domain.dto.BrowseOptionType;
+import org.folio.search.domain.dto.BrowseType;
+import org.folio.search.service.consortium.BrowseConfigServiceDecorator;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CallNumberTypeIdSearchTermProcessor implements SearchTermProcessor {
+
+  private final BrowseConfigServiceDecorator configService;
+
+  @Override
+  public Object getSearchTerm(String inputTerm) {
+    try {
+      var browseOptionType = BrowseOptionType.fromValue(inputTerm);
+      var browseConfig = configService.getConfig(BrowseType.CALL_NUMBER, browseOptionType);
+      return browseConfig.getTypeIds().stream().map(Object::toString).toArray(String[]::new);
+    } catch (IllegalArgumentException e) {
+      return inputTerm;
+    }
+  }
+}

--- a/src/main/java/org/folio/search/cql/searchterm/ClassificationNumberSearchTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/searchterm/ClassificationNumberSearchTermProcessor.java
@@ -1,4 +1,4 @@
-package org.folio.search.cql;
+package org.folio.search.cql.searchterm;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isBlank;

--- a/src/main/java/org/folio/search/cql/searchterm/EffectiveShelvingOrderTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/searchterm/EffectiveShelvingOrderTermProcessor.java
@@ -1,4 +1,4 @@
-package org.folio.search.cql;
+package org.folio.search.cql.searchterm;
 
 import static org.folio.search.utils.CallNumberUtils.getShelfKeyFromCallNumber;
 import static org.folio.search.utils.CallNumberUtils.normalizeEffectiveShelvingOrder;
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import org.folio.search.cql.SuDocCallNumber;
 import org.folio.search.domain.dto.CallNumberType;
 import org.marc4j.callnum.CallNumber;
 import org.marc4j.callnum.DeweyCallNumber;

--- a/src/main/java/org/folio/search/cql/searchterm/IsbnSearchTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/searchterm/IsbnSearchTermProcessor.java
@@ -1,4 +1,4 @@
-package org.folio.search.cql;
+package org.folio.search.cql.searchterm;
 
 import lombok.RequiredArgsConstructor;
 import org.folio.search.service.setter.instance.IsbnProcessor;

--- a/src/main/java/org/folio/search/cql/searchterm/LccnSearchTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/searchterm/LccnSearchTermProcessor.java
@@ -1,4 +1,4 @@
-package org.folio.search.cql;
+package org.folio.search.cql.searchterm;
 
 import lombok.RequiredArgsConstructor;
 import org.folio.search.service.lccn.LccnNormalizer;

--- a/src/main/java/org/folio/search/cql/searchterm/OclcSearchTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/searchterm/OclcSearchTermProcessor.java
@@ -1,4 +1,4 @@
-package org.folio.search.cql;
+package org.folio.search.cql.searchterm;
 
 import lombok.RequiredArgsConstructor;
 import org.folio.search.service.setter.instance.OclcProcessor;

--- a/src/main/java/org/folio/search/cql/searchterm/SearchTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/searchterm/SearchTermProcessor.java
@@ -1,4 +1,4 @@
-package org.folio.search.cql;
+package org.folio.search.cql.searchterm;
 
 public interface SearchTermProcessor {
 

--- a/src/main/java/org/folio/search/utils/SearchQueryUtils.java
+++ b/src/main/java/org/folio/search/utils/SearchQueryUtils.java
@@ -18,6 +18,7 @@ import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -75,7 +76,8 @@ public class SearchQueryUtils {
    * @return true if query is type of filter, false - otherwise
    */
   public static boolean isFilterQuery(QueryBuilder query, Predicate<String> check) {
-    return query instanceof TermQueryBuilder && check.test(((TermQueryBuilder) query).fieldName())
+    return query instanceof TermsQueryBuilder && check.test(((TermsQueryBuilder) query).fieldName())
+      || query instanceof TermQueryBuilder && check.test(((TermQueryBuilder) query).fieldName())
       || query instanceof RangeQueryBuilder && check.test(((RangeQueryBuilder) query).fieldName());
   }
 

--- a/src/main/resources/model/instance_call_number.json
+++ b/src/main/resources/model/instance_call_number.json
@@ -21,8 +21,9 @@
     },
     "callNumberTypeId": {
       "index": "keyword",
-      "searchTypes": [ "facet" ],
-      "showInResponse": [ "browse" ]
+      "searchTypes": [ "filter", "facet" ],
+      "showInResponse": [ "browse" ],
+      "searchTermProcessor": "callNumberTypeIdSearchTermProcessor"
     },
     "volume": {
       "index": "source",

--- a/src/main/resources/swagger.api/examples/result/browseCallNumberResult.yaml
+++ b/src/main/resources/swagger.api/examples/result/browseCallNumberResult.yaml
@@ -1,33 +1,16 @@
 value:
   items:
-    - fullCallNumber: "Bilingualism: a bibliography of 1000 references with special reference to Wales."
-      shelfKey: "Bilingualism: a bibliography of 1000 references with special reference to Wales."
+    - fullCallNumber: "NS 1 .B5"
+      callNumber: "NS 1 .B4"
+      callNumberTypeId: "2b94c631-fca9-4892-a730-03ee529ff6c3"
+      prefix: "pref1"
       isAnchor: true
       totalRecords: 1
-      instance:
-        id: "d20569a7-9bba-44dd-9ad5-6f8f1d24ee1f"
-        title: "Bilingualism: a bibliography of 1000 references with special reference to Wales."
-        contributors:
-          - name: "Eichhorst, Georg."
-        publication:
-          - publisher: "Duncker und Humblot"
-            dateOfPublication: "1976"
-        electronicAccess:
-          - uri: "http://www.example.com"
-        notes:
-          - note: "Staff note"
-        items:
-          - barcode: "12345"
-            notes:
-              - note: "Staff note"
-            electronicAccess:
-              - uri: "http://www.example.com"
-        holdings:
-          - callNumber: "FS 124.44"
-            notes:
-              - note: "Staff note"
-            electronicAccess:
-              - uri: "http://www.example.com"
-  prev: "string"
-  next: "string"
-  totalRecords: 1
+    - fullCallNumber: "NS 1 .B5 suf-1801"
+      callNumber: "NS 1 .B5"
+      suffix: "suf-1801"
+      isAnchor: true
+      totalRecords: 1
+  prev: "NS 1 .B4"
+  next: "NS 1 .B5 suf-1801"
+  totalRecords: 2

--- a/src/main/resources/swagger.api/parameters/instance-call-number-browse-cql-query.yaml
+++ b/src/main/resources/swagger.api/parameters/instance-call-number-browse-cql-query.yaml
@@ -2,7 +2,7 @@ name: query
 in: query
 required: true
 description: |
-  A CQL query string with filter conditions must include anchor query with range conditions. Anchor field is `number`. 
+  A CQL query string with filter conditions must include anchor query with range conditions. Anchor field is `fullCallNumber`. 
   Filters support logic operators `AND` and `OR`. All filters should be combined in parentheses.
   Anchor will be included only if `<=` or `>=` are used in the query. Otherwise, the empty row will be added if `highlightMatch` is equal to `true`.
   <table>
@@ -30,6 +30,18 @@ description: |
         <td>==</td>
         <td>Filter by shared/non-shared in consortium</td>
     </tr>
+    <tr>
+        <td>instances.locationId</td>
+        <td>string</td>
+        <td>==</td>
+        <td>Filter by location ID</td>
+    </tr>
+    <tr>
+        <td>callNumberTypeId</td>
+        <td>string</td>
+        <td>==</td>
+        <td>Filter by call-number type ID</td>
+    </tr>
     </tbody>
   </table>
 schema:
@@ -45,5 +57,5 @@ examples:
     value: number >= "DT571.F84"
     summary: Search for all classification numbers before "DT571.F84"
   browseAroundWithFilters:
-    value: (number >= "DT571.F84" or number < "DT571.F84") and instances.shared==false
+    value: (number >= "DT571.F84" or number < "DT571.F84") and instances.shared==false and instances.locationId=="2b94c631-fca9-4892-a730-03ee529ff6c3"
     summary: Search for local classification numbers before and after "DT571.F84"

--- a/src/main/resources/swagger.api/paths/browse-call-numbers/browse-instance-call-numbers.yaml
+++ b/src/main/resources/swagger.api/paths/browse-call-numbers/browse-instance-call-numbers.yaml
@@ -18,7 +18,7 @@ get:
         application/json:
           examples:
             browseResult:
-              $ref: '../../examples/result/browseClassificationNumberResult.yaml'
+              $ref: '../../examples/result/browseCallNumberResult.yaml'
           schema:
             $ref: '../../schemas/response/callNumberBrowseResult.yaml'
     '400':

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
@@ -106,6 +106,8 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       arguments("cql.allRecords=1", array("instances.locationId"), mapOf("instances.locationId",
         facet(facetItem(locations.get(1), 42), facetItem(locations.get(2), 34), facetItem(locations.get(3), 24)))),
       arguments("callNumberTypeId=\"" + LC.getId() + "\"", array("instances.locationId"), mapOf("instances.locationId",
+        facet(facetItem(locations.get(1), 8), facetItem(locations.get(2), 8), facetItem(locations.get(3), 4)))),
+      arguments("callNumberTypeId==lc", array("instances.locationId"), mapOf("instances.locationId",
         facet(facetItem(locations.get(1), 8), facetItem(locations.get(2), 8), facetItem(locations.get(3), 4))))
     );
   }

--- a/src/test/java/org/folio/search/cql/CallNumberSearchTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/CallNumberSearchTermProcessorTest.java
@@ -2,6 +2,7 @@ package org.folio.search.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.folio.search.cql.searchterm.CallNumberSearchTermProcessor;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/org/folio/search/cql/ClassificationNumberSearchTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/ClassificationNumberSearchTermProcessorTest.java
@@ -3,6 +3,7 @@ package org.folio.search.cql;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.Stream;
+import org.folio.search.cql.searchterm.ClassificationNumberSearchTermProcessor;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/src/test/java/org/folio/search/cql/CqlSearchQueryConverterTest.java
+++ b/src/test/java/org/folio/search/cql/CqlSearchQueryConverterTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.folio.search.cql.CqlSearchQueryConverterTest.ConverterTestConfiguration;
+import org.folio.search.cql.searchterm.SearchTermProcessor;
 import org.folio.search.exception.RequestValidationException;
 import org.folio.search.exception.SearchServiceException;
 import org.folio.search.model.metadata.PlainFieldDescription;

--- a/src/test/java/org/folio/search/cql/CqlTermQueryConverterTest.java
+++ b/src/test/java/org/folio/search/cql/CqlTermQueryConverterTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.folio.search.cql.builders.TermQueryBuilder;
+import org.folio.search.cql.searchterm.SearchTermProcessor;
 import org.folio.search.exception.RequestValidationException;
 import org.folio.search.exception.ValidationException;
 import org.folio.search.service.metadata.LocalSearchFieldProvider;

--- a/src/test/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/EffectiveShelvingOrderTermProcessorTest.java
@@ -6,6 +6,7 @@ import static org.folio.search.utils.CallNumberUtils.normalizeEffectiveShelvingO
 
 import java.util.List;
 import java.util.stream.Collectors;
+import org.folio.search.cql.searchterm.EffectiveShelvingOrderTermProcessor;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/org/folio/search/cql/IsbnSearchTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/IsbnSearchTermProcessorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import org.folio.search.cql.searchterm.IsbnSearchTermProcessor;
 import org.folio.search.service.setter.instance.IsbnProcessor;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/search/cql/LccnSearchTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/LccnSearchTermProcessorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import org.folio.search.cql.searchterm.LccnSearchTermProcessor;
 import org.folio.search.service.lccn.LccnNormalizer;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/search/cql/OclcSearchTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/OclcSearchTermProcessorTest.java
@@ -3,6 +3,7 @@ package org.folio.search.cql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import org.folio.search.cql.searchterm.OclcSearchTermProcessor;
 import org.folio.search.service.setter.instance.OclcProcessor;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/search/cql/builders/ExactTermQueryBuilderTest.java
+++ b/src/test/java/org/folio/search/cql/builders/ExactTermQueryBuilderTest.java
@@ -12,6 +12,7 @@ import static org.opensearch.index.query.MultiMatchQueryBuilder.Type.PHRASE;
 import static org.opensearch.index.query.QueryBuilders.multiMatchQuery;
 import static org.opensearch.index.query.QueryBuilders.scriptQuery;
 import static org.opensearch.index.query.QueryBuilders.termQuery;
+import static org.opensearch.index.query.QueryBuilders.termsQuery;
 
 import java.util.List;
 import java.util.Optional;
@@ -93,6 +94,19 @@ class ExactTermQueryBuilderTest {
   void getTermLevelQuery_positive_emptyArrayValueNonKeywordField() {
     var actual = queryBuilder.getTermLevelQuery("[]", "field", UNKNOWN, null);
     assertThat(actual).isEqualTo(termQuery("field", "[]"));
+  }
+
+  @Test
+  void getTermLevelQuery_positive_arrayOfTermsWithSizeLessThen1() {
+    var actual = queryBuilder.getTermLevelQuery(new String[]{"val1"}, "field", UNKNOWN, null);
+    assertThat(actual).isEqualTo(termQuery("field", "val1"));
+  }
+
+
+  @Test
+  void getTermLevelQuery_positive_arrayOfTermsWithSizeGreaterThen1() {
+    var actual = queryBuilder.getTermLevelQuery(new String[]{"val1", "val2"}, "field", UNKNOWN, null);
+    assertThat(actual).isEqualTo(termsQuery("field", "val1", "val2"));
   }
 
   @Test

--- a/src/test/java/org/folio/search/service/browse/LegacyCallNumberBrowseServiceTest.java
+++ b/src/test/java/org/folio/search/service/browse/LegacyCallNumberBrowseServiceTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import org.apache.lucene.search.TotalHits;
 import org.folio.search.configuration.properties.SearchConfigurationProperties;
 import org.folio.search.cql.CqlSearchQueryConverter;
-import org.folio.search.cql.EffectiveShelvingOrderTermProcessor;
+import org.folio.search.cql.searchterm.EffectiveShelvingOrderTermProcessor;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.Item;
 import org.folio.search.domain.dto.ItemEffectiveCallNumberComponents;

--- a/src/test/java/org/folio/search/utils/SearchQueryUtilsTest.java
+++ b/src/test/java/org/folio/search/utils/SearchQueryUtilsTest.java
@@ -99,7 +99,8 @@ class SearchQueryUtilsTest {
       arguments(rangeQuery("f").gt(10), false),
       arguments(matchQuery(FIELD, "value"), false),
       arguments(termQuery(FIELD, "value"), true),
-      arguments(termQuery("f", "v"), false)
-    );
+      arguments(termQuery("f", "v"), false),
+      arguments(termsQuery(FIELD, "value"), true)
+      );
   }
 }


### PR DESCRIPTION
### Purpose
Support call-number browse option names as aliases for callNumberTypeId filters for call-number documents.

### Approach
Add search term processor for call-number type id field.
Modify query construction for exact match term queries to support array of values.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MSEARCH-942
