### PR TITLE
feat(cn-browse): support showing instance title in browse results list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Call Numbers Browse: Implement Indexing and Re-indexing Mechanisms for Call-Numbers ([MSEARCH-864](https://folio-org.atlassian.net/browse/MSEARCH-864))
 * Call Numbers Browse: Implement Browsing Endpoint for Call-Numbers ([MSEARCH-865](https://folio-org.atlassian.net/browse/MSEARCH-865))
 * Call Numbers Browse: Support aliases for callNumberTypeId filters ([MSEARCH-942](https://folio-org.atlassian.net/browse/MSEARCH-942))
+* Call Numbers Browse: Support showing instance title in browse results list ([MSEARCH-948](https://folio-org.atlassian.net/browse/MSEARCH-948))
 
 ### Bug fixes
 * Remove shelving order calculation for local call-number types

--- a/src/main/java/org/folio/search/model/index/InstanceSubResource.java
+++ b/src/main/java/org/folio/search/model/index/InstanceSubResource.java
@@ -11,5 +11,7 @@ public class InstanceSubResource {
   private Boolean shared;
   private int count;
   private List<String> typeId;
-  private List<String> locationId;
+  private String locationId;
+  private List<String> instanceId;
+  private String instanceTitle;
 }

--- a/src/main/java/org/folio/search/service/browse/AbstractShelvingOrderBrowseServiceBySearchAfter.java
+++ b/src/main/java/org/folio/search/service/browse/AbstractShelvingOrderBrowseServiceBySearchAfter.java
@@ -31,7 +31,7 @@ import org.opensearch.search.builder.SearchSourceBuilder;
 public abstract class AbstractShelvingOrderBrowseServiceBySearchAfter<T, R>
   extends AbstractBrowseServiceBySearchAfter<T, R> {
 
-  private final ConsortiumSearchHelper consortiumSearchHelper;
+  protected final ConsortiumSearchHelper consortiumSearchHelper;
   private final BrowseConfigServiceDecorator configService;
 
   protected AbstractShelvingOrderBrowseServiceBySearchAfter(ConsortiumSearchHelper consortiumSearchHelper,

--- a/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/CallNumberBrowseService.java
@@ -2,12 +2,16 @@ package org.folio.search.service.browse;
 
 import static org.folio.search.utils.SearchUtils.CALL_NUMBER_TYPE_ID_FIELD;
 
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
 import lombok.extern.log4j.Log4j2;
 import org.folio.search.domain.dto.BrowseType;
 import org.folio.search.domain.dto.CallNumberBrowseItem;
 import org.folio.search.model.BrowseResult;
 import org.folio.search.model.SearchResult;
 import org.folio.search.model.index.CallNumberResource;
+import org.folio.search.model.index.InstanceSubResource;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.service.consortium.BrowseConfigServiceDecorator;
 import org.folio.search.service.consortium.ConsortiumSearchHelper;
@@ -61,8 +65,27 @@ public class CallNumberBrowseService
         .chronology(resource.chronology())
         .enumeration(resource.enumeration())
         .copyNumber(resource.copyNumber())
+        .instanceTitle(getInstanceTitle(ctx, resource, CallNumberResource::instances))
         .isAnchor(isAnchor ? true : null)
         .totalRecords(getTotalRecords(ctx, resource, CallNumberResource::instances)));
   }
 
+  private String getInstanceTitle(BrowseContext ctx, CallNumberResource resource,
+                                  Function<CallNumberResource, Set<InstanceSubResource>> func) {
+    var instanceSubResources = consortiumSearchHelper.filterSubResourcesForConsortium(ctx, resource, func);
+    if (instanceSubResources.size() == 1) {
+      return instanceSubResources.iterator().next().getInstanceTitle();
+    }
+    return null;
+  }
+
+  @Override
+  protected Integer getTotalRecords(BrowseContext ctx, CallNumberResource resource,
+                                    Function<CallNumberResource, Set<InstanceSubResource>> func) {
+    return consortiumSearchHelper.filterSubResourcesForConsortium(ctx, resource, func)
+      .stream()
+      .map(InstanceSubResource::getInstanceId)
+      .map(List::size)
+      .reduce(0, Integer::sum);
+  }
 }

--- a/src/main/java/org/folio/search/service/consortium/ConsortiumSearchHelper.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumSearchHelper.java
@@ -6,15 +6,15 @@ import static org.opensearch.index.query.QueryBuilders.boolQuery;
 import static org.opensearch.index.query.QueryBuilders.termQuery;
 
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.search.model.index.CallNumberResource;
 import org.folio.search.model.index.InstanceSubResource;
 import org.folio.search.model.service.BrowseContext;
 import org.folio.search.model.types.ResourceType;
@@ -34,6 +34,7 @@ public class ConsortiumSearchHelper {
   private static final Logger logger = LoggerFactory.getLogger(ConsortiumSearchHelper.class);
   private static final String BROWSE_SHARED_FILTER_KEY = "instances.shared";
   private static final String BROWSE_TENANT_FILTER_KEY = "instances.tenantId";
+  private static final String BROWSE_LOCATION_FILTER_KEY = "instances.locationId";
 
   private final FolioExecutionContext folioExecutionContext;
   private final ConsortiumTenantService consortiumTenantService;
@@ -111,7 +112,9 @@ public class ConsortiumSearchHelper {
     var contextTenantId = folioExecutionContext.getTenantId();
     var centralTenantId = consortiumTenantService.getCentralTenant(contextTenantId);
     if (centralTenantId.isEmpty()) {
-      return subResources;
+      return subResources.stream()
+        .filter(instanceSubResource -> filterForCallNumbers(context, resource, instanceSubResource))
+        .collect(Collectors.toSet());
     } else if (contextTenantId.equals(centralTenantId.get())) {
       return subResources.stream()
         .filter(InstanceSubResource::getShared)
@@ -138,22 +141,29 @@ public class ConsortiumSearchHelper {
     }
     return subResources.stream()
       .filter(subResourcesFilter)
+      .filter(instanceSubResource -> filterForCallNumbers(context, resource, instanceSubResource))
       .collect(Collectors.toSet());
   }
 
-  public static Optional<TermQueryBuilder> getBrowseFilter(BrowseContext context, String filterKey) {
+  protected Optional<TermQueryBuilder> getBrowseFilter(BrowseContext context, String filterKey) {
     return context.getFilters().stream()
       .map(filter -> getTermFilterForKey(filter, filterKey))
       .filter(Objects::nonNull)
       .findFirst();
   }
 
-  public static List<Object> getBrowseFilterValues(BrowseContext context, String filterKey) {
-    return context.getFilters().stream()
-      .flatMap(filter -> getTermFiltersForKey(filter, filterKey))
-      .filter(Objects::nonNull)
-      .map(TermQueryBuilder::value)
-      .toList();
+  private <T> boolean filterForCallNumbers(BrowseContext context, T resource, InstanceSubResource instanceSubResource) {
+    if (resource instanceof CallNumberResource) {
+      var locationIds = context.getFilters().stream()
+        .map(filter -> getTermFilterForKey(filter, BROWSE_LOCATION_FILTER_KEY))
+        .filter(Objects::nonNull)
+        .map(TermQueryBuilder::value)
+        .map(String::valueOf)
+        .filter(StringUtils::isNotBlank)
+        .toList();
+      return locationIds.isEmpty() || locationIds.contains(instanceSubResource.getLocationId());
+    }
+    return true;
   }
 
   private BoolQueryBuilder prepareBoolQueryForActiveAffiliation(QueryBuilder query) {
@@ -222,15 +232,6 @@ public class ConsortiumSearchHelper {
     return filter instanceof TermQueryBuilder termFilter && termFilter.fieldName().equals(filterKey)
            ? termFilter
            : null;
-  }
-
-  private static Stream<TermQueryBuilder> getTermFiltersForKey(QueryBuilder filter, String filterKey) {
-    if (filter instanceof TermQueryBuilder termFilter && termFilter.fieldName().equals(filterKey)) {
-      return Stream.of(termFilter);
-    } else if (filter instanceof BoolQueryBuilder boolFilter) {
-      return boolFilter.should().stream().map(shouldFilter -> getTermFilterForKey(shouldFilter, filterKey));
-    }
-    return null;
   }
 
   private boolean sharedFilterValue(TermQueryBuilder sharedQuery) {

--- a/src/main/java/org/folio/search/service/setter/callnumber/CallNumberSearchResponsePostProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/callnumber/CallNumberSearchResponsePostProcessor.java
@@ -1,0 +1,85 @@
+package org.folio.search.service.setter.callnumber;
+
+import static org.folio.search.utils.LogUtils.collectionToLogMsg;
+import static org.opensearch.index.query.QueryBuilders.idsQuery;
+
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.collections4.MapUtils;
+import org.folio.search.model.SimpleResourceRequest;
+import org.folio.search.model.index.CallNumberResource;
+import org.folio.search.model.index.InstanceSubResource;
+import org.folio.search.model.types.ResourceType;
+import org.folio.search.repository.SearchRepository;
+import org.folio.search.service.consortium.TenantProvider;
+import org.folio.search.service.setter.SearchResponsePostProcessor;
+import org.folio.spring.FolioExecutionContext;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public final class CallNumberSearchResponsePostProcessor implements SearchResponsePostProcessor<CallNumberResource> {
+
+  private static final String INSTANCE_TITLE_FIELD = "plain_title";
+
+  private final SearchRepository searchRepository;
+  private final FolioExecutionContext context;
+  private final TenantProvider tenantProvider;
+
+  @Override
+  public Class<CallNumberResource> getGeneric() {
+    return CallNumberResource.class;
+  }
+
+  @Override
+  public void process(List<CallNumberResource> res) {
+    log.debug("process:: by [res: {}]", collectionToLogMsg(res, true));
+
+    if (res == null || res.isEmpty()) {
+      return;
+    }
+    var subResources = res.stream()
+      .flatMap(resource -> resource.instances().stream())
+      .toList();
+
+    countAndSetNumberOfLinkedInstances(subResources);
+  }
+
+  private void countAndSetNumberOfLinkedInstances(List<InstanceSubResource> authorities) {
+    var ids = authorities.stream()
+      .map(InstanceSubResource::getInstanceId)
+      .filter(instanceIds -> instanceIds.size() == 1)
+      .flatMap(Collection::stream)
+      .distinct()
+      .toList();
+    var queries = buildQuery(ids);
+
+    var resourceRequest = SimpleResourceRequest.of(ResourceType.INSTANCE,
+      tenantProvider.getTenant(context.getTenantId()));
+    var searchHits = searchRepository.search(resourceRequest, queries).getHits().getHits();
+
+    for (var searchHit : searchHits) {
+      var instanceId = searchHit.getId();
+      var instanceTitle = MapUtils.getString(searchHit.getSourceAsMap(), INSTANCE_TITLE_FIELD);
+      for (var authority : authorities) {
+        if (authority.getInstanceId().size() == 1 && authority.getInstanceId().get(0).equals(instanceId)) {
+          authority.setInstanceTitle(instanceTitle);
+        }
+      }
+    }
+  }
+
+  private SearchSourceBuilder buildQuery(List<String> instanceIds) {
+    var boolQueryBuilder = idsQuery().addIds(instanceIds.toArray(String[]::new));
+
+    return new SearchSourceBuilder()
+      .query(boolQueryBuilder)
+      .size(instanceIds.size())
+      .fetchSource(INSTANCE_TITLE_FIELD, null)
+      .trackTotalHits(true);
+  }
+}

--- a/src/main/resources/model/instance_call_number.json
+++ b/src/main/resources/model/instance_call_number.json
@@ -53,12 +53,12 @@
           "searchTypes": [ "facet", "filter" ],
           "default": false
         },
+        "instanceId": {
+          "index": "source"
+        },
         "locationId": {
           "index": "keyword",
           "searchTypes": [ "facet", "filter" ]
-        },
-        "count": {
-          "index": "source"
         }
       }
     }

--- a/src/main/resources/swagger.api/schemas/response/callNumberBrowseItem.yaml
+++ b/src/main/resources/swagger.api/schemas/response/callNumberBrowseItem.yaml
@@ -28,6 +28,9 @@ properties:
   copyNumber:
     type: string
     description: Copy number
+  instanceTitle:
+    type: string
+    description: Instance title
   isAnchor:
     type: boolean
     description: Marks if current value is anchor or not

--- a/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/BrowseCallNumberIT.java
@@ -1,5 +1,6 @@
 package org.folio.search.controller;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,6 +9,7 @@ import static org.awaitility.Durations.TWO_MINUTES;
 import static org.awaitility.Durations.TWO_SECONDS;
 import static org.folio.search.support.base.ApiEndpoints.browseConfigPath;
 import static org.folio.search.support.base.ApiEndpoints.instanceCallNumberBrowsePath;
+import static org.folio.search.support.base.ApiEndpoints.instanceSearchPath;
 import static org.folio.search.support.base.ApiEndpoints.recordFacetsPath;
 import static org.folio.search.utils.CallNumberTestData.CallNumberTypeId.LC;
 import static org.folio.search.utils.CallNumberTestData.callNumbers;
@@ -38,7 +40,9 @@ import org.folio.search.domain.dto.Instance;
 import org.folio.search.domain.dto.RecordType;
 import org.folio.search.domain.dto.ShelvingOrderAlgorithmType;
 import org.folio.search.model.index.CallNumberResource;
+import org.folio.search.model.types.ReindexEntityType;
 import org.folio.search.model.types.ResourceType;
+import org.folio.search.service.reindex.jdbc.SubResourcesLockRepository;
 import org.folio.search.support.base.BaseIntegrationTest;
 import org.folio.search.utils.CallNumberTestData;
 import org.folio.spring.testing.type.IntegrationTest;
@@ -49,13 +53,26 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @IntegrationTest
 class BrowseCallNumberIT extends BaseIntegrationTest {
 
+  private static final List<Instance> INSTANCES = CallNumberTestData.instances();
+
   @BeforeAll
-  static void prepare() {
-    setUpTenant(CallNumberTestData.instances().toArray(Instance[]::new));
+  static void prepare(@Autowired SubResourcesLockRepository subResourcesLockRepository) {
+    setUpTenant(TENANT_ID);
+
+    var timestamp = subResourcesLockRepository.lockSubResource(ReindexEntityType.CALL_NUMBER, TENANT_ID);
+    if (timestamp.isEmpty()) {
+      throw new IllegalStateException("Unexpected state of database: unable to lock call-number resource");
+    }
+    var instances = BrowseCallNumberIT.INSTANCES.toArray(Instance[]::new);
+    saveRecords(TENANT_ID, instanceSearchPath(), asList(instances), instances.length, emptyList(),
+      instance -> inventoryApi.createInstance(TENANT_ID, instance));
+    subResourcesLockRepository.unlockSubResource(ReindexEntityType.CALL_NUMBER, timestamp.get(), TENANT_ID);
+
     await().atMost(TWO_MINUTES).pollInterval(TWO_SECONDS).untilAsserted(() -> {
       var counted = countIndexDocument(ResourceType.INSTANCE_CALL_NUMBER, TENANT_ID);
       assertThat(counted).isEqualTo(100);
@@ -127,73 +144,73 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       // anchor call number appears in the middle of the result set
       arguments(1, aroundQuery, BrowseOptionType.ALL, callNumbers.get(1).fullCallNumber(), 5,
         cnBrowseResult(callNumbers.get(91).fullCallNumber(), callNumbers.get(68).fullCallNumber(), 100, List.of(
-          cnBrowseItem(callNumbers.get(91), 1),
-          cnBrowseItem(callNumbers.get(25), 1),
-          cnBrowseItem(callNumbers.get(1), 3, true),
-          cnBrowseItem(callNumbers.get(70), 1),
-          cnBrowseItem(callNumbers.get(68), 1)
+          cnBrowseItem(callNumbers.get(91), 1, INSTANCES.get(45).getTitle()),
+          cnBrowseItem(callNumbers.get(25), 1, INSTANCES.get(15).getTitle()),
+          cnBrowseItem(callNumbers.get(1), 3, null, true),
+          cnBrowseItem(callNumbers.get(70), 1, INSTANCES.get(34).getTitle()),
+          cnBrowseItem(callNumbers.get(68), 1, INSTANCES.get(34).getTitle())
         ))),
 
       // not existed anchor call number appears in the middle of the result set
       arguments(2, aroundQuery, BrowseOptionType.ALL, "TA357 .A78 2011", 5,
         cnBrowseResult(callNumbers.get(25).fullCallNumber(), callNumbers.get(68).fullCallNumber(), 100, List.of(
-          cnBrowseItem(callNumbers.get(25), 1),
-          cnBrowseItem(callNumbers.get(1), 3),
+          cnBrowseItem(callNumbers.get(25), 1, INSTANCES.get(15).getTitle()),
+          cnBrowseItem(callNumbers.get(1), 3, null),
           cnEmptyBrowseItem("TA357 .A78 2011"),
-          cnBrowseItem(callNumbers.get(70), 1),
-          cnBrowseItem(callNumbers.get(68), 1)
+          cnBrowseItem(callNumbers.get(70), 1, INSTANCES.get(34).getTitle()),
+          cnBrowseItem(callNumbers.get(68), 1, INSTANCES.get(34).getTitle())
         ))),
 
       // anchor call number appears first in the result set
       arguments(3, aroundQuery, BrowseOptionType.ALL, callNumbers.get(50).fullCallNumber(), 5,
         cnBrowseResult(null, callNumbers.get(95).fullCallNumber(), 100, List.of(
-          cnBrowseItem(callNumbers.get(50), 1, true),
-          cnBrowseItem(callNumbers.get(97), 1),
-          cnBrowseItem(callNumbers.get(95), 1)
+          cnBrowseItem(callNumbers.get(50), 1, INSTANCES.get(26).getTitle(), true),
+          cnBrowseItem(callNumbers.get(97), 1, INSTANCES.get(48).getTitle()),
+          cnBrowseItem(callNumbers.get(95), 1, INSTANCES.get(47).getTitle())
         ))),
 
       // not existed anchor call number appears first in the result set
       arguments(4, aroundQuery, BrowseOptionType.ALL, "0.0", 5,
         cnBrowseResult(null, callNumbers.get(97).fullCallNumber(), 100, List.of(
           cnEmptyBrowseItem("0.0"),
-          cnBrowseItem(callNumbers.get(50), 1),
-          cnBrowseItem(callNumbers.get(97), 1)
+          cnBrowseItem(callNumbers.get(50), 1, INSTANCES.get(26).getTitle()),
+          cnBrowseItem(callNumbers.get(97), 1, INSTANCES.get(48).getTitle())
         ))),
 
       // anchor call number appears last in the result set
       arguments(5, aroundQuery, BrowseOptionType.ALL, callNumbers.get(11).fullCallNumber(), 5,
         cnBrowseResult(callNumbers.get(49).fullCallNumber(), null, 100, List.of(
-          cnBrowseItem(callNumbers.get(49), 1),
-          cnBrowseItem(callNumbers.get(44), 1),
-          cnBrowseItem(callNumbers.get(11), 1, true)
+          cnBrowseItem(callNumbers.get(49), 1, INSTANCES.get(26).getTitle()),
+          cnBrowseItem(callNumbers.get(44), 1, INSTANCES.get(24).getTitle()),
+          cnBrowseItem(callNumbers.get(11), 1, INSTANCES.get(5).getTitle(), true)
         ))),
 
       // not existed anchor call number appears last in the result set
       arguments(6, aroundQuery, BrowseOptionType.ALL, "ZZ", 5,
         cnBrowseResult(callNumbers.get(44).fullCallNumber(), null, 100, List.of(
-          cnBrowseItem(callNumbers.get(44), 1),
-          cnBrowseItem(callNumbers.get(11), 1),
+          cnBrowseItem(callNumbers.get(44), 1, INSTANCES.get(24).getTitle()),
+          cnBrowseItem(callNumbers.get(11), 1, INSTANCES.get(5).getTitle()),
           cnEmptyBrowseItem("ZZ")
         ))),
 
       // anchor call number appears in the middle of the result set when filtering by type
       arguments(7, aroundQuery, BrowseOptionType.LC, callNumbers.get(46).fullCallNumber(), 5,
         cnBrowseResult(callNumbers.get(66).fullCallNumber(), callNumbers.get(21).fullCallNumber(), 20, List.of(
-          cnBrowseItem(callNumbers.get(66), 1),
-          cnBrowseItem(callNumbers.get(96), 1),
-          cnBrowseItem(callNumbers.get(46), 1, true),
-          cnBrowseItem(callNumbers.get(86), 1),
-          cnBrowseItem(callNumbers.get(21), 2)
+          cnBrowseItem(callNumbers.get(66), 1, INSTANCES.get(32).getTitle()),
+          cnBrowseItem(callNumbers.get(96), 1, INSTANCES.get(47).getTitle()),
+          cnBrowseItem(callNumbers.get(46), 1, INSTANCES.get(25).getTitle(), true),
+          cnBrowseItem(callNumbers.get(86), 1, INSTANCES.get(42).getTitle()),
+          cnBrowseItem(callNumbers.get(21), 2, null)
         ))),
 
       // forward browsing from the middle of the result set
       arguments(8, forwardQuery, BrowseOptionType.ALL, callNumbers.get(22).fullCallNumber(), 5,
         cnBrowseResult(callNumbers.get(47).fullCallNumber(), callNumbers.get(32).fullCallNumber(), 100, List.of(
-          cnBrowseItem(callNumbers.get(47), 1),
-          cnBrowseItem(callNumbers.get(62), 1),
-          cnBrowseItem(callNumbers.get(67), 1),
-          cnBrowseItem(callNumbers.get(55), 1),
-          cnBrowseItem(callNumbers.get(32), 1)
+          cnBrowseItem(callNumbers.get(47), 1, INSTANCES.get(26).getTitle()),
+          cnBrowseItem(callNumbers.get(62), 1, INSTANCES.get(30).getTitle()),
+          cnBrowseItem(callNumbers.get(67), 1, INSTANCES.get(33).getTitle()),
+          cnBrowseItem(callNumbers.get(55), 1, INSTANCES.get(28).getTitle()),
+          cnBrowseItem(callNumbers.get(32), 1, INSTANCES.get(16).getTitle())
         ))),
 
       // forward browsing from the end of the result set
@@ -203,11 +220,11 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       // backward browsing from the middle of the result set
       arguments(10, backwardQuery, BrowseOptionType.ALL, callNumbers.get(22).fullCallNumber(), 5,
         cnBrowseResult(callNumbers.get(92).fullCallNumber(), callNumbers.get(90).fullCallNumber(), 100, List.of(
-          cnBrowseItem(callNumbers.get(92), 1),
-          cnBrowseItem(callNumbers.get(17), 1),
-          cnBrowseItem(callNumbers.get(27), 1),
-          cnBrowseItem(callNumbers.get(42), 1),
-          cnBrowseItem(callNumbers.get(90), 1)
+          cnBrowseItem(callNumbers.get(92), 1, INSTANCES.get(45).getTitle()),
+          cnBrowseItem(callNumbers.get(17), 1, INSTANCES.get(10).getTitle()),
+          cnBrowseItem(callNumbers.get(27), 1, INSTANCES.get(15).getTitle()),
+          cnBrowseItem(callNumbers.get(42), 1, INSTANCES.get(22).getTitle()),
+          cnBrowseItem(callNumbers.get(90), 1, INSTANCES.get(44).getTitle())
         ))),
 
       // backward browsing from the end of the result set
@@ -236,11 +253,12 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
     return new CallNumberBrowseItem().fullCallNumber(callNumber).isAnchor(true).totalRecords(0);
   }
 
-  private static CallNumberBrowseItem cnBrowseItem(CallNumberResource resource, int count) {
-    return cnBrowseItem(resource, count, null);
+  private static CallNumberBrowseItem cnBrowseItem(CallNumberResource resource, int count, String instanceTitle) {
+    return cnBrowseItem(resource, count, instanceTitle, null);
   }
 
-  private static CallNumberBrowseItem cnBrowseItem(CallNumberResource resource, int count, Boolean isAnchor) {
+  private static CallNumberBrowseItem cnBrowseItem(CallNumberResource resource, int count,
+                                                   String instanceTitle, Boolean isAnchor) {
     return new CallNumberBrowseItem()
       .fullCallNumber(resource.fullCallNumber())
       .callNumber(resource.callNumber())
@@ -251,6 +269,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       .chronology(resource.chronology())
       .enumeration(resource.enumeration())
       .copyNumber(resource.copyNumber())
+      .instanceTitle(instanceTitle)
       .totalRecords(count)
       .isAnchor(isAnchor);
   }

--- a/src/test/java/org/folio/search/controller/IndexingInstanceCallNumberIT.java
+++ b/src/test/java/org/folio/search/controller/IndexingInstanceCallNumberIT.java
@@ -81,8 +81,10 @@ class IndexingInstanceCallNumberIT extends BaseIntegrationTest {
     assertThat(instances)
       .hasSize(1)
       .allSatisfy(map -> assertThat(map).containsEntry("shared", false))
-      .allSatisfy(map -> assertThat(map).containsEntry("tenantId", TENANT_ID))
-      .allSatisfy(map -> assertThat(map).containsEntry("count", 2));
+      .allSatisfy(map -> assertThat(map).containsEntry("tenantId", TENANT_ID));
+    @SuppressWarnings("unchecked")
+    var ids = (List<String>) instances.get(0).get("instanceId");
+    assertThat(ids).containsExactlyInAnyOrder(INSTANCE_ID_1, INSTANCE_ID_2);
   }
 
   @Test

--- a/src/test/java/org/folio/search/service/consortium/ConsortiumSearchHelperTest.java
+++ b/src/test/java/org/folio/search/service/consortium/ConsortiumSearchHelperTest.java
@@ -369,7 +369,7 @@ class ConsortiumSearchHelperTest {
     var browseContext = browseContext(null, null);
     browseContext.getFilters().add(expected);
 
-    var actual = ConsortiumSearchHelper.getBrowseFilter(browseContext, filterKey);
+    var actual = consortiumSearchHelper.getBrowseFilter(browseContext, filterKey);
 
     assertThat(actual).contains(expected);
   }

--- a/src/test/java/org/folio/search/service/reindex/jdbc/CallNumberRepositoryIT.java
+++ b/src/test/java/org/folio/search/service/reindex/jdbc/CallNumberRepositoryIT.java
@@ -103,9 +103,11 @@ class CallNumberRepositoryIT {
       .extracting("callNumber", "instances")
       .contains(
         tuple("number1",
-          List.of(mapOf("count", 1, "locationId", null, "shared", false, "tenantId", TENANT_ID, "typeId", null))),
+          List.of(mapOf("count", 0, "instanceId", List.of("9f8febd1-e96c-46c4-a5f4-84a45cc499a2"),
+            "instanceTitle", null, "locationId", null, "shared", false, "tenantId", TENANT_ID, "typeId", null))),
         tuple("number2",
-          List.of(mapOf("count", 1, "locationId", null, "shared", false, "tenantId", TENANT_ID, "typeId", null))));
+          List.of(mapOf("count", 0, "instanceId", List.of("9f8febd1-e96c-46c4-a5f4-84a45cc499a2"),
+            "instanceTitle", null, "locationId", null, "shared", false, "tenantId", TENANT_ID, "typeId", null))));
   }
 
   private static List<UUID> getList(int size) {


### PR DESCRIPTION
### Purpose
Support showing instance title in the browse results list

### Approach
Change index structure to include not `counts` but `instanceIds`. This change allows to fetch instance titles from the instance index. Counts are calculated on the fly during conversion by counting instance ids. Add filtering `instances` objects by `locationId` filter.

### Changes Checklist
- [x] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MSEARCH-948
