### PR TITLE
fix(reindex): Fix issue with using member tenant postgres schema on reindexing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 * Use 'lccnSearchTermProcessor' in linked-data search APIs ([MSEARCH-935](https://folio-org.atlassian.net/browse/MSEARCH-935))
 * Fix documentation not being updated ([MSEARCH-937](https://folio-org.atlassian.net/browse/MSEARCH-937))
 * Fix "Fix dead link" api-docs workflow step for release builds ([MSEARCH-947](https://folio-org.atlassian.net/browse/MSEARCH-947))
+* Fix issue with using member tenant postgres schema on reindexing ([MSEARCH-957](https://folio-org.atlassian.net/browse/MSEARCH-957))
 
 ### Tech Dept
 * Recreate upload ranges each upload execution ([MSEARCH-934](https://folio-org.atlassian.net/browse/MSEARCH-934))

--- a/src/main/java/org/folio/search/service/reindex/ReindexService.java
+++ b/src/main/java/org/folio/search/service/reindex/ReindexService.java
@@ -1,5 +1,6 @@
 package org.folio.search.service.reindex;
 
+import static org.folio.search.configuration.SearchCacheNames.USER_TENANTS_CACHE;
 import static org.folio.search.model.types.ReindexStatus.MERGE_FAILED;
 import static org.folio.search.model.types.ReindexStatus.MERGE_IN_PROGRESS;
 
@@ -22,6 +23,7 @@ import org.folio.search.model.types.ReindexStatus;
 import org.folio.search.service.consortium.ConsortiumTenantService;
 import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 
 @Log4j2
@@ -64,6 +66,7 @@ public class ReindexService {
     this.reindexCommonService = reindexCommonService;
   }
 
+  @CacheEvict(cacheNames = USER_TENANTS_CACHE, allEntries = true, beforeInvocation = true)
   public CompletableFuture<Void> submitFullReindex(String tenantId, IndexSettings indexSettings) {
     log.info("submitFullReindex:: for [tenantId: {}]", tenantId);
 


### PR DESCRIPTION
### Purpose
Fix issue with using member tenant postgres schema on reindexing

### Approach
- Add user tenants cache eviction on full reindex service call

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-957](https://folio-org.atlassian.net/browse/MSEARCH-957)
