### PR TITLE
fix(cn-browse): fix permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -406,7 +406,7 @@
           ],
           "pathPattern": "/browse/call-numbers/instances",
           "permissionsRequired": [
-            "browse.call-numbers.instances.collection.get"
+            "browse.call-numbers-legacy.instances.collection.get"
           ],
           "modulePermissions": [
             "user-tenants.collection.get"
@@ -418,7 +418,7 @@
           ],
           "pathPattern": "/browse/call-numbers/{browseOptionId}/instances",
           "permissionsRequired": [
-            "browse.call-numbers-new.instances.collection.get"
+            "browse.call-numbers.instances.collection.get"
           ],
           "modulePermissions": [
             "user-tenants.collection.get"
@@ -762,7 +762,7 @@
       "description": "Browse instances by given query"
     },
     {
-      "permissionName": "browse.call-numbers-new.instances.collection.get",
+      "permissionName": "browse.call-numbers-legacy.instances.collection.get",
       "displayName": "Browse - provides collections of browse items for instance by call number",
       "description": "Browse instances by given query"
     },


### PR DESCRIPTION
### Purpose
Fix issue when User with permission “Inventory: View instances, holdings, and items” doesn't have access to call numbers browse

### Approach
Assign correct permissions to endpoints

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [x] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MSEARCH-965