### PR TITLE
MSEARCH-989: Linked Data Instance and Work: search by classification type/number/additionalNumber

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## v6.0.0 YYYY-mm-DD
+### Features
+* Linked Data Instance and Work: search by classification type/number/additionalNumber ([MSEARCH-989](https://folio-org.atlassian.net/browse/MSEARCH-989))
+
 ## v5.1.0 YYYY-mm-DD
 ### Breaking changes
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/search/cql/searchterm/NoSpaceSearchTermProcessor.java
+++ b/src/main/java/org/folio/search/cql/searchterm/NoSpaceSearchTermProcessor.java
@@ -1,18 +1,18 @@
 package org.folio.search.cql.searchterm;
 
 import lombok.RequiredArgsConstructor;
-import org.folio.search.service.lccn.LccnNormalizer;
+import org.folio.search.service.lccn.StringNormalizer;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class LccnSearchTermProcessor implements SearchTermProcessor {
+public class NoSpaceSearchTermProcessor implements SearchTermProcessor {
 
-  private final LccnNormalizer lccnNormalizer;
+  private final StringNormalizer stringNormalizer;
 
   @Override
   public String getSearchTerm(String inputTerm) {
-    return lccnNormalizer.apply(inputTerm)
+    return stringNormalizer.apply(inputTerm)
       .orElse(null);
   }
 }

--- a/src/main/java/org/folio/search/service/lccn/NoSpaceNormalizer.java
+++ b/src/main/java/org/folio/search/service/lccn/NoSpaceNormalizer.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Primary
-public class DefaultLccnNormalizer implements LccnNormalizer {
+public class NoSpaceNormalizer implements StringNormalizer {
 
   @Override
   public Optional<String> apply(String lccn) {

--- a/src/main/java/org/folio/search/service/lccn/StringNormalizer.java
+++ b/src/main/java/org/folio/search/service/lccn/StringNormalizer.java
@@ -3,5 +3,5 @@ package org.folio.search.service.lccn;
 import java.util.Optional;
 import java.util.function.Function;
 
-public interface LccnNormalizer extends Function<String, Optional<String>> {
+public interface StringNormalizer extends Function<String, Optional<String>> {
 }

--- a/src/main/java/org/folio/search/service/setter/AbstractLccnProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/AbstractLccnProcessor.java
@@ -8,22 +8,22 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.folio.search.domain.dto.Identifier;
 import org.folio.search.integration.folio.ReferenceDataService;
-import org.folio.search.service.lccn.LccnNormalizer;
+import org.folio.search.service.lccn.StringNormalizer;
 
 public abstract class AbstractLccnProcessor<T> extends AbstractIdentifierProcessor<T> {
 
   private static final List<String> LCCN_IDENTIFIER_NAME = List.of("LCCN", "Canceled LCCN");
-  private final LccnNormalizer lccnNormalizer;
+  private final StringNormalizer stringNormalizer;
 
-  protected AbstractLccnProcessor(ReferenceDataService referenceDataService, LccnNormalizer lccnNormalizer) {
+  protected AbstractLccnProcessor(ReferenceDataService referenceDataService, StringNormalizer stringNormalizer) {
     super(referenceDataService, LCCN_IDENTIFIER_NAME);
-    this.lccnNormalizer = lccnNormalizer;
+    this.stringNormalizer = stringNormalizer;
   }
 
   @Override
   public Set<String> getFieldValue(T entity) {
     return filterIdentifiersValue(getIdentifiers(entity)).stream()
-      .map(lccnNormalizer)
+      .map(stringNormalizer)
       .flatMap(Optional::stream)
       .filter(Objects::nonNull)
       .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/src/main/java/org/folio/search/service/setter/authority/LccnAuthorityProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/authority/LccnAuthorityProcessor.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.folio.search.domain.dto.Authority;
 import org.folio.search.domain.dto.Identifier;
 import org.folio.search.integration.folio.ReferenceDataService;
-import org.folio.search.service.lccn.LccnNormalizer;
+import org.folio.search.service.lccn.StringNormalizer;
 import org.folio.search.service.setter.AbstractLccnProcessor;
 import org.springframework.stereotype.Component;
 
@@ -17,10 +17,10 @@ public class LccnAuthorityProcessor extends AbstractLccnProcessor<Authority> {
    * Used by dependency injection.
    *
    * @param referenceDataService {@link ReferenceDataService} bean
-   * @param lccnNormalizer {@link LccnNormalizer} bean
+   * @param stringNormalizer {@link StringNormalizer} bean
    */
-  public LccnAuthorityProcessor(ReferenceDataService referenceDataService, LccnNormalizer lccnNormalizer) {
-    super(referenceDataService, lccnNormalizer);
+  public LccnAuthorityProcessor(ReferenceDataService referenceDataService, StringNormalizer stringNormalizer) {
+    super(referenceDataService, stringNormalizer);
   }
 
   @Override

--- a/src/main/java/org/folio/search/service/setter/instance/LccnInstanceProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/LccnInstanceProcessor.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.folio.search.domain.dto.Identifier;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.integration.folio.ReferenceDataService;
-import org.folio.search.service.lccn.LccnNormalizer;
+import org.folio.search.service.lccn.StringNormalizer;
 import org.folio.search.service.setter.AbstractLccnProcessor;
 import org.springframework.stereotype.Component;
 
@@ -20,10 +20,10 @@ public class LccnInstanceProcessor extends AbstractLccnProcessor<Instance> {
    * Used by dependency injection.
    *
    * @param referenceDataService {@link ReferenceDataService} bean
-   * @param lccnNormalizer {@link LccnNormalizer} bean
+   * @param stringNormalizer {@link StringNormalizer} bean
    */
-  public LccnInstanceProcessor(ReferenceDataService referenceDataService, LccnNormalizer lccnNormalizer) {
-    super(referenceDataService, lccnNormalizer);
+  public LccnInstanceProcessor(ReferenceDataService referenceDataService, StringNormalizer stringNormalizer) {
+    super(referenceDataService, stringNormalizer);
   }
 
   @Override

--- a/src/main/java/org/folio/search/service/setter/linkeddata/common/LinkedDataClassificationAdditionalNumberProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/linkeddata/common/LinkedDataClassificationAdditionalNumberProcessor.java
@@ -2,7 +2,6 @@ package org.folio.search.service.setter.linkeddata.common;
 
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toCollection;
-import static org.folio.search.domain.dto.LinkedDataIdentifier.TypeEnum.LCCN;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -11,25 +10,25 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.folio.search.domain.dto.LinkedDataIdentifier;
+import org.folio.search.domain.dto.LinkedDataClassification;
 import org.folio.search.service.lccn.StringNormalizer;
 import org.folio.search.service.setter.FieldProcessor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class LinkedDataLccnProcessor implements FieldProcessor<List<LinkedDataIdentifier>, Set<String>> {
+public class LinkedDataClassificationAdditionalNumberProcessor
+  implements FieldProcessor<List<LinkedDataClassification>, Set<String>> {
 
   private final StringNormalizer stringNormalizer;
 
   @Override
-  public Set<String> getFieldValue(List<LinkedDataIdentifier> linkedDataIdentifiers) {
-    return ofNullable(linkedDataIdentifiers)
+  public Set<String> getFieldValue(List<LinkedDataClassification> linkedDataClassifications) {
+    return ofNullable(linkedDataClassifications)
       .stream()
       .flatMap(Collection::stream)
       .filter(Objects::nonNull)
-      .filter(i -> LCCN.equals(i.getType()))
-      .map(LinkedDataIdentifier::getValue)
+      .map(LinkedDataClassification::getAdditionalNumber)
       .filter(Objects::nonNull)
       .map(stringNormalizer)
       .flatMap(Optional::stream)

--- a/src/main/java/org/folio/search/service/setter/linkeddata/common/LinkedDataClassificationNumberProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/linkeddata/common/LinkedDataClassificationNumberProcessor.java
@@ -2,7 +2,6 @@ package org.folio.search.service.setter.linkeddata.common;
 
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toCollection;
-import static org.folio.search.domain.dto.LinkedDataIdentifier.TypeEnum.LCCN;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -11,25 +10,25 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.folio.search.domain.dto.LinkedDataIdentifier;
+import org.folio.search.domain.dto.LinkedDataClassification;
 import org.folio.search.service.lccn.StringNormalizer;
 import org.folio.search.service.setter.FieldProcessor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class LinkedDataLccnProcessor implements FieldProcessor<List<LinkedDataIdentifier>, Set<String>> {
+public class LinkedDataClassificationNumberProcessor
+  implements FieldProcessor<List<LinkedDataClassification>, Set<String>> {
 
   private final StringNormalizer stringNormalizer;
 
   @Override
-  public Set<String> getFieldValue(List<LinkedDataIdentifier> linkedDataIdentifiers) {
-    return ofNullable(linkedDataIdentifiers)
+  public Set<String> getFieldValue(List<LinkedDataClassification> linkedDataClassifications) {
+    return ofNullable(linkedDataClassifications)
       .stream()
       .flatMap(Collection::stream)
       .filter(Objects::nonNull)
-      .filter(i -> LCCN.equals(i.getType()))
-      .map(LinkedDataIdentifier::getValue)
+      .map(LinkedDataClassification::getNumber)
       .filter(Objects::nonNull)
       .map(stringNormalizer)
       .flatMap(Optional::stream)

--- a/src/main/java/org/folio/search/service/setter/linkeddata/instance/LinkedDataInstanceClassificationAdditionalNumberProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/linkeddata/instance/LinkedDataInstanceClassificationAdditionalNumberProcessor.java
@@ -1,0 +1,30 @@
+package org.folio.search.service.setter.linkeddata.instance;
+
+import static java.util.Optional.ofNullable;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.folio.search.domain.dto.LinkedDataInstance;
+import org.folio.search.domain.dto.LinkedDataWorkOnly;
+import org.folio.search.service.setter.FieldProcessor;
+import org.folio.search.service.setter.linkeddata.common.LinkedDataClassificationAdditionalNumberProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LinkedDataInstanceClassificationAdditionalNumberProcessor
+  implements FieldProcessor<LinkedDataInstance, Set<String>> {
+
+  private final LinkedDataClassificationAdditionalNumberProcessor processor;
+
+  @Override
+  public Set<String> getFieldValue(LinkedDataInstance linkedDataInstance) {
+    return ofNullable(linkedDataInstance.getParentWork())
+      .map(LinkedDataWorkOnly::getClassifications)
+      .stream()
+      .flatMap(i -> processor.getFieldValue(i).stream())
+      .collect(Collectors.toSet());
+  }
+
+}

--- a/src/main/java/org/folio/search/service/setter/linkeddata/instance/LinkedDataInstanceClassificationNumberProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/linkeddata/instance/LinkedDataInstanceClassificationNumberProcessor.java
@@ -1,0 +1,30 @@
+package org.folio.search.service.setter.linkeddata.instance;
+
+import static java.util.Optional.ofNullable;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.folio.search.domain.dto.LinkedDataInstance;
+import org.folio.search.domain.dto.LinkedDataWorkOnly;
+import org.folio.search.service.setter.FieldProcessor;
+import org.folio.search.service.setter.linkeddata.common.LinkedDataClassificationNumberProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LinkedDataInstanceClassificationNumberProcessor
+  implements FieldProcessor<LinkedDataInstance, Set<String>> {
+
+  private final LinkedDataClassificationNumberProcessor processor;
+
+  @Override
+  public Set<String> getFieldValue(LinkedDataInstance linkedDataInstance) {
+    return ofNullable(linkedDataInstance.getParentWork())
+      .map(LinkedDataWorkOnly::getClassifications)
+      .stream()
+      .flatMap(i -> processor.getFieldValue(i).stream())
+      .collect(Collectors.toSet());
+  }
+
+}

--- a/src/main/java/org/folio/search/service/setter/linkeddata/work/LinkedDataWorkClassificationAdditionalNumberProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/linkeddata/work/LinkedDataWorkClassificationAdditionalNumberProcessor.java
@@ -1,0 +1,27 @@
+package org.folio.search.service.setter.linkeddata.work;
+
+import static java.util.Optional.ofNullable;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.folio.search.domain.dto.LinkedDataWork;
+import org.folio.search.service.setter.FieldProcessor;
+import org.folio.search.service.setter.linkeddata.common.LinkedDataClassificationAdditionalNumberProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LinkedDataWorkClassificationAdditionalNumberProcessor
+  implements FieldProcessor<LinkedDataWork, Set<String>> {
+
+  private final LinkedDataClassificationAdditionalNumberProcessor processor;
+
+  @Override
+  public Set<String> getFieldValue(LinkedDataWork linkedDataWork) {
+    return ofNullable(linkedDataWork.getClassifications())
+      .stream()
+      .flatMap(i -> processor.getFieldValue(i).stream())
+      .collect(Collectors.toSet());
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/linkeddata/work/LinkedDataWorkClassificationNumberProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/linkeddata/work/LinkedDataWorkClassificationNumberProcessor.java
@@ -1,0 +1,27 @@
+package org.folio.search.service.setter.linkeddata.work;
+
+import static java.util.Optional.ofNullable;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.folio.search.domain.dto.LinkedDataWork;
+import org.folio.search.service.setter.FieldProcessor;
+import org.folio.search.service.setter.linkeddata.common.LinkedDataClassificationNumberProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LinkedDataWorkClassificationNumberProcessor implements FieldProcessor<LinkedDataWork, Set<String>> {
+
+  private final LinkedDataClassificationNumberProcessor processor;
+
+  @Override
+  public Set<String> getFieldValue(LinkedDataWork linkedDataWork) {
+    return ofNullable(linkedDataWork.getClassifications())
+      .stream()
+      .flatMap(i -> processor.getFieldValue(i).stream())
+      .collect(Collectors.toSet());
+  }
+
+}

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -544,7 +544,7 @@
       "type": "search",
       "index": "keyword_lowercase",
       "processor": "lccnAuthorityProcessor",
-      "searchTermProcessor": "lccnSearchTermProcessor"
+      "searchTermProcessor": "noSpaceSearchTermProcessor"
     }
   },
   "mappingsSource": {

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -702,7 +702,7 @@
       "type": "search",
       "index": "keyword_icu",
       "processor": "lccnInstanceProcessor",
-      "searchTermProcessor": "lccnSearchTermProcessor"
+      "searchTermProcessor": "noSpaceSearchTermProcessor"
     },
     "normalizedClassificationNumber": {
       "type": "search",

--- a/src/main/resources/model/linked_data_instance.json
+++ b/src/main/resources/model/linked_data_instance.json
@@ -16,10 +16,13 @@
     "classifications": {
       "type": "object",
       "properties": {
+        "type": {
+          "index": "whitespace"
+        },
         "number": {
           "index": "whitespace"
         },
-        "source": {
+        "additionalNumber": {
           "index": "whitespace"
         }
       }
@@ -115,11 +118,17 @@
         "classifications": {
           "type": "object",
           "properties": {
-            "number": {
-              "index": "whitespace"
+            "type": {
+              "index": "whitespace",
+              "searchAliases": [ "classificationType" ]
             },
-            "source": {
-              "index": "whitespace"
+            "number": {
+              "index": "whitespace",
+              "searchAliases": [ "classificationNumber" ]
+            },
+            "additionalNumber": {
+              "index": "whitespace",
+              "searchAliases": [ "classificationAdditionalNumber" ]
             }
           }
         },

--- a/src/main/resources/model/linked_data_instance.json
+++ b/src/main/resources/model/linked_data_instance.json
@@ -17,7 +17,8 @@
       "type": "object",
       "properties": {
         "type": {
-          "index": "whitespace"
+          "index": "whitespace",
+          "searchAliases": [ "classificationType" ]
         },
         "number": {
           "index": "whitespace"
@@ -123,12 +124,10 @@
               "searchAliases": [ "classificationType" ]
             },
             "number": {
-              "index": "whitespace",
-              "searchAliases": [ "classificationNumber" ]
+              "index": "whitespace"
             },
             "additionalNumber": {
-              "index": "whitespace",
-              "searchAliases": [ "classificationAdditionalNumber" ]
+              "index": "whitespace"
             }
           }
         },
@@ -200,7 +199,7 @@
       "type": "search",
       "index": "standard",
       "processor": "linkedDataInstanceLccnProcessor",
-      "searchTermProcessor": "lccnSearchTermProcessor"
+      "searchTermProcessor": "noSpaceSearchTermProcessor"
     },
     "note": {
       "type": "search",
@@ -219,6 +218,18 @@
       "type": "search",
       "index": "keyword_lowercase",
       "processor": "linkedDataInstanceSortTitleProcessor"
+    },
+    "classificationNumber": {
+      "type": "search",
+      "index": "standard",
+      "processor": "linkedDataInstanceClassificationNumberProcessor",
+      "searchTermProcessor": "noSpaceSearchTermProcessor"
+    },
+    "classificationAdditionalNumber": {
+      "type": "search",
+      "index": "standard",
+      "processor": "linkedDataInstanceClassificationAdditionalNumberProcessor",
+      "searchTermProcessor": "noSpaceSearchTermProcessor"
     }
   },
   "indexMappings": { }

--- a/src/main/resources/model/linked_data_work.json
+++ b/src/main/resources/model/linked_data_work.json
@@ -16,11 +16,17 @@
     "classifications": {
       "type": "object",
       "properties": {
-        "number": {
-          "index": "whitespace"
+        "type": {
+          "index": "whitespace",
+          "searchAliases": [ "classificationType" ]
         },
-        "source": {
-          "index": "whitespace"
+        "number": {
+          "index": "whitespace",
+          "searchAliases": [ "classificationNumber" ]
+        },
+        "additionalNumber": {
+          "index": "whitespace",
+          "searchAliases": [ "classificationAdditionalNumber" ]
         }
       }
     },

--- a/src/main/resources/model/linked_data_work.json
+++ b/src/main/resources/model/linked_data_work.json
@@ -21,12 +21,10 @@
           "searchAliases": [ "classificationType" ]
         },
         "number": {
-          "index": "whitespace",
-          "searchAliases": [ "classificationNumber" ]
+          "index": "whitespace"
         },
         "additionalNumber": {
-          "index": "whitespace",
-          "searchAliases": [ "classificationAdditionalNumber" ]
+          "index": "whitespace"
         }
       }
     },
@@ -190,7 +188,7 @@
       "type": "search",
       "index": "standard",
       "processor": "linkedDataWorkLccnProcessor",
-      "searchTermProcessor": "lccnSearchTermProcessor"
+      "searchTermProcessor": "noSpaceSearchTermProcessor"
     },
     "note": {
       "type": "search",
@@ -209,6 +207,18 @@
       "type": "search",
       "index": "keyword_lowercase",
       "processor": "linkedDataWorkSortTitleProcessor"
+    },
+    "classificationNumber": {
+      "type": "search",
+      "index": "standard",
+      "processor": "linkedDataWorkClassificationNumberProcessor",
+      "searchTermProcessor": "noSpaceSearchTermProcessor"
+    },
+    "classificationAdditionalNumber": {
+      "type": "search",
+      "index": "standard",
+      "processor": "linkedDataWorkClassificationAdditionalNumberProcessor",
+      "searchTermProcessor": "noSpaceSearchTermProcessor"
     }
   },
   "indexMappings": { }

--- a/src/main/resources/swagger.api/examples/result/linkedDataInstanceSearchResult.yaml
+++ b/src/main/resources/swagger.api/examples/result/linkedDataInstanceSearchResult.yaml
@@ -12,8 +12,9 @@ value:
       languages:
         - "eng"
       classifications:
-        - number: "1234"
-          source: "ddc"
+        - type: "ddc"
+          number: "1234"
+          additionalNumber: "5678"
       subjects:
         - "Subject"
       identifiers:

--- a/src/main/resources/swagger.api/examples/result/linkedDataWorkSearchResult.yaml
+++ b/src/main/resources/swagger.api/examples/result/linkedDataWorkSearchResult.yaml
@@ -12,8 +12,9 @@ value:
       languages:
         - "eng"
       classifications:
-        - number: "1234"
-          source: "ddc"
+        - type: "ddc"
+          number: "1234"
+          additionalNumber: "5678"
       subjects:
         - "Subject"
       instances:

--- a/src/main/resources/swagger.api/schemas/dto/linked-data/common/linkedDataClassification.yaml
+++ b/src/main/resources/swagger.api/schemas/dto/linked-data/common/linkedDataClassification.yaml
@@ -1,0 +1,18 @@
+description: "Linked data Classification DTO, contains type and numbers"
+type: "object"
+properties:
+  type:
+    type: "string"
+    enum:
+      - "ddc"
+      - "lc"
+    description: "The type of the classification number"
+  number:
+    type: "string"
+    description: "Classification number"
+  additionalNumber:
+    type: "string"
+    description: "Additional classification number"
+required:
+  - "type"
+  - "number"

--- a/src/main/resources/swagger.api/schemas/dto/linked-data/common/linkedDataWorkOnly.yaml
+++ b/src/main/resources/swagger.api/schemas/dto/linked-data/common/linkedDataWorkOnly.yaml
@@ -11,17 +11,7 @@ properties:
     type: "array"
     description: "List of classification items"
     items:
-      type: "object"
-      properties:
-        type:
-          type: "string"
-          description: "The type of the classification"
-        number:
-          type: "string"
-          description: "Classification number"
-        additionalNumber:
-          type: "string"
-          description: "Additional classification number"
+      $ref: "linkedDataClassification.yaml"
   contributors:
     type: "array"
     description: "Contributor array"

--- a/src/main/resources/swagger.api/schemas/dto/linked-data/common/linkedDataWorkOnly.yaml
+++ b/src/main/resources/swagger.api/schemas/dto/linked-data/common/linkedDataWorkOnly.yaml
@@ -13,12 +13,15 @@ properties:
     items:
       type: "object"
       properties:
+        type:
+          type: "string"
+          description: "The type of the classification"
         number:
           type: "string"
           description: "Classification number"
-        source:
+        additionalNumber:
           type: "string"
-          description: "The source of the classification"
+          description: "Additional classification number"
   contributors:
     type: "array"
     description: "Contributor array"

--- a/src/test/java/org/folio/search/controller/SearchLinkedDataInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchLinkedDataInstanceIT.java
@@ -2,8 +2,9 @@ package org.folio.search.controller;
 
 import static org.folio.search.sample.SampleLinkedData.getInstance2SampleAsMap;
 import static org.folio.search.sample.SampleLinkedData.getInstanceSampleAsMap;
+import static org.folio.search.utils.LinkedDataTestUtils.toClassificationAdditionalNumber;
 import static org.folio.search.utils.LinkedDataTestUtils.toClassificationNumber;
-import static org.folio.search.utils.LinkedDataTestUtils.toClassificationSource;
+import static org.folio.search.utils.LinkedDataTestUtils.toClassificationType;
 import static org.folio.search.utils.LinkedDataTestUtils.toContributorIsCreator;
 import static org.folio.search.utils.LinkedDataTestUtils.toContributorName;
 import static org.folio.search.utils.LinkedDataTestUtils.toContributorType;
@@ -75,6 +76,9 @@ class SearchLinkedDataInstanceIT extends BaseIntegrationTest {
     "19, title all \"titleAbc\" sortBy title",
     "20, title all \"titleAbc\" sortBy title/sort.ascending",
     "21, title all \"titleAbc\" sortBy title/sort.descending",
+    "22, classificationType <> \"aaa\"",
+    "23, classificationNumber <> \"000\"",
+    "24, classificationAdditionalNumber <> \"000\"",
   })
   void searchByLinkedDataInstance_parameterized_allResults(int index, String query) throws Throwable {
     var asc = !query.contains("descending");
@@ -154,16 +158,21 @@ class SearchLinkedDataInstanceIT extends BaseIntegrationTest {
     "65, publicationDate == 2024",
     "66, publicationDate ==/string 2023",
     "67, publicationDate == (\"2023\" or \"2024\" or \"2020\")",
-    "68, publicationDate all 2024"
+    "68, publicationDate all 2024",
+    "69, classificationType == \"ddc\"",
+    "70, classificationNumber == \"123\"",
+    "71, classificationAdditionalNumber == \"456\"",
   })
   void searchByLinkedDataInstance_parameterized_singleResult(int index, String query) throws Throwable {
     doSearchByLinkedDataInstance(query)
       .andExpect(jsonPath(toTotalRecords(), is(1)))
       .andExpect(jsonPath(toId(toRootContent()), is("instance1")))
-      .andExpect(jsonPath(toClassificationNumber(toParentWork(), 0), is("1234")))
-      .andExpect(jsonPath(toClassificationSource(toParentWork(), 0), is("ddc")))
-      .andExpect(jsonPath(toClassificationNumber(toParentWork(), 1), is("5678")))
-      .andExpect(jsonPath(toClassificationSource(toParentWork(), 1), is("other")))
+      .andExpect(jsonPath(toClassificationType(toParentWork(), 0), is("ddc")))
+      .andExpect(jsonPath(toClassificationNumber(toParentWork(), 0), is("123")))
+      .andExpect(jsonPath(toClassificationAdditionalNumber(toParentWork(), 0), is("456")))
+      .andExpect(jsonPath(toClassificationType(toParentWork(), 1), is("llc")))
+      .andExpect(jsonPath(toClassificationNumber(toParentWork(), 1), is("789")))
+      .andExpect(jsonPath(toClassificationAdditionalNumber(toParentWork(), 1), is("012")))
       .andExpect(jsonPath(toContributorName(toRootContent(), 0), is("Instance1_Family")))
       .andExpect(jsonPath(toContributorType(toRootContent(), 0), is("Family")))
       .andExpect(jsonPath(toContributorIsCreator(toRootContent(), 0), is(true)))
@@ -265,6 +274,9 @@ class SearchLinkedDataInstanceIT extends BaseIntegrationTest {
     "28, contributor any \"comm\"",
     "29, contributor = \"comm\"",
     "30, contributor <> \"common\"",
+    "31, classificationType == \"aaa\"",
+    "31, classificationNumber == \"000\"",
+    "33, classificationAdditionalNumber == \"000\"",
   })
   void searchByLinkedDataInstance_parameterized_zeroResults(int index, String query) throws Throwable {
     doSearchByLinkedDataInstance(query)

--- a/src/test/java/org/folio/search/controller/SearchLinkedDataInstanceIT.java
+++ b/src/test/java/org/folio/search/controller/SearchLinkedDataInstanceIT.java
@@ -162,6 +162,8 @@ class SearchLinkedDataInstanceIT extends BaseIntegrationTest {
     "69, classificationType == \"ddc\"",
     "70, classificationNumber == \"123\"",
     "71, classificationAdditionalNumber == \"456\"",
+    "72, classificationNumber == \"1 2  3\"",
+    "73, classificationAdditionalNumber == \"45  6\"",
   })
   void searchByLinkedDataInstance_parameterized_singleResult(int index, String query) throws Throwable {
     doSearchByLinkedDataInstance(query)
@@ -170,7 +172,7 @@ class SearchLinkedDataInstanceIT extends BaseIntegrationTest {
       .andExpect(jsonPath(toClassificationType(toParentWork(), 0), is("ddc")))
       .andExpect(jsonPath(toClassificationNumber(toParentWork(), 0), is("123")))
       .andExpect(jsonPath(toClassificationAdditionalNumber(toParentWork(), 0), is("456")))
-      .andExpect(jsonPath(toClassificationType(toParentWork(), 1), is("llc")))
+      .andExpect(jsonPath(toClassificationType(toParentWork(), 1), is("lc")))
       .andExpect(jsonPath(toClassificationNumber(toParentWork(), 1), is("789")))
       .andExpect(jsonPath(toClassificationAdditionalNumber(toParentWork(), 1), is("012")))
       .andExpect(jsonPath(toContributorName(toRootContent(), 0), is("Instance1_Family")))

--- a/src/test/java/org/folio/search/controller/SearchLinkedDataWorkIT.java
+++ b/src/test/java/org/folio/search/controller/SearchLinkedDataWorkIT.java
@@ -2,8 +2,9 @@ package org.folio.search.controller;
 
 import static org.folio.search.sample.SampleLinkedData.getWork2SampleAsMap;
 import static org.folio.search.sample.SampleLinkedData.getWorkSampleAsMap;
+import static org.folio.search.utils.LinkedDataTestUtils.toClassificationAdditionalNumber;
 import static org.folio.search.utils.LinkedDataTestUtils.toClassificationNumber;
-import static org.folio.search.utils.LinkedDataTestUtils.toClassificationSource;
+import static org.folio.search.utils.LinkedDataTestUtils.toClassificationType;
 import static org.folio.search.utils.LinkedDataTestUtils.toContributorIsCreator;
 import static org.folio.search.utils.LinkedDataTestUtils.toContributorName;
 import static org.folio.search.utils.LinkedDataTestUtils.toContributorType;
@@ -75,6 +76,9 @@ class SearchLinkedDataWorkIT extends BaseIntegrationTest {
     "19, title all \"titleAbc\" sortBy title",
     "20, title all \"titleAbc\" sortBy title/sort.ascending",
     "21, title all \"titleAbc\" sortBy title/sort.descending",
+    "22, classificationType <> \"aaa\"",
+    "23, classificationNumber <> \"000\"",
+    "24, classificationAdditionalNumber <> \"000\"",
   })
   void searchByLinkedDataWork_parameterized_allResults(int index, String query) throws Throwable {
     var asc = query.contains("titleAbc def") || query.contains("sortBy") && !query.contains("descending");
@@ -154,16 +158,21 @@ class SearchLinkedDataWorkIT extends BaseIntegrationTest {
     "65, publicationDate == 2024",
     "66, publicationDate ==/string 2023",
     "67, publicationDate == (\"2023\" or \"2024\" or \"2020\")",
-    "68, publicationDate all 2024"
+    "68, publicationDate all 2024",
+    "69, classificationType == \"ddc\"",
+    "70, classificationNumber == \"123\"",
+    "71, classificationAdditionalNumber == \"456\"",
   })
   void searchByLinkedDataWork_parameterized_singleResult(int index, String query) throws Throwable {
     doSearchByLinkedDataWork(query)
       .andExpect(jsonPath(toTotalRecords(), is(1)))
       .andExpect(jsonPath(toId(toRootContent()), is("123456123456")))
-      .andExpect(jsonPath(toClassificationNumber(toRootContent(), 0), is("1234")))
-      .andExpect(jsonPath(toClassificationSource(toRootContent(), 0), is("ddc")))
-      .andExpect(jsonPath(toClassificationNumber(toRootContent(), 1), is("5678")))
-      .andExpect(jsonPath(toClassificationSource(toRootContent(), 1), is("other")))
+      .andExpect(jsonPath(toClassificationType(toRootContent(), 0), is("ddc")))
+      .andExpect(jsonPath(toClassificationNumber(toRootContent(), 0), is("123")))
+      .andExpect(jsonPath(toClassificationAdditionalNumber(toRootContent(), 0), is("456")))
+      .andExpect(jsonPath(toClassificationType(toRootContent(), 1), is("llc")))
+      .andExpect(jsonPath(toClassificationNumber(toRootContent(), 1), is("789")))
+      .andExpect(jsonPath(toClassificationAdditionalNumber(toRootContent(), 1), is("012")))
       .andExpect(jsonPath(toContributorName(toRootContent(), 0), is("Family")))
       .andExpect(jsonPath(toContributorType(toRootContent(), 0), is("Family")))
       .andExpect(jsonPath(toContributorIsCreator(toRootContent(), 0), is(true)))
@@ -263,6 +272,9 @@ class SearchLinkedDataWorkIT extends BaseIntegrationTest {
     "28, contributor any \"comm\"",
     "29, contributor = \"comm\"",
     "30, contributor <> \"common\"",
+    "31, classificationType == \"aaa\"",
+    "31, classificationNumber == \"000\"",
+    "33, classificationAdditionalNumber == \"000\"",
   })
   void searchByLinkedDataWork_parameterized_zeroResults(int index, String query) throws Throwable {
     doSearchByLinkedDataWork(query)
@@ -311,10 +323,12 @@ class SearchLinkedDataWorkIT extends BaseIntegrationTest {
     doSearchByLinkedDataWorkWithoutInstances(query)
       .andExpect(jsonPath(toTotalRecords(), is(1)))
       .andExpect(jsonPath(toId(toRootContent()), is("123456123456")))
-      .andExpect(jsonPath(toClassificationNumber(toRootContent(), 0), is("1234")))
-      .andExpect(jsonPath(toClassificationSource(toRootContent(), 0), is("ddc")))
-      .andExpect(jsonPath(toClassificationNumber(toRootContent(), 1), is("5678")))
-      .andExpect(jsonPath(toClassificationSource(toRootContent(), 1), is("other")))
+      .andExpect(jsonPath(toClassificationType(toRootContent(), 0), is("ddc")))
+      .andExpect(jsonPath(toClassificationNumber(toRootContent(), 0), is("123")))
+      .andExpect(jsonPath(toClassificationAdditionalNumber(toRootContent(), 0), is("456")))
+      .andExpect(jsonPath(toClassificationType(toRootContent(), 1), is("llc")))
+      .andExpect(jsonPath(toClassificationNumber(toRootContent(), 1), is("789")))
+      .andExpect(jsonPath(toClassificationAdditionalNumber(toRootContent(), 1), is("012")))
       .andExpect(jsonPath(toContributorName(toRootContent(), 0), is("Family")))
       .andExpect(jsonPath(toContributorType(toRootContent(), 0), is("Family")))
       .andExpect(jsonPath(toContributorIsCreator(toRootContent(), 0), is(true)))

--- a/src/test/java/org/folio/search/controller/SearchLinkedDataWorkIT.java
+++ b/src/test/java/org/folio/search/controller/SearchLinkedDataWorkIT.java
@@ -162,6 +162,8 @@ class SearchLinkedDataWorkIT extends BaseIntegrationTest {
     "69, classificationType == \"ddc\"",
     "70, classificationNumber == \"123\"",
     "71, classificationAdditionalNumber == \"456\"",
+    "72, classificationNumber == \"1 2 3\"",
+    "73, classificationAdditionalNumber == \"4  56\"",
   })
   void searchByLinkedDataWork_parameterized_singleResult(int index, String query) throws Throwable {
     doSearchByLinkedDataWork(query)
@@ -170,7 +172,7 @@ class SearchLinkedDataWorkIT extends BaseIntegrationTest {
       .andExpect(jsonPath(toClassificationType(toRootContent(), 0), is("ddc")))
       .andExpect(jsonPath(toClassificationNumber(toRootContent(), 0), is("123")))
       .andExpect(jsonPath(toClassificationAdditionalNumber(toRootContent(), 0), is("456")))
-      .andExpect(jsonPath(toClassificationType(toRootContent(), 1), is("llc")))
+      .andExpect(jsonPath(toClassificationType(toRootContent(), 1), is("lc")))
       .andExpect(jsonPath(toClassificationNumber(toRootContent(), 1), is("789")))
       .andExpect(jsonPath(toClassificationAdditionalNumber(toRootContent(), 1), is("012")))
       .andExpect(jsonPath(toContributorName(toRootContent(), 0), is("Family")))
@@ -326,7 +328,7 @@ class SearchLinkedDataWorkIT extends BaseIntegrationTest {
       .andExpect(jsonPath(toClassificationType(toRootContent(), 0), is("ddc")))
       .andExpect(jsonPath(toClassificationNumber(toRootContent(), 0), is("123")))
       .andExpect(jsonPath(toClassificationAdditionalNumber(toRootContent(), 0), is("456")))
-      .andExpect(jsonPath(toClassificationType(toRootContent(), 1), is("llc")))
+      .andExpect(jsonPath(toClassificationType(toRootContent(), 1), is("lc")))
       .andExpect(jsonPath(toClassificationNumber(toRootContent(), 1), is("789")))
       .andExpect(jsonPath(toClassificationAdditionalNumber(toRootContent(), 1), is("012")))
       .andExpect(jsonPath(toContributorName(toRootContent(), 0), is("Family")))

--- a/src/test/java/org/folio/search/cql/searchterm/NoSpaceSearchTermProcessorTest.java
+++ b/src/test/java/org/folio/search/cql/searchterm/NoSpaceSearchTermProcessorTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
-import org.folio.search.service.lccn.LccnNormalizer;
+import org.folio.search.service.lccn.StringNormalizer;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,11 +14,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-class LccnSearchTermProcessorTest {
+class NoSpaceSearchTermProcessorTest {
   @Mock
-  private LccnNormalizer normalizer;
+  private StringNormalizer normalizer;
   @InjectMocks
-  private LccnSearchTermProcessor lccnSearchTermProcessor;
+  private NoSpaceSearchTermProcessor noSpaceSearchTermProcessor;
 
   @Test
   void getSearchTerm_positive() {
@@ -28,7 +28,7 @@ class LccnSearchTermProcessorTest {
     when(normalizer.apply(searchTerm)).thenReturn(Optional.of(normalizedTerm));
 
     // when
-    var actual = lccnSearchTermProcessor.getSearchTerm(searchTerm);
+    var actual = noSpaceSearchTermProcessor.getSearchTerm(searchTerm);
 
     // then
     assertThat(actual).isEqualTo(normalizedTerm);

--- a/src/test/java/org/folio/search/service/lccn/NoSpaceNormalizerTest.java
+++ b/src/test/java/org/folio/search/service/lccn/NoSpaceNormalizerTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 @UnitTest
-class DefaultLccnNormalizerTest {
-  private final DefaultLccnNormalizer lccnNormalizer = new DefaultLccnNormalizer();
+class NoSpaceNormalizerTest {
+  private final NoSpaceNormalizer lccnNormalizer = new NoSpaceNormalizer();
 
   @DisplayName("LCCN value normalization")
   @CsvSource({"n 1234,n1234", "  N  1234 ,n1234", "*1234,*1234", "1234*,1234*"})

--- a/src/test/java/org/folio/search/service/setter/authority/LccnAuthorityProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/authority/LccnAuthorityProcessorTest.java
@@ -16,7 +16,7 @@ import org.folio.search.domain.dto.Authority;
 import org.folio.search.domain.dto.Identifier;
 import org.folio.search.integration.folio.ReferenceDataService;
 import org.folio.search.model.client.CqlQueryParam;
-import org.folio.search.service.lccn.DefaultLccnNormalizer;
+import org.folio.search.service.lccn.NoSpaceNormalizer;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,7 +38,7 @@ class LccnAuthorityProcessorTest {
 
   @BeforeEach
   void setup() {
-    var lccnNormalizer = new DefaultLccnNormalizer();
+    var lccnNormalizer = new NoSpaceNormalizer();
     lccnProcessor = new LccnAuthorityProcessor(referenceDataService, lccnNormalizer);
   }
 

--- a/src/test/java/org/folio/search/service/setter/instance/LccnInstanceProcessorTest.java
+++ b/src/test/java/org/folio/search/service/setter/instance/LccnInstanceProcessorTest.java
@@ -16,7 +16,7 @@ import org.folio.search.domain.dto.Identifier;
 import org.folio.search.domain.dto.Instance;
 import org.folio.search.integration.folio.ReferenceDataService;
 import org.folio.search.model.client.CqlQueryParam;
-import org.folio.search.service.lccn.DefaultLccnNormalizer;
+import org.folio.search.service.lccn.NoSpaceNormalizer;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,7 +40,7 @@ class LccnInstanceProcessorTest {
 
   @BeforeEach
   void setup() {
-    var lccnNormalizer = new DefaultLccnNormalizer();
+    var lccnNormalizer = new NoSpaceNormalizer();
     lccnProcessor = new LccnInstanceProcessor(referenceDataService, lccnNormalizer);
   }
 

--- a/src/test/java/org/folio/search/utils/LinkedDataTestUtils.java
+++ b/src/test/java/org/folio/search/utils/LinkedDataTestUtils.java
@@ -73,12 +73,16 @@ public class LinkedDataTestUtils {
     return join(".", base, arrayPath("classifications", number));
   }
 
+  public static String toClassificationType(String base, int number) {
+    return join(".", toClassification(base, number), path("type"));
+  }
+
   public static String toClassificationNumber(String base, int number) {
     return join(".", toClassification(base, number), path("number"));
   }
 
-  public static String toClassificationSource(String base, int number) {
-    return join(".", toClassification(base, number), path("source"));
+  public static String toClassificationAdditionalNumber(String base, int number) {
+    return join(".", toClassification(base, number), path("additionalNumber"));
   }
 
   public static String toSubject(String base, int number) {

--- a/src/test/resources/samples/linked-data/instance.json
+++ b/src/test/resources/samples/linked-data/instance.json
@@ -79,12 +79,14 @@
     "id": "123456123456",
     "classifications": [
       {
-        "number": "1234",
-        "source": "ddc"
+        "type": "ddc",
+        "number": "123",
+        "additionalNumber": "456"
       },
       {
-        "number": "5678",
-        "source": "other"
+        "type": "llc",
+        "number": "789",
+        "additionalNumber": "012"
       }
     ],
     "contributors": [

--- a/src/test/resources/samples/linked-data/instance.json
+++ b/src/test/resources/samples/linked-data/instance.json
@@ -84,7 +84,7 @@
         "additionalNumber": "456"
       },
       {
-        "type": "llc",
+        "type": "lc",
         "number": "789",
         "additionalNumber": "012"
       }

--- a/src/test/resources/samples/linked-data/work.json
+++ b/src/test/resources/samples/linked-data/work.json
@@ -2,12 +2,14 @@
   "id": "123456123456",
   "classifications": [
     {
-      "number": "1234",
-      "source": "ddc"
+      "type": "ddc",
+      "number": "123",
+      "additionalNumber": "456"
     },
     {
-      "number": "5678",
-      "source": "other"
+      "type": "llc",
+      "number": "789",
+      "additionalNumber": "012"
     }
   ],
   "contributors": [

--- a/src/test/resources/samples/linked-data/work.json
+++ b/src/test/resources/samples/linked-data/work.json
@@ -7,7 +7,7 @@
       "additionalNumber": "456"
     },
     {
-      "type": "llc",
+      "type": "lc",
       "number": "789",
       "additionalNumber": "012"
     }


### PR DESCRIPTION
### Purpose
Linked Data Instance and Work: search by classification type/number/additionalNumber

### Approach
Existed Linked Data model and DTO extended with few additional fields

### Changes Checklist
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MSEARCH-989