### PR TITLE
fix: adjust facet filtering for nested queries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,3 @@
-## v6.0.0 YYYY-mm-DD
-### Features
-* Linked Data Instance and Work: search by classification type/number/additionalNumber ([MSEARCH-989](https://folio-org.atlassian.net/browse/MSEARCH-989))
-
 ## v5.1.0 YYYY-mm-DD
 ### Breaking changes
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
@@ -11,13 +7,14 @@
 * Requires `API_NAME vX.Y`
 
 ### Features
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Linked Data Instance and Work: search by classification type/number/additionalNumber ([MSEARCH-989](https://folio-org.atlassian.net/browse/MSEARCH-989))
 
 ### Bug fixes
 * Browse Config: fix exception while trying to validate empty type ids ([MSEARCH-998](https://folio-org.atlassian.net/browse/MSEARCH-998))
 * ECS: Modify filters for sub-resources during browse ([MSEARCH-990](https://folio-org.atlassian.net/browse/MSEARCH-990))
 * Facets: Modify facet queries to remove filters for nested queries ([MSEARCH-995](https://folio-org.atlassian.net/browse/MSEARCH-995))
 * Move index recreation before merge range publishing on full reindex ([MSEARCH-1006](https://folio-org.atlassian.net/browse/MSEARCH-1006))
+* Add facet filtering for nested queries ([MSEARCH-1012](https://folio-org.atlassian.net/browse/MSEARCH-1012))
 
 ### Tech Dept
 * Stabilize test execution ([MSEARCH-991](https://folio-org.atlassian.net/browse/MSEARCH-991))

--- a/src/test/java/org/folio/api/browse/BrowseCallNumberConsortiumIT.java
+++ b/src/test/java/org/folio/api/browse/BrowseCallNumberConsortiumIT.java
@@ -68,6 +68,7 @@ class BrowseCallNumberConsortiumIT extends BaseConsortiumIntegrationTest {
 
   private static final String LOCATION_FACET = "instances.locationId";
   private static final String TENANT_FACET = "instances.tenantId";
+  private static final String SHARED_FACET = "instances.shared";
   private static final List<Instance> INSTANCES = instances();
   private static final String MEMBER2_LOCATION = UUID.randomUUID().toString();
 
@@ -236,10 +237,12 @@ class BrowseCallNumberConsortiumIT extends BaseConsortiumIntegrationTest {
         facet(facetItem(CENTRAL_TENANT_ID, 60), facetItem(MEMBER_TENANT_ID, 42),
           facetItem(MEMBER2_TENANT_ID, 3)))),
       arguments(MEMBER_TENANT_ID, "instances.shared==false", array(LOCATION_FACET),
-        expectedLocationFacet(locations, 42, 34, 24, true)),
+        expectedLocationFacet(locations, 15, 14, 11, true)),
       arguments(MEMBER_TENANT_ID, "instances.shared==false", array(TENANT_FACET), mapOf(TENANT_FACET,
-        facet(facetItem(CENTRAL_TENANT_ID, 60), facetItem(MEMBER_TENANT_ID, 42),
-          facetItem(MEMBER2_TENANT_ID, 3))))
+        facet(facetItem(MEMBER_TENANT_ID, 40), facetItem(MEMBER2_TENANT_ID, 1)))),
+      arguments(MEMBER_TENANT_ID, "instances.locationId==" + MEMBER2_LOCATION, array(SHARED_FACET, LOCATION_FACET),
+        mapOf(SHARED_FACET, facet(facetItem("false", 1))),
+        mapOf(LOCATION_FACET, expectedLocationFacet(locations, 42, 34, 24, true)))
     );
   }
 


### PR DESCRIPTION
### Purpose
Filtering by one of facet in call-number browse, doesn't have affect to other facets.

### Approach
adjust facet filtering for nested queries

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MSEARCH-1012