### PR TITLE
MSEARCH-1020: Authority Search: Fix keyword search by all heading fields  

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * Move index recreation before merge range publishing on full reindex ([MSEARCH-1006](https://folio-org.atlassian.net/browse/MSEARCH-1006))
 * Add facet filtering for nested queries ([MSEARCH-1012](https://folio-org.atlassian.net/browse/MSEARCH-1012))
 * NumberFormatException: "1\_000" "20\_000" ([MSEARCH-1016](https://folio-org.atlassian.net/browse/MSEARCH-1016))
+* Authority search: make searching by all heading fields handled with separate/generated search field  ([MSEARCH-1020](https://folio-org.atlassian.net/browse/MSEARCH-1020))
 
 ### Tech Dept
 * Stabilize test execution ([MSEARCH-991](https://folio-org.atlassian.net/browse/MSEARCH-991))

--- a/src/main/resources/model/authority.json
+++ b/src/main/resources/model/authority.json
@@ -18,7 +18,6 @@
     "personalName": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "personalName",
       "headingType": "Personal Name",
       "authRefType": "Authorized"
@@ -26,7 +25,6 @@
     "sftPersonalName": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftPersonalName",
       "headingType": "Personal Name",
       "authRefType": "Reference"
@@ -34,7 +32,6 @@
     "saftPersonalName": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftPersonalName",
       "headingType": "Personal Name",
       "authRefType": "Auth/Ref"
@@ -42,7 +39,6 @@
     "personalNameTitle": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "personalNameTitle",
       "headingType": "Personal Name",
       "isTitleHeadingRef": true,
@@ -51,7 +47,6 @@
     "sftPersonalNameTitle": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftPersonalNameTitle",
       "headingType": "Personal Name",
       "isTitleHeadingRef": true,
@@ -60,7 +55,6 @@
     "saftPersonalNameTitle": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftPersonalNameTitle",
       "headingType": "Personal Name",
       "isTitleHeadingRef": true,
@@ -69,7 +63,6 @@
     "corporateName": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "corporateName",
       "headingType": "Corporate Name",
       "authRefType": "Authorized"
@@ -77,7 +70,6 @@
     "sftCorporateName": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftCorporateName",
       "headingType": "Corporate Name",
       "authRefType": "Reference"
@@ -85,7 +77,6 @@
     "saftCorporateName": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftCorporateName",
       "headingType": "Corporate Name",
       "authRefType": "Auth/Ref"
@@ -93,7 +84,6 @@
     "corporateNameTitle": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "corporateNameTitle",
       "headingType": "Corporate Name",
       "isTitleHeadingRef": true,
@@ -102,7 +92,6 @@
     "sftCorporateNameTitle": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftCorporateNameTitle",
       "headingType": "Corporate Name",
       "isTitleHeadingRef": true,
@@ -111,7 +100,6 @@
     "saftCorporateNameTitle": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftCorporateNameTitle",
       "headingType": "Corporate Name",
       "isTitleHeadingRef": true,
@@ -120,7 +108,6 @@
     "meetingName": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "meetingName",
       "headingType": "Conference Name",
       "authRefType": "Authorized"
@@ -128,7 +115,6 @@
     "sftMeetingName": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftMeetingName",
       "headingType": "Conference Name",
       "authRefType": "Reference"
@@ -136,7 +122,6 @@
     "saftMeetingName": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftMeetingName",
       "headingType": "Conference Name",
       "authRefType": "Auth/Ref"
@@ -144,7 +129,6 @@
     "meetingNameTitle": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "meetingNameTitle",
       "headingType": "Conference Name",
       "isTitleHeadingRef": true,
@@ -153,7 +137,6 @@
     "sftMeetingNameTitle": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftMeetingNameTitle",
       "headingType": "Conference Name",
       "isTitleHeadingRef": true,
@@ -162,7 +145,6 @@
     "saftMeetingNameTitle": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftMeetingNameTitle",
       "headingType": "Conference Name",
       "isTitleHeadingRef": true,
@@ -171,7 +153,6 @@
     "geographicName": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "geographicName",
       "headingType": "Geographic Name",
       "authRefType": "Authorized"
@@ -179,7 +160,6 @@
     "sftGeographicName": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftGeographicName",
       "headingType": "Geographic Name",
       "authRefType": "Reference"
@@ -187,7 +167,6 @@
     "saftGeographicName": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftGeographicName",
       "headingType": "Geographic Name",
       "authRefType": "Auth/Ref"
@@ -195,7 +174,6 @@
     "uniformTitle": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "uniformTitle",
       "headingType": "Uniform Title",
       "authRefType": "Authorized"
@@ -204,7 +182,6 @@
       "type": "authority",
       "index": "standard",
       "distinctType": "sftUniformTitle",
-      "searchAliases": [ "keyword" ],
       "headingType": "Uniform Title",
       "authRefType": "Reference"
     },
@@ -212,14 +189,12 @@
       "type": "authority",
       "index": "standard",
       "distinctType": "saftUniformTitle",
-      "searchAliases": [ "keyword" ],
       "headingType": "Uniform Title",
       "authRefType": "Auth/Ref"
     },
     "namedEvent": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "namedEvent",
       "headingType": "Named Event",
       "authRefType": "Authorized"
@@ -227,7 +202,6 @@
     "sftNamedEvent": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftNamedEvent",
       "headingType": "Named Event",
       "authRefType": "Reference"
@@ -235,7 +209,6 @@
     "saftNamedEvent": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftNamedEvent",
       "headingType": "Named Event",
       "authRefType": "Auth/Ref"
@@ -243,7 +216,6 @@
     "generalSubdivision": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "generalSubdivision",
       "headingType": "General Subdivision",
       "authRefType": "Authorized"
@@ -251,7 +223,6 @@
     "sftGeneralSubdivision": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftGeneralSubdivision",
       "headingType": "General Subdivision",
       "authRefType": "Reference"
@@ -259,7 +230,6 @@
     "saftGeneralSubdivision": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftGeneralSubdivision",
       "headingType": "General Subdivision",
       "authRefType": "Auth/Ref"
@@ -267,7 +237,6 @@
     "topicalTerm": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "topicalTerm",
       "headingType": "Topical",
       "authRefType": "Authorized"
@@ -275,7 +244,6 @@
     "sftTopicalTerm": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftTopicalTerm",
       "headingType": "Topical",
       "authRefType": "Reference"
@@ -283,7 +251,6 @@
     "saftTopicalTerm": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftTopicalTerm",
       "headingType": "Topical",
       "authRefType": "Auth/Ref"
@@ -291,7 +258,6 @@
     "genreTerm": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "genreTerm",
       "headingType": "Genre",
       "authRefType": "Authorized"
@@ -299,7 +265,6 @@
     "sftGenreTerm": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftGenreTerm",
       "headingType": "Genre",
       "authRefType": "Reference"
@@ -307,7 +272,6 @@
     "saftGenreTerm": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftGenreTerm",
       "headingType": "Genre",
       "authRefType": "Auth/Ref"
@@ -315,7 +279,6 @@
     "chronTerm": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "chronTerm",
       "headingType": "Chronological Term",
       "authRefType": "Authorized"
@@ -323,7 +286,6 @@
     "sftChronTerm": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftChronTerm",
       "headingType": "Chronological Term",
       "authRefType": "Reference"
@@ -331,7 +293,6 @@
     "saftChronTerm": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftChronTerm",
       "headingType": "Chronological Term",
       "authRefType": "Auth/Ref"
@@ -339,7 +300,6 @@
     "mediumPerfTerm": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "mediumPerfTerm",
       "headingType": "Medium of Performance Term",
       "authRefType": "Authorized"
@@ -347,7 +307,6 @@
     "sftMediumPerfTerm": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftMediumPerfTerm",
       "headingType": "Medium of Performance Term",
       "authRefType": "Reference"
@@ -355,7 +314,6 @@
     "saftMediumPerfTerm": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftMediumPerfTerm",
       "headingType": "Medium of Performance Term",
       "authRefType": "Auth/Ref"
@@ -363,7 +321,6 @@
     "geographicSubdivision": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "geographicSubdivision",
       "headingType": "Geographic Subdivision",
       "authRefType": "Authorized"
@@ -371,7 +328,6 @@
     "sftGeographicSubdivision": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftGeographicSubdivision",
       "headingType": "Geographic Subdivision",
       "authRefType": "Reference"
@@ -379,7 +335,6 @@
     "saftGeographicSubdivision": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftGeographicSubdivision",
       "headingType": "Geographic Subdivision",
       "authRefType": "Auth/Ref"
@@ -387,7 +342,6 @@
     "chronSubdivision": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "chronSubdivision",
       "headingType": "Chronological Subdivision",
       "authRefType": "Authorized"
@@ -395,7 +349,6 @@
     "sftChronSubdivision": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftChronSubdivision",
       "headingType": "Chronological Subdivision",
       "authRefType": "Reference"
@@ -403,7 +356,6 @@
     "saftChronSubdivision": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftChronSubdivision",
       "headingType": "Chronological Subdivision",
       "authRefType": "Auth/Ref"
@@ -411,7 +363,6 @@
     "formSubdivision": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "formSubdivision",
       "headingType": "Form Subdivision",
       "authRefType": "Authorized"
@@ -419,7 +370,6 @@
     "sftFormSubdivision": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "sftFormSubdivision",
       "headingType": "Form Subdivision",
       "authRefType": "Reference"
@@ -427,7 +377,6 @@
     "saftFormSubdivision": {
       "type": "authority",
       "index": "standard",
-      "searchAliases": [ "keyword" ],
       "distinctType": "saftFormSubdivision",
       "headingType": "Form Subdivision",
       "authRefType": "Auth/Ref"
@@ -540,6 +489,14 @@
         "copy_to": [ "sort_headingRef" ]
       }
     },
+    "headingTermRef": {
+      "type": "search",
+      "index": "standard",
+      "searchAliases": [ "keyword" ],
+      "processor": "headingRefProcessor",
+      "rawProcessing": true,
+      "showInResponse": [ "search", "browse" ]
+    },
     "lccn": {
       "type": "search",
       "index": "keyword_lowercase",
@@ -558,7 +515,11 @@
       "geographicName", "sftGeographicName", "saftGeographicName",
       "uniformTitle", "sftUniformTitle", "saftUniformTitle",
       "topicalTerm", "sftTopicalTerm", "saftTopicalTerm",
-      "genreTerm", "sftGenreTerm", "saftGenreTerm"
+      "genreTerm", "sftGenreTerm", "saftGenreTerm", "chronTerm", "sftChronTerm",
+      "saftChronTerm", "mediumPerfTerm", "sftMediumPerfTerm", "saftMediumPerfTerm",
+      "geographicSubdivision", "sftGeographicSubdivision", "saftGeographicSubdivision",
+      "chronSubdivision", "sftChronSubdivision", "saftChronSubdivision",
+      "formSubdivision", "sftFormSubdivision", "saftFormSubdivision"
     ]
   },
   "indexMappings": {


### PR DESCRIPTION
### Purpose
With the increase of the number of headings the keyword search becomes unachievable as now it searches by all heading fields. In this case the generated elastic search query contains more boolean clauses than it is allowed  - regulated with setting and default value: maxClauseCount = 1024

### Approach
introduce new generated search field for keyword search which would represent all headings

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-1020](https://folio-org.atlassian.net/browse/MSEARCH-1020)