### PR TITLE
feat(classification-browse): POC adding title and contributors to browse response

### DIFF
--- a/src/main/java/org/folio/search/model/index/InstanceSubResource.java
+++ b/src/main/java/org/folio/search/model/index/InstanceSubResource.java
@@ -7,6 +7,7 @@ import lombok.Data;
 @Data
 @Builder
 public class InstanceSubResource {
+  private String resourceId;
   private String tenantId;
   private Boolean shared;
   private int count;
@@ -14,4 +15,5 @@ public class InstanceSubResource {
   private String locationId;
   private List<String> instanceId;
   private String instanceTitle;
+  private List<String> instanceContributors;
 }

--- a/src/main/java/org/folio/search/service/browse/ClassificationBrowseService.java
+++ b/src/main/java/org/folio/search/service/browse/ClassificationBrowseService.java
@@ -54,11 +54,24 @@ public class ClassificationBrowseService
                                                                            SearchResult<ClassificationResource> res,
                                                                            boolean isAnchor) {
     return BrowseResult.of(res)
-      .map(resource -> new ClassificationNumberBrowseItem()
-        .classificationNumber(resource.number())
-        .classificationTypeId(resource.typeId())
-        .isAnchor(isAnchor ? true : null)
-        .totalRecords(getTotalRecords(ctx, resource, ClassificationResource::instances)));
+      .map(resource -> {
+        var totalRecords = getTotalRecords(ctx, resource, ClassificationResource::instances);
+        var item = new ClassificationNumberBrowseItem()
+          .classificationNumber(resource.number())
+          .classificationTypeId(resource.typeId())
+          .isAnchor(isAnchor ? true : null)
+          .totalRecords(totalRecords);
+
+        if (totalRecords == 1) {
+          var subResource = consortiumSearchHelper.filterSubResourcesForConsortium(ctx, resource,
+            ClassificationResource::instances)
+            .iterator().next();
+          item.setInstanceTitle(subResource.getInstanceTitle());
+          item.setInstanceContributors(subResource.getInstanceContributors());
+        }
+
+        return item;
+      });
   }
 
   private Integer getTotalRecords(BrowseContext ctx, ClassificationResource resource,

--- a/src/main/java/org/folio/search/service/setter/callnumber/CallNumberSearchResponsePostProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/callnumber/CallNumberSearchResponsePostProcessor.java
@@ -49,8 +49,8 @@ public final class CallNumberSearchResponsePostProcessor implements SearchRespon
     countAndSetNumberOfLinkedInstances(subResources);
   }
 
-  private void countAndSetNumberOfLinkedInstances(List<InstanceSubResource> authorities) {
-    var ids = authorities.stream()
+  private void countAndSetNumberOfLinkedInstances(List<InstanceSubResource> callNumbers) {
+    var ids = callNumbers.stream()
       .map(InstanceSubResource::getInstanceId)
       .filter(instanceIds -> instanceIds.size() == 1)
       .flatMap(Collection::stream)
@@ -65,9 +65,9 @@ public final class CallNumberSearchResponsePostProcessor implements SearchRespon
     for (var searchHit : searchHits) {
       var instanceId = searchHit.getId();
       var instanceTitle = MapUtils.getString(searchHit.getSourceAsMap(), INSTANCE_TITLE_FIELD);
-      for (var authority : authorities) {
-        if (authority.getInstanceId().size() == 1 && authority.getInstanceId().getFirst().equals(instanceId)) {
-          authority.setInstanceTitle(instanceTitle);
+      for (var callNumber : callNumbers) {
+        if (callNumber.getInstanceId().size() == 1 && callNumber.getInstanceId().getFirst().equals(instanceId)) {
+          callNumber.setInstanceTitle(instanceTitle);
         }
       }
     }

--- a/src/main/java/org/folio/search/service/setter/classification/ClassificationSearchResponsePostProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/classification/ClassificationSearchResponsePostProcessor.java
@@ -1,0 +1,101 @@
+package org.folio.search.service.setter.classification;
+
+import static org.folio.search.utils.LogUtils.collectionToLogMsg;
+import static org.opensearch.index.query.QueryBuilders.termsQuery;
+
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.collections4.MapUtils;
+import org.folio.search.model.SimpleResourceRequest;
+import org.folio.search.model.index.ClassificationResource;
+import org.folio.search.model.index.InstanceSubResource;
+import org.folio.search.model.types.ResourceType;
+import org.folio.search.repository.SearchRepository;
+import org.folio.search.service.consortium.TenantProvider;
+import org.folio.search.service.setter.SearchResponsePostProcessor;
+import org.folio.spring.FolioExecutionContext;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public final class ClassificationSearchResponsePostProcessor
+  implements SearchResponsePostProcessor<ClassificationResource> {
+
+  private static final String INSTANCE_TENANT_FIELD = "tenantId";
+  private static final String INSTANCE_CLASSIFICATION_IDS_FIELD = "classificationIds";
+  private static final String INSTANCE_TITLE_FIELD = "plain_title";
+  private static final String INSTANCE_CONTRIBUTORS_FIELD = "contributors";
+
+  private final SearchRepository searchRepository;
+  private final FolioExecutionContext context;
+  private final TenantProvider tenantProvider;
+
+  @Override
+  public Class<ClassificationResource> getGeneric() {
+    return ClassificationResource.class;
+  }
+
+  @Override
+  public void process(List<ClassificationResource> res) {
+    log.debug("process:: by [res: {}]", collectionToLogMsg(res, true));
+
+    if (res == null || res.isEmpty()) {
+      return;
+    }
+    var subResources = res.stream()
+      .flatMap(resource -> resource.instances().stream().map(subResource -> {
+        subResource.setResourceId(resource.id());
+        return subResource;
+      }))
+      .toList();
+
+    countAndSetInstanceProperties(subResources);
+  }
+
+  private void countAndSetInstanceProperties(List<InstanceSubResource> subResources) {
+    var classificationIds = subResources.stream()
+      .filter(subResource -> subResource.getCount() == 1)
+      .map(InstanceSubResource::getResourceId)
+      .distinct()
+      .toList();
+    var queries = buildQuery(classificationIds);
+
+    var resourceRequest = SimpleResourceRequest.of(ResourceType.INSTANCE,
+      tenantProvider.getTenant(context.getTenantId()));
+    var searchHits = searchRepository.search(resourceRequest, queries).getHits().getHits();
+
+    for (var searchHit : searchHits) {
+      var source = searchHit.getSourceAsMap();
+      var tenantId = MapUtils.getString(source, INSTANCE_TENANT_FIELD);
+      var classificationIdsFromSource = (List<String>) MapUtils.getObject(source, INSTANCE_CLASSIFICATION_IDS_FIELD);
+      var instanceTitle = MapUtils.getString(source, INSTANCE_TITLE_FIELD);
+      var instanceContributors = ((List<Map<String, String>>)  MapUtils.getObject(source, INSTANCE_CONTRIBUTORS_FIELD))
+        .stream()
+        .map(contributor -> contributor.get("name"))
+        .toList();
+      for (var subResource : subResources) {
+        if (subResource.getCount() == 1
+          && classificationIdsFromSource.contains(subResource.getResourceId())
+          && subResource.getTenantId().equals(tenantId)) {
+          subResource.setInstanceTitle(instanceTitle);
+          subResource.setInstanceContributors(instanceContributors);
+        }
+      }
+    }
+  }
+
+  private SearchSourceBuilder buildQuery(List<String> classificationIds) {
+    var queryBuilder = termsQuery(INSTANCE_CLASSIFICATION_IDS_FIELD, classificationIds.toArray(String[]::new));
+
+    return new SearchSourceBuilder()
+      .query(queryBuilder)
+//      .size(classificationIds.size())
+      .fetchSource(new String[]{INSTANCE_TENANT_FIELD, INSTANCE_CLASSIFICATION_IDS_FIELD, INSTANCE_TITLE_FIELD,
+        INSTANCE_CONTRIBUTORS_FIELD}, null)
+      .trackTotalHits(true);
+  }
+}

--- a/src/main/java/org/folio/search/service/setter/instance/ClassificationIdsProcessor.java
+++ b/src/main/java/org/folio/search/service/setter/instance/ClassificationIdsProcessor.java
@@ -1,0 +1,36 @@
+package org.folio.search.service.setter.instance;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.folio.search.utils.CollectionUtils.toStreamSafe;
+import static org.folio.search.utils.SearchUtils.prepareForExpectedFormat;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.folio.search.domain.dto.Classification;
+import org.folio.search.domain.dto.Instance;
+import org.folio.search.service.setter.FieldProcessor;
+import org.folio.search.utils.ShaUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClassificationIdsProcessor implements FieldProcessor<Instance, Set<String>> {
+
+  @Override
+  public Set<String> getFieldValue(Instance instance) {
+    return toStreamSafe(instance.getClassifications())
+      .map(this::getClassificationId)
+      .filter(Objects::nonNull)
+      .collect(Collectors.toSet());
+  }
+
+  private String getClassificationId(Classification classification) {
+    var classificationNumber = prepareForExpectedFormat(classification.getClassificationNumber(), 50);
+    if (isBlank(classificationNumber)) {
+      return null;
+    }
+
+    return ShaUtils.sha(classificationNumber, Objects.toString(classification.getClassificationTypeId(), EMPTY));
+  }
+}

--- a/src/main/resources/model/instance.json
+++ b/src/main/resources/model/instance.json
@@ -718,6 +718,11 @@
       "index": "keyword_icu",
       "processor": "classificationNumberProcessor",
       "searchTermProcessor": "classificationNumberSearchTermProcessor"
+    },
+    "classificationIds": {
+      "type": "search",
+      "index": "keyword_lowercase",
+      "processor": "classificationIdsProcessor"
     }
   },
   "indexMappings": { }

--- a/src/main/resources/model/instance_classification.json
+++ b/src/main/resources/model/instance_classification.json
@@ -3,6 +3,9 @@
   "eventBodyJavaClass": "org.folio.search.model.index.ClassificationResource",
   "parent": "instance",
   "fields": {
+    "id": {
+      "index": "keyword"
+    },
     "number": {
       "index": "keyword_icu",
       "showInResponse": [ "browse" ]

--- a/src/main/resources/swagger.api/schemas/response/classificationNumberBrowseItem.yaml
+++ b/src/main/resources/swagger.api/schemas/response/classificationNumberBrowseItem.yaml
@@ -10,6 +10,16 @@ properties:
   isAnchor:
     type: boolean
     description: Marks if current value is anchor or not
+  instanceTitle:
+    type: string
+    description: Instance title
+  instanceContributors:
+    type: array
+    description: List of contributor names.
+    minItems: 0
+    items:
+      description: Contributor name
+      type: string
   totalRecords:
     type: integer
     description: Amount of records for the classification number value

--- a/src/test/java/org/folio/api/browse/BrowseClassificationConsortiumIT.java
+++ b/src/test/java/org/folio/api/browse/BrowseClassificationConsortiumIT.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
 import org.folio.search.domain.dto.BrowseOptionType;
 import org.folio.search.domain.dto.Classification;
 import org.folio.search.domain.dto.ClassificationNumberBrowseResult;
+import org.folio.search.domain.dto.Contributor;
 import org.folio.search.domain.dto.Facet;
 import org.folio.search.domain.dto.FacetResult;
 import org.folio.search.domain.dto.Instance;
@@ -173,9 +174,10 @@ class BrowseClassificationConsortiumIT extends BaseConsortiumIntegrationTest {
   private static Instance instance(List<Object> data) {
     @SuppressWarnings("unchecked")
     var pairs = (List<Pair<String, String>>) data.get(1);
-    return new Instance()
+    var title = (String) data.get(0);
+    var instance = new Instance()
       .id(randomId())
-      .title((String) data.get(0))
+      .title(title)
       .classifications(pairs.stream()
         .map(pair -> new Classification()
           .classificationNumber(String.valueOf(pair.getFirst()))
@@ -184,6 +186,12 @@ class BrowseClassificationConsortiumIT extends BaseConsortiumIntegrationTest {
       .staffSuppress(false)
       .discoverySuppress(false)
       .holdings(emptyList());
+
+    if ("instance #10".equals(title)) {
+      instance.setContributors(List.of(new Contributor().name("Contributor #1"), new Contributor().name("Contributor #2")));
+    }
+
+    return instance;
   }
 
   private static List<List<Object>> classificationBrowseInstanceData() {


### PR DESCRIPTION
### Purpose
Implement POC for adding instance title and contributors to browse classification response

### Approach
Option 3 from []()
- Add classificationIds to instance index
- Add id to source of classification index
- Implement classification browse response post processor
- Update classification browse service

### Related Issues
[MSEARCH-1009](https://folio-org.atlassian.net/browse/MSEARCH-1009)

### Screenshots (if applicable)
Central tenant browse result:
![image](https://github.com/user-attachments/assets/b40a936a-e5c5-40ef-a243-42be34a1ac13)
Member tenant browse result:
![image](https://github.com/user-attachments/assets/f53cd071-9b2b-4678-b3a3-5813f1009968)

