### PR TITLE
fix(sub-resource-indexing) Fix item handling in a background job

### DIFF
--- a/src/main/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesService.java
+++ b/src/main/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesService.java
@@ -195,7 +195,7 @@ public class ScheduledInstanceSubResourcesService {
             .collect(Collectors.groupingBy(ResourceEvent::getTenant,
               Collectors.mapping(ResourceEvent::getId, Collectors.toList())))
             .forEach((groupTenant, ids) ->
-              repository.deleteEntitiesForTenant(ids, groupTenant)
+              repository.deleteEntitiesForTenant(ids, groupTenant, true)
             );
         } else {
           // Instances use regular deletion

--- a/src/test/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesServiceTest.java
+++ b/src/test/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesServiceTest.java
@@ -87,8 +87,10 @@ class ScheduledInstanceSubResourcesServiceTest {
 
     // Assert
     verify(instanceRepository).fetchByTimestamp(tenantId, timestamp);
+    verify(itemRepository).fetchByTimestamp(tenantId, timestamp);
     verify(subjectRepository).fetchByTimestamp(tenantId, timestamp, 3);
     verify(resourceService).indexResources(anyList());
+    verify(itemRepository).deleteEntitiesForTenant(List.of("4"), tenantId, true);
     verify(subResourcesLockRepository).unlockSubResource(eq(ReindexEntityType.SUBJECT), any(), eq(tenantId));
   }
 
@@ -174,6 +176,7 @@ class ScheduledInstanceSubResourcesServiceTest {
     when(instanceRepository.fetchByTimestamp(tenantId, timestamp))
       .thenReturn(new SubResourceResult(List.of(Map.of("id", "2", "tenantId", tenantId)), null));
     when(itemRepository.fetchByTimestamp(tenantId, timestamp))
-      .thenReturn(new SubResourceResult(List.of(Map.of("id", "3", "tenantId", tenantId)), null));
+      .thenReturn(new SubResourceResult(List.of(Map.of("id", "3", "tenantId", tenantId),
+        Map.of("id", "4", "tenantId", tenantId, "isDeleted", true)), null));
   }
 }

--- a/src/test/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesServiceTest.java
+++ b/src/test/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesServiceTest.java
@@ -89,6 +89,7 @@ class ScheduledInstanceSubResourcesServiceTest {
     verify(instanceRepository).fetchByTimestamp(tenantId, timestamp);
     verify(itemRepository).fetchByTimestamp(tenantId, timestamp);
     verify(subjectRepository).fetchByTimestamp(tenantId, timestamp, 3);
+    verify(instanceChildrenResourceService, times(3)).persistChildren(anyString(), any(), anyList());
     verify(resourceService).indexResources(anyList());
     verify(itemRepository).deleteEntitiesForTenant(List.of("4"), tenantId, true);
     verify(subResourcesLockRepository).unlockSubResource(eq(ReindexEntityType.SUBJECT), any(), eq(tenantId));


### PR DESCRIPTION
### Purpose
Fix item handling in a background job
Fixes change ownership flow

### Approach
Make hard-delete of items in a background job
Process delete events first, then - create/update events so in case there're 2 events for the same item (delete+create) then data doesn't get deleted after creation. This is the case with update ownership flow where item is deleted from one tenant and created in other tenant while all other properties remain the same 

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-1085](https://folio-org.atlassian.net/browse/MSEARCH-1085)
