### PR TITLE
fix(deps): update httpclient5 and httpcore5 versions to 5.6/5.4 to support OpenSearch 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
     <folio-isbn-utils.version>1.9.0-SNAPSHOT</folio-isbn-utils.version>
     <folio-cql2pgjson.version>35.4.2</folio-cql2pgjson.version>
     <opensearch.version>3.5.0</opensearch.version>
+    <!-- opensearch-rest-client:3.5.0 removed manual gzip decompression relying on httpclient5 5.6's
+         automatic async decompression. Spring Boot 4.x manages older versions, so we pin to 5.6/5.4. -->
+    <httpclient5.version>5.6</httpclient5.version>
+    <httpcore5.version>5.4</httpcore5.version>
     <mapstruct.version>1.6.3</mapstruct.version>
     <apache-commons-io.version>2.21.0</apache-commons-io.version>
     <apache-commons-collections.version>4.5.0</apache-commons-collections.version>

--- a/src/test/java/org/folio/search/configuration/OpensearchCompressionIT.java
+++ b/src/test/java/org/folio/search/configuration/OpensearchCompressionIT.java
@@ -1,0 +1,49 @@
+package org.folio.search.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.support.TestConstants.TENANT_ID;
+import static org.opensearch.client.RequestOptions.DEFAULT;
+import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
+import static org.opensearch.search.builder.SearchSourceBuilder.searchSource;
+
+import java.io.IOException;
+import org.folio.spring.testing.type.IntegrationTest;
+import org.folio.support.base.BaseIntegrationTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opensearch.action.search.SearchRequest;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Verifies that OpenSearch responses are correctly parsed when gzip compression is enabled.
+ *
+ * <p>opensearch-rest-client 3.x removed the manual {@code GzipDecompressingEntity} wrapping from
+ * {@code RestClient.convertResponse()}, relying on httpclient5 5.6's automatic async gzip
+ * decompression. Without httpclient5 5.6 on the classpath, compressed responses are returned as
+ * raw bytes and JSON parsing fails.
+ */
+@IntegrationTest
+@TestPropertySource(properties = "spring.opensearch.compression-enabled=true")
+class OpensearchCompressionIT extends BaseIntegrationTest {
+
+  @BeforeAll
+  static void prepare() {
+    enableTenant(TENANT_ID);
+  }
+
+  @AfterAll
+  static void cleanUp() {
+    removeTenant();
+  }
+
+  @Test
+  void shouldParseSearchResponseWhenCompressionEnabled() throws IOException {
+    var request = new SearchRequest()
+      .source(searchSource().query(matchAllQuery()).trackTotalHits(true));
+
+    var response = elasticClient.search(request, DEFAULT);
+
+    assertThat(response.getHits().getTotalHits()).isNotNull();
+  }
+}


### PR DESCRIPTION
### Purpose
update httpclient5 and httpcore5 versions to 5.6/5.4 to support OpenSearch 3.5.0

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MSEARCH-1104
