### PR TITLE
fix(reindex): Analyze merge entity tables before upload

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,7 +76,7 @@
   * Add support for exact match on isbn, honor '*' in IsbnSearchTermProcessor ([MSEARCH-1011](https://folio-org.atlassian.net/browse/MSEARCH-1011))
   * Update instance_call_number tenantId on Instance becoming shared ([MSEARCH-1168](https://folio-org.atlassian.net/browse/MSEARCH-1168))
   * Fix deadlocks for sub-resources on reindex ([MSEARCH-1196](https://folio-org.atlassian.net/browse/MSEARCH-1196))
-  * Manually analyze instance/holding/item tables before upload phase of reindexing ([MSEARCH-1178](https://folio-org.atlassian.net/browse/MSEARCH-1178))
+  * Manually analyze instance/holding/item tables before upload phase of reindexing ([MSEARCH-1197](https://folio-org.atlassian.net/browse/MSEARCH-1197))
 
 ### Tech Dept
 * Migrate to Opensearch 3.0.0 ([MSEARCH-1033](https://folio-org.atlassian.net/browse/MSEARCH-1033))

--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,7 @@
   * Add support for exact match on isbn, honor '*' in IsbnSearchTermProcessor ([MSEARCH-1011](https://folio-org.atlassian.net/browse/MSEARCH-1011))
   * Update instance_call_number tenantId on Instance becoming shared ([MSEARCH-1168](https://folio-org.atlassian.net/browse/MSEARCH-1168))
   * Fix deadlocks for sub-resources on reindex ([MSEARCH-1178](https://folio-org.atlassian.net/browse/MSEARCH-1178))
+  * Manually analyze instance/holding/item tables before upload phase of reindexing ([MSEARCH-1178](https://folio-org.atlassian.net/browse/MSEARCH-1178))
 
 ### Tech Dept
 * Migrate to Opensearch 3.0.0 ([MSEARCH-1033](https://folio-org.atlassian.net/browse/MSEARCH-1033))

--- a/NEWS.md
+++ b/NEWS.md
@@ -75,7 +75,7 @@
   * Ignore shadow locations and location units while indexing domain events ([MSEARCH-1154](https://folio-org.atlassian.net/browse/MSEARCH-1154))
   * Add support for exact match on isbn, honor '*' in IsbnSearchTermProcessor ([MSEARCH-1011](https://folio-org.atlassian.net/browse/MSEARCH-1011))
   * Update instance_call_number tenantId on Instance becoming shared ([MSEARCH-1168](https://folio-org.atlassian.net/browse/MSEARCH-1168))
-  * Fix deadlocks for sub-resources on reindex ([MSEARCH-1178](https://folio-org.atlassian.net/browse/MSEARCH-1178))
+  * Fix deadlocks for sub-resources on reindex ([MSEARCH-1196](https://folio-org.atlassian.net/browse/MSEARCH-1196))
   * Manually analyze instance/holding/item tables before upload phase of reindexing ([MSEARCH-1178](https://folio-org.atlassian.net/browse/MSEARCH-1178))
 
 ### Tech Dept

--- a/src/main/java/org/folio/search/service/reindex/ReindexMergeRangeIndexService.java
+++ b/src/main/java/org/folio/search/service/reindex/ReindexMergeRangeIndexService.java
@@ -57,6 +57,12 @@ public class ReindexMergeRangeIndexService {
     repositories.values().iterator().next().truncateMergeRanges();
   }
 
+  public void analyzeEntityTables() {
+    log.info("analyzeEntityTables:: analyzing merge entity tables to update statistics");
+    repositories.values().forEach(MergeRangeRepository::analyzeEntityTable);
+    log.info("analyzeEntityTables:: analyzed merge entity tables");
+  }
+
   public List<MergeRangeEntity> createMergeRanges(String tenantId) {
     List<MergeRangeEntity> mergeRangeEntities = new ArrayList<>();
     var rangeSize = reindexConfig.getMergeRangeSize();

--- a/src/main/java/org/folio/search/service/reindex/ReindexService.java
+++ b/src/main/java/org/folio/search/service/reindex/ReindexService.java
@@ -157,13 +157,7 @@ public class ReindexService {
     log.info("submitUploadReindex:: for [tenantId: {}, entities: {}]", tenantId, entityTypes);
 
     validateUploadReindex(tenantId, entityTypes);
-
-    for (var reindexEntityType : entityTypes) {
-      statusService.recreateUploadStatusRecord(reindexEntityType);
-      if (recreateIndex) {
-        reindexCommonService.recreateIndex(reindexEntityType, tenantId, indexSettings);
-      }
-    }
+    prepareForUploadReindex(tenantId, entityTypes, recreateIndex, indexSettings);
 
     var futures = new ArrayList<>();
     for (var entityType : entityTypes) {
@@ -181,6 +175,18 @@ public class ReindexService {
 
     log.info("submitUploadReindex:: submitted [tenantId: {}]", tenantId);
     return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+  }
+
+  private void prepareForUploadReindex(String tenantId, List<ReindexEntityType> entityTypes, boolean recreateIndex,
+                                       IndexSettings indexSettings) {
+    for (var reindexEntityType : entityTypes) {
+      statusService.recreateUploadStatusRecord(reindexEntityType);
+      if (recreateIndex) {
+        reindexCommonService.recreateIndex(reindexEntityType, tenantId, indexSettings);
+      }
+    }
+
+    mergeRangeService.analyzeEntityTables();
   }
 
   private void recreateIndices(String tenantId, List<ReindexEntityType> entityTypes, IndexSettings indexSettings) {

--- a/src/main/java/org/folio/search/service/reindex/jdbc/MergeRangeRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/MergeRangeRepository.java
@@ -36,6 +36,9 @@ public abstract class MergeRangeRepository extends ReindexJdbcRepository {
   private static final String SOFT_DELETE_SQL_FOR_TENANT = """
     UPDATE %s SET is_deleted = true, last_updated_date = CURRENT_TIMESTAMP WHERE id = ANY (?) AND tenant_id = ?;
     """;
+
+  private static final String ANALYZE_SQL = "ANALYZE %s;";
+
   private static final String INSERT_MERGE_RANGE_SQL = """
       INSERT INTO %s (id, entity_type, tenant_id, lower, upper, created_at, finished_at)
       VALUES (?, ?, ?, ?, ?, ?, ?);
@@ -86,6 +89,13 @@ public abstract class MergeRangeRepository extends ReindexJdbcRepository {
 
   public void truncateMergeRanges() {
     JdbcUtils.truncateTable(MERGE_RANGE_TABLE, jdbcTemplate, context);
+  }
+
+  @SuppressWarnings("java:S2077")
+  public void analyzeEntityTable() {
+    var fullTableName = getFullTableName(context, entityTable());
+    var sql = ANALYZE_SQL.formatted(fullTableName);
+    jdbcTemplate.execute(sql);
   }
 
   @Override

--- a/src/test/java/org/folio/search/service/reindex/ReindexMergeRangeIndexServiceTest.java
+++ b/src/test/java/org/folio/search/service/reindex/ReindexMergeRangeIndexServiceTest.java
@@ -140,5 +140,16 @@ class ReindexMergeRangeIndexServiceTest {
     // assert
     verify(repositoryMap.values().iterator().next()).getFailedMergeRanges();
   }
+
+  @Test
+  void analyzeEntityTables_positive() {
+    // act
+    service.analyzeEntityTables();
+
+    // assert
+    verify(instanceRepository).analyzeEntityTable();
+    verify(itemRepository).analyzeEntityTable();
+    verify(holdingRepository).analyzeEntityTable();
+  }
 }
 

--- a/src/test/java/org/folio/search/service/reindex/ReindexServiceTest.java
+++ b/src/test/java/org/folio/search/service/reindex/ReindexServiceTest.java
@@ -193,6 +193,7 @@ class ReindexServiceTest {
     reindexService.submitUploadReindex(TENANT_ID, List.of(ReindexEntityType.INSTANCE));
 
     verify(statusService).recreateUploadStatusRecord(INSTANCE);
+    verify(mergeRangeService).analyzeEntityTables();
     verify(uploadRangeService).prepareAndSendIndexRanges(INSTANCE);
   }
 
@@ -206,6 +207,7 @@ class ReindexServiceTest {
     reindexService.submitUploadReindex(TENANT_ID, uploadDto);
 
     verify(statusService).recreateUploadStatusRecord(INSTANCE);
+    verify(mergeRangeService).analyzeEntityTables();
     verify(uploadRangeService).prepareAndSendIndexRanges(INSTANCE);
   }
 


### PR DESCRIPTION
### Purpose
It was observed that upload phase of full reindex has different duration on the same dataset from time to time.
When the duration is longer - CPU load on database is higher during the whole upload phase. With main loading query being fetching instances aggregated with holdings/items.
This suggests that query planner uses inefficient query plan during whole upload phase from time to time.
To solve this - we need to analyze tables manually before the upload phase starts.

### Approach
Analyze merge entity tables before upload

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-1197](https://folio-org.atlassian.net/browse/MSEARCH-1197)