### PR TITLE
fix(reindex): Don't recreate reindex status on upload phase start

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@
   * Remove excessive escaping of backslash character in sub-resources ([MSEARCH-1094](https://folio-org.atlassian.net/browse/MSEARCH-1094))
   * Implement two-stage Kafka processing with event aggregation for instance indexing ([MSEARCH-1157](https://folio-org.atlassian.net/browse/MSEARCH-1157))
   * Implement member tenant reindex ([MSEARCH-1100](https://folio-org.atlassian.net/browse/MSEARCH-1100))
+  * Don't recreate reindex status on upload phase start ([MSEARCH-1198](https://folio-org.atlassian.net/browse/MSEARCH-1198))
 * **Instance Search**
   * Add support for searching by instance/holdings/item electronic access relationship ID ([MSEARCH-816](https://folio-org.atlassian.net/browse/MSEARCH-816))
   * Normalize ISSN search ([MSEARCH-658](https://folio-org.atlassian.net/browse/MSEARCH-658))

--- a/src/main/java/org/folio/search/service/reindex/ReindexService.java
+++ b/src/main/java/org/folio/search/service/reindex/ReindexService.java
@@ -172,7 +172,7 @@ public class ReindexService {
                                       boolean recreateIndex, IndexSettings indexSettings) {
     var targetTenantId = statusService.getTargetTenantId();
     for (var reindexEntityType : entityTypes) {
-      statusService.recreateUploadStatusRecord(reindexEntityType, targetTenantId);
+      statusService.upsertUploadStatusRecord(reindexEntityType, targetTenantId);
       if (recreateIndex) {
         reindexCommonService.recreateIndex(reindexEntityType, tenantId, indexSettings);
       }

--- a/src/main/java/org/folio/search/service/reindex/ReindexStatusService.java
+++ b/src/main/java/org/folio/search/service/reindex/ReindexStatusService.java
@@ -60,13 +60,10 @@ public class ReindexStatusService {
   }
 
   @Transactional
-  public void recreateUploadStatusRecord(ReindexEntityType entityType, String targetTenantId) {
-    var uploadStatusEntity = new ReindexStatusEntity(entityType, ReindexStatus.UPLOAD_IN_PROGRESS);
-    uploadStatusEntity.setTargetTenantId(targetTenantId);
-    statusRepository.delete(entityType);
-    statusRepository.saveReindexStatusRecords(List.of(uploadStatusEntity));
+  public void upsertUploadStatusRecord(ReindexEntityType entityType, String targetTenantId) {
+    statusRepository.upsertUploadStatusRecord(entityType, targetTenantId);
 
-    log.debug("recreateUploadStatusRecord:: created upload record [entityType: {}, targetTenant: {}]",
+    log.debug("recreateUploadStatusRecord:: upserted upload record [entityType: {}, targetTenant: {}]",
       entityType, targetTenantId);
   }
 

--- a/src/main/java/org/folio/search/service/reindex/jdbc/ReindexStatusRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/ReindexStatusRepository.java
@@ -41,6 +41,20 @@ public class ReindexStatusRepository {
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
     """;
 
+  private static final String UPSERT_UPLOAD_STATUS_SQL = """
+      INSERT INTO %s (entity_type, status, total_merge_ranges, processed_merge_ranges, total_upload_ranges,
+      processed_upload_ranges, start_time_merge, end_time_merge, start_time_upload, end_time_upload,
+      start_time_staging, end_time_staging, target_tenant_id)
+      VALUES (?, ?, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, ?)
+      ON CONFLICT (entity_type) DO UPDATE SET
+        status = EXCLUDED.status,
+        total_upload_ranges = EXCLUDED.total_upload_ranges,
+        processed_upload_ranges = EXCLUDED.processed_upload_ranges,
+        start_time_upload = EXCLUDED.start_time_upload,
+        end_time_upload = EXCLUDED.end_time_upload,
+        target_tenant_id = EXCLUDED.target_tenant_id;
+    """;
+
   private static final String UPDATE_SQL = """
     UPDATE %s
     SET %s
@@ -116,6 +130,22 @@ public class ReindexStatusRepository {
     var fullTableName = getFullTableName(context, REINDEX_STATUS_TABLE);
     String sql = "DELETE FROM %s WHERE entity_type = ?;".formatted(fullTableName);
     jdbcTemplate.update(sql, entityType.name());
+  }
+
+  /**
+   * Upserts the upload status for the given entity type.
+   * If a record already exists, only upload-related columns are reset
+   * (status, upload counters and timestamps), preserving merge and staging metrics.
+   * If no record exists, a fresh row is inserted.
+   *
+   * @param entityType     the entity type whose upload status to reset
+   * @param targetTenantId the target tenant ID for this reindex operation
+   */
+  @SuppressWarnings("java:S2077")
+  public void upsertUploadStatusRecord(ReindexEntityType entityType, String targetTenantId) {
+    var fullTableName = getFullTableName(context, REINDEX_STATUS_TABLE);
+    var sql = UPSERT_UPLOAD_STATUS_SQL.formatted(fullTableName);
+    jdbcTemplate.update(sql, entityType.name(), ReindexStatus.UPLOAD_IN_PROGRESS.name(), targetTenantId);
   }
 
   public void setMergeReindexStarted(ReindexEntityType entityType, int totalMergeRanges) {

--- a/src/test/java/org/folio/search/service/reindex/ReindexServiceTest.java
+++ b/src/test/java/org/folio/search/service/reindex/ReindexServiceTest.java
@@ -196,7 +196,7 @@ class ReindexServiceTest {
     reindexService.submitUploadReindex(TENANT_ID, List.of(ReindexEntityType.INSTANCE));
 
     verify(statusService).getTargetTenantId();
-    verify(statusService).recreateUploadStatusRecord(eq(INSTANCE), any());
+    verify(statusService).upsertUploadStatusRecord(eq(INSTANCE), any());
     verify(mergeRangeService).analyzeEntityTables();
     verify(uploadRangeService).prepareAndSendIndexRanges(INSTANCE);
     verify(reindexCommonService, never()).recreateIndex(any(), any(), any());
@@ -212,7 +212,7 @@ class ReindexServiceTest {
     reindexService.submitUploadReindex(TENANT_ID, uploadDto);
 
     verify(statusService).getTargetTenantId();
-    verify(statusService).recreateUploadStatusRecord(eq(INSTANCE), any());
+    verify(statusService).upsertUploadStatusRecord(eq(INSTANCE), any());
     verify(reindexCommonService).recreateIndex(eq(INSTANCE), eq(TENANT_ID), any());
     verify(mergeRangeService).analyzeEntityTables();
     verify(uploadRangeService).prepareAndSendIndexRanges(INSTANCE);
@@ -395,7 +395,7 @@ class ReindexServiceTest {
     reindexService.submitUploadReindexWithTenantCleanup(TENANT_ID, List.of(INSTANCE), "member");
 
     verify(reindexCommonService).deleteInstanceDocumentsByTenantId("member");
-    verify(statusService).recreateUploadStatusRecord(eq(INSTANCE), any());
+    verify(statusService).upsertUploadStatusRecord(eq(INSTANCE), any());
     verify(uploadRangeService).prepareAndSendIndexRanges(INSTANCE);
     verifyNoInteractions(mergeRangeService);
   }
@@ -408,7 +408,7 @@ class ReindexServiceTest {
     reindexService.submitUploadReindexWithTenantCleanup(TENANT_ID, List.of(INSTANCE), null);
 
     verify(reindexCommonService, never()).deleteInstanceDocumentsByTenantId(any());
-    verify(statusService).recreateUploadStatusRecord(eq(INSTANCE), any());
+    verify(statusService).upsertUploadStatusRecord(eq(INSTANCE), any());
     verify(uploadRangeService).prepareAndSendIndexRanges(INSTANCE);
     verify(mergeRangeService).analyzeEntityTables();
   }

--- a/src/test/java/org/folio/search/service/reindex/ReindexStatusServiceTest.java
+++ b/src/test/java/org/folio/search/service/reindex/ReindexStatusServiceTest.java
@@ -206,40 +206,24 @@ class ReindexStatusServiceTest {
   }
 
   @Test
-  void recreateUploadStatusRecord_shouldPreserveTargetTenantId() {
+  void upsertUploadStatusRecord_shouldPreserveTargetTenantId() {
     // given
     var targetTenantId = MEMBER_TENANT_ID;
 
     // act
-    service.recreateUploadStatusRecord(INSTANCE, targetTenantId);
+    service.upsertUploadStatusRecord(INSTANCE, targetTenantId);
 
     // assert
-    verify(statusRepository).delete(INSTANCE);
-    verify(statusRepository).saveReindexStatusRecords(reindexStatusEntitiesCaptor.capture());
-
-    var savedEntities = reindexStatusEntitiesCaptor.getValue();
-    assertThat(savedEntities)
-      .hasSize(1)
-      .first()
-      .satisfies(entity -> assertThat(entity.getEntityType()).isEqualTo(INSTANCE))
-      .satisfies(entity -> assertThat(entity.getStatus()).isEqualTo(ReindexStatus.UPLOAD_IN_PROGRESS))
-      .satisfies(entity -> assertThat(entity.getTargetTenantId()).isEqualTo(targetTenantId));
+    verify(statusRepository).upsertUploadStatusRecord(INSTANCE, targetTenantId);
   }
 
   @Test
-  void recreateUploadStatusRecord_whenNoExistingTargetTenantId_shouldSetNull() {
+  void upsertUploadStatusRecord_whenNoExistingTargetTenantId_shouldSetNull() {
     // act
-    service.recreateUploadStatusRecord(INSTANCE, null);
+    service.upsertUploadStatusRecord(INSTANCE, null);
 
     // assert
-    verify(statusRepository).delete(INSTANCE);
-    verify(statusRepository).saveReindexStatusRecords(reindexStatusEntitiesCaptor.capture());
-
-    var savedEntities = reindexStatusEntitiesCaptor.getValue();
-    assertThat(savedEntities)
-      .hasSize(1)
-      .first()
-      .satisfies(entity -> assertThat(entity.getTargetTenantId()).isNull());
+    verify(statusRepository).upsertUploadStatusRecord(INSTANCE, null);
   }
 
   @Test

--- a/src/test/java/org/folio/search/service/reindex/jdbc/ReindexStatusRepositoryIT.java
+++ b/src/test/java/org/folio/search/service/reindex/jdbc/ReindexStatusRepositoryIT.java
@@ -13,6 +13,7 @@ import static org.folio.search.model.types.ReindexStatus.MERGE_IN_PROGRESS;
 import static org.folio.search.model.types.ReindexStatus.UPLOAD_COMPLETED;
 import static org.folio.search.model.types.ReindexStatus.UPLOAD_FAILED;
 import static org.folio.search.model.types.ReindexStatus.UPLOAD_IN_PROGRESS;
+import static org.folio.support.TestConstants.MEMBER2_TENANT_ID;
 import static org.folio.support.TestConstants.MEMBER_TENANT_ID;
 import static org.folio.support.TestConstants.TENANT_ID;
 import static org.mockito.Mockito.when;
@@ -398,5 +399,64 @@ class ReindexStatusRepositoryIT {
     entity.setTargetTenantId("consortium_member");
     repository.saveReindexStatusRecords(java.util.List.of(entity));
     assertThat(repository.getReindexStatuses()).hasSize(1);
+  }
+
+  @Test
+  @Sql("/sql/populate-reindex-status.sql")
+  void upsertUploadStatusRecord_shouldPreserveMergeMetricsWhenRecordExists() {
+    // act - upsert upload status for INSTANCE which already has merge metrics and target_tenant_id=MEMBER_TENANT_ID
+    repository.upsertUploadStatusRecord(INSTANCE, MEMBER2_TENANT_ID);
+
+    // assert - merge and staging metrics preserved; upload columns and target_tenant_id overwritten
+    var statuses = repository.getReindexStatuses();
+    assertThat(statuses)
+      .filteredOn(s -> s.getEntityType() == INSTANCE)
+      .hasSize(1)
+      .first()
+      .satisfies(s -> {
+        assertThat(s.getStatus()).isEqualTo(UPLOAD_IN_PROGRESS);
+        // merge metrics preserved
+        assertThat(s.getTotalMergeRanges()).isEqualTo(3);
+        assertThat(s.getProcessedMergeRanges()).isEqualTo(3);
+        assertThat(s.getStartTimeMerge()).isNotNull();
+        assertThat(s.getEndTimeMerge()).isNotNull();
+        // staging metrics preserved
+        assertThat(s.getStartTimeStaging()).isNotNull();
+        assertThat(s.getEndTimeStaging()).isNotNull();
+        // target_tenant_id overwritten by the value passed to upsert
+        assertThat(s.getTargetTenantId()).isEqualTo(MEMBER2_TENANT_ID);
+        // upload columns reset
+        assertThat(s.getTotalUploadRanges()).isZero();
+        assertThat(s.getProcessedUploadRanges()).isZero();
+        assertThat(s.getStartTimeUpload()).isNull();
+        assertThat(s.getEndTimeUpload()).isNull();
+      });
+  }
+
+  @Test
+  void upsertUploadStatusRecord_shouldInsertNewRecordWhenNoneExists() {
+    // act - no pre-existing record for CONTRIBUTOR
+    repository.upsertUploadStatusRecord(CONTRIBUTOR, MEMBER_TENANT_ID);
+
+    // assert - fresh row inserted with UPLOAD_IN_PROGRESS, zeroed metrics and target_tenant_id set
+    var statuses = repository.getReindexStatuses();
+    assertThat(statuses)
+      .hasSize(1)
+      .first()
+      .satisfies(s -> {
+        assertThat(s.getEntityType()).isEqualTo(CONTRIBUTOR);
+        assertThat(s.getStatus()).isEqualTo(UPLOAD_IN_PROGRESS);
+        assertThat(s.getTotalMergeRanges()).isZero();
+        assertThat(s.getProcessedMergeRanges()).isZero();
+        assertThat(s.getTotalUploadRanges()).isZero();
+        assertThat(s.getProcessedUploadRanges()).isZero();
+        assertThat(s.getStartTimeMerge()).isNull();
+        assertThat(s.getEndTimeMerge()).isNull();
+        assertThat(s.getStartTimeStaging()).isNull();
+        assertThat(s.getEndTimeStaging()).isNull();
+        assertThat(s.getStartTimeUpload()).isNull();
+        assertThat(s.getEndTimeUpload()).isNull();
+        assertThat(s.getTargetTenantId()).isEqualTo(MEMBER_TENANT_ID);
+      });
   }
 }

--- a/src/test/resources/sql/populate-reindex-status.sql
+++ b/src/test/resources/sql/populate-reindex-status.sql
@@ -1,6 +1,6 @@
-INSERT INTO reindex_status (entity_type, status, total_merge_ranges, processed_merge_ranges, total_upload_ranges, processed_upload_ranges, start_time_merge, end_time_merge, start_time_upload, end_time_upload)
+INSERT INTO reindex_status (entity_type, status, total_merge_ranges, processed_merge_ranges, total_upload_ranges, processed_upload_ranges, start_time_merge, end_time_merge, start_time_upload, end_time_upload, start_time_staging, end_time_staging, target_tenant_id)
 VALUES
-    ('CONTRIBUTOR', 'MERGE_COMPLETED', '3', '3', '0', '0', '2024-04-01T01:37:34.15755006Z', '2024-04-01T01:37:35.15755006Z', null, null),
-    ('SUBJECT', 'UPLOAD_IN_PROGRESS', '3', '2', '2', '1', '2024-04-01T01:37:34.15755006Z', '2024-04-01T01:37:35.15755006Z', '2024-04-01T01:37:36.15755006Z', null),
-    ('INSTANCE', 'UPLOAD_COMPLETED', '3', '3', '2', '2', '2024-04-01T01:37:34.15755006Z', '2024-04-01T01:37:35.15755006Z', '2024-04-01T01:37:36.15755006Z', '2024-04-01T01:37:37.15755006Z'),
-    ('CLASSIFICATION', 'UPLOAD_FAILED', '3', '3', '2', '1', '2024-04-01T01:37:34.15755006Z', '2024-04-01T01:37:35.15755006Z', '2024-04-01T01:37:36.15755006Z', '2024-04-01T01:37:37.15755006Z');
+    ('CONTRIBUTOR',   'MERGE_COMPLETED',  '3', '3', '0', '0', '2024-04-01T01:37:34.15755006Z', '2024-04-01T01:37:35.15755006Z', null,                              null,                              null,                              null,                              null),
+    ('SUBJECT',       'UPLOAD_IN_PROGRESS','3', '2', '2', '1', '2024-04-01T01:37:34.15755006Z', '2024-04-01T01:37:35.15755006Z', '2024-04-01T01:37:36.15755006Z', null,                              null,                              null,                              null),
+    ('INSTANCE',      'UPLOAD_COMPLETED',  '3', '3', '2', '2', '2024-04-01T01:37:34.15755006Z', '2024-04-01T01:37:35.15755006Z', '2024-04-01T01:37:36.15755006Z', '2024-04-01T01:37:37.15755006Z', '2024-04-01T01:37:33.15755006Z', '2024-04-01T01:37:34.15755006Z', 'member_tenant'),
+    ('CLASSIFICATION','UPLOAD_FAILED',     '3', '3', '2', '1', '2024-04-01T01:37:34.15755006Z', '2024-04-01T01:37:35.15755006Z', '2024-04-01T01:37:36.15755006Z', '2024-04-01T01:37:37.15755006Z', null,                              null,                              null);


### PR DESCRIPTION
### Purpose
Don't recreate reindex status on upload phase start

### Approach
Insread of delete+create use upsert for upload statuses to create when absent and only update upload-related columns when exists

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-1198](https://folio-org.atlassian.net/browse/MSEARCH-1198)
