### PR TITLE
fix: add retry for search operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Bug fixes
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Add retry for search operations ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/search/configuration/OpensearchRestClientConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/OpensearchRestClientConfiguration.java
@@ -156,6 +156,7 @@ public class OpensearchRestClientConfiguration {
         .to(timeout -> builder.setConnectTimeout(Timeout.ofMilliseconds(timeout)));
       MAPPER.from(this.properties::getSocketTimeout).asInt(Duration::toMillis)
         .to(timeout -> builder.setSocketTimeout(Timeout.ofMilliseconds(timeout)));
+      builder.setValidateAfterInactivity(Timeout.ofSeconds(5));
       return builder.build();
     }
 

--- a/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
@@ -64,17 +64,6 @@ public class RetryTemplateConfiguration {
       .build());
   }
 
-  private static boolean isConnectionClosedException(Throwable throwable) {
-    var cause = throwable;
-    while (cause != null) {
-      if (cause instanceof ConnectionClosedException) {
-        return true;
-      }
-      cause = cause.getCause();
-    }
-    return false;
-  }
-
   @ConditionalOnBean(ReindexConfigurationProperties.class)
   @Bean(name = REINDEX_PUBLISH_RANGE_RETRY_TEMPLATE_NAME)
   public RetryTemplate reindexPublishRangeRetryTemplate(ReindexConfigurationProperties properties) {
@@ -93,5 +82,16 @@ public class RetryTemplateConfiguration {
       }
     });
     return retryTemplate;
+  }
+
+  private static boolean isConnectionClosedException(Throwable throwable) {
+    var cause = throwable;
+    while (cause != null) {
+      if (cause instanceof ConnectionClosedException) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    return false;
   }
 }

--- a/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
@@ -3,7 +3,9 @@ package org.folio.search.configuration;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.logging.log4j.message.FormattedMessage;
+import org.folio.search.configuration.properties.OpensearchProperties;
 import org.folio.search.configuration.properties.ReindexConfigurationProperties;
 import org.folio.search.configuration.properties.StreamIdsProperties;
 import org.folio.search.exception.FolioIntegrationException;
@@ -25,6 +27,7 @@ public class RetryTemplateConfiguration {
 
   public static final String KAFKA_RETRY_TEMPLATE_NAME = "kafkaMessageListenerRetryTemplate";
   public static final String STREAM_IDS_RETRY_TEMPLATE_NAME = "streamIdsRetryTemplate";
+  public static final String SEARCH_RETRY_TEMPLATE_NAME = "searchRetryTemplate";
   public static final String REINDEX_PUBLISH_RANGE_RETRY_TEMPLATE_NAME = "reindexPublishRangeRetryTemplate";
 
   /**
@@ -50,6 +53,26 @@ public class RetryTemplateConfiguration {
       .maxRetries(properties.getRetryAttempts())
       .delay(Duration.ofMillis(properties.getRetryIntervalMs()))
       .build());
+  }
+
+  @Bean(name = SEARCH_RETRY_TEMPLATE_NAME)
+  public RetryTemplate searchRetryTemplate(OpensearchProperties properties) {
+    return new RetryTemplate(RetryPolicy.builder()
+      .maxRetries(properties.getSearchRetryAttempts())
+      .delay(Duration.ofMillis(properties.getSearchRetryIntervalMs()))
+      .predicate(RetryTemplateConfiguration::isConnectionClosedException)
+      .build());
+  }
+
+  private static boolean isConnectionClosedException(Throwable throwable) {
+    var cause = throwable;
+    while (cause != null) {
+      if (cause instanceof ConnectionClosedException) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    return false;
   }
 
   @ConditionalOnBean(ReindexConfigurationProperties.class)

--- a/src/main/java/org/folio/search/configuration/properties/OpensearchProperties.java
+++ b/src/main/java/org/folio/search/configuration/properties/OpensearchProperties.java
@@ -42,4 +42,14 @@ public class OpensearchProperties {
   private String pathPrefix;
 
   private boolean compressionEnabled = true;
+
+  /**
+   * Specifies the number of retry attempts for search requests on transient connection errors.
+   */
+  private int searchRetryAttempts = 3;
+
+  /**
+   * Specifies time in milliseconds to wait before reattempting a failed search request.
+   */
+  private long searchRetryIntervalMs = 500;
 }

--- a/src/main/java/org/folio/search/repository/SearchRepository.java
+++ b/src/main/java/org/folio/search/repository/SearchRepository.java
@@ -2,6 +2,7 @@ package org.folio.search.repository;
 
 import static java.util.Arrays.stream;
 import static org.apache.commons.lang3.ArrayUtils.isNotEmpty;
+import static org.folio.search.configuration.RetryTemplateConfiguration.SEARCH_RETRY_TEMPLATE_NAME;
 import static org.folio.search.configuration.RetryTemplateConfiguration.STREAM_IDS_RETRY_TEMPLATE_NAME;
 import static org.folio.search.utils.CollectionUtils.anyMatch;
 import static org.folio.search.utils.CollectionUtils.getValuesByPath;
@@ -49,6 +50,8 @@ public class SearchRepository {
   private final RestHighLevelClient client;
   @Qualifier(value = STREAM_IDS_RETRY_TEMPLATE_NAME)
   private final RetryTemplate retryTemplate;
+  @Qualifier(value = SEARCH_RETRY_TEMPLATE_NAME)
+  private final RetryTemplate searchRetryTemplate;
   private final IndexNameProvider indexNameProvider;
 
   public String analyze(String text, String field, ResourceType resource, String tenantId) {
@@ -72,7 +75,8 @@ public class SearchRepository {
   public SearchResponse search(ResourceRequest resourceRequest, SearchSourceBuilder searchSource) {
     var index = indexNameProvider.getIndexName(resourceRequest);
     var searchRequest = buildSearchRequest(index, searchSource);
-    return performExceptionalOperation(() -> client.search(searchRequest, DEFAULT), index, SEARCH_OPERATION_TYPE);
+    return searchRetryTemplate.invoke(
+      () -> performExceptionalOperation(() -> client.search(searchRequest, DEFAULT), index, SEARCH_OPERATION_TYPE));
   }
 
   /**
@@ -86,7 +90,8 @@ public class SearchRepository {
   public SearchResponse search(ResourceRequest resourceRequest, SearchSourceBuilder searchSource, String preference) {
     var index = indexNameProvider.getIndexName(resourceRequest);
     var searchRequest = buildSearchRequest(index, searchSource, preference);
-    return performExceptionalOperation(() -> client.search(searchRequest, DEFAULT), index, SEARCH_OPERATION_TYPE);
+    return searchRetryTemplate.invoke(
+      () -> performExceptionalOperation(() -> client.search(searchRequest, DEFAULT), index, SEARCH_OPERATION_TYPE));
   }
 
   /**
@@ -100,7 +105,8 @@ public class SearchRepository {
     var index = indexNameProvider.getIndexName(resourceRequest);
     var request = new MultiSearchRequest();
     searchSources.forEach(source -> request.add(buildSearchRequest(index, source)));
-    var response = performExceptionalOperation(() -> client.msearch(request, DEFAULT), index, "multiSearchApi");
+    var response = searchRetryTemplate.invoke(
+      () -> performExceptionalOperation(() -> client.msearch(request, DEFAULT), index, "multiSearchApi"));
 
     if (isFailedMultiSearchRequest(response.getResponses(), searchSources.size())) {
       var failureMessages = stream(response.getResponses())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
     password: ${ELASTICSEARCH_PASSWORD:}
     uris: ${ELASTICSEARCH_URL:http://localhost:9200}
     compression-enabled: ${ELASTICSEARCH_COMPRESSION_ENABLED:true}
+    search-retry-attempts: ${OPENSEARCH_SEARCH_RETRY_ATTEMPTS:3}
+    search-retry-interval-ms: ${OPENSEARCH_SEARCH_RETRY_INTERVAL_MS:500}
     elasticsearch-server: ${ELASTICSEARCH_SERVER:false}
   kafka:
     bootstrap-servers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}

--- a/src/test/java/org/folio/search/configuration/RetryTemplateConfigurationTest.java
+++ b/src/test/java/org/folio/search/configuration/RetryTemplateConfigurationTest.java
@@ -1,8 +1,12 @@
 package org.folio.search.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.hc.core5.http.ConnectionClosedException;
+import org.folio.search.configuration.properties.OpensearchProperties;
 import org.folio.search.configuration.properties.ReindexConfigurationProperties;
 import org.folio.search.configuration.properties.StreamIdsProperties;
 import org.folio.spring.testing.type.UnitTest;
@@ -12,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.retry.RetryException;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -48,5 +53,57 @@ class RetryTemplateConfigurationTest {
     when(reindexConfigurationProperties.getMergeRangePublisherRetryIntervalMs()).thenReturn(200L);
     var actual = configuration.reindexPublishRangeRetryTemplate(reindexConfigurationProperties);
     assertThat(actual).isNotNull();
+  }
+
+  @Test
+  void searchRetryTemplate_connectionClosedException_retries() {
+    var properties = new OpensearchProperties();
+    properties.setSearchRetryAttempts(3);
+    properties.setSearchRetryIntervalMs(1);
+
+    var retryTemplate = configuration.searchRetryTemplate(properties);
+    var attempts = new AtomicInteger();
+
+    assertThatThrownBy(() -> retryTemplate.execute(() -> {
+      attempts.incrementAndGet();
+      throw new ConnectionClosedException("closed");
+    })).isInstanceOf(RetryException.class);
+
+    assertThat(attempts.get()).isGreaterThan(1);
+  }
+
+  @Test
+  void searchRetryTemplate_wrappedConnectionClosedException_retries() {
+    var properties = new OpensearchProperties();
+    properties.setSearchRetryAttempts(3);
+    properties.setSearchRetryIntervalMs(1);
+
+    var retryTemplate = configuration.searchRetryTemplate(properties);
+    var attempts = new AtomicInteger();
+
+    assertThatThrownBy(() -> retryTemplate.execute(() -> {
+      attempts.incrementAndGet();
+      throw new RuntimeException(new ConnectionClosedException("closed"));
+    })).isInstanceOf(RetryException.class)
+      .hasRootCauseInstanceOf(ConnectionClosedException.class);
+
+    assertThat(attempts.get()).isGreaterThan(1);
+  }
+
+  @Test
+  void searchRetryTemplate_otherException_doesNotRetry() {
+    var properties = new OpensearchProperties();
+    properties.setSearchRetryAttempts(3);
+    properties.setSearchRetryIntervalMs(1);
+
+    var retryTemplate = configuration.searchRetryTemplate(properties);
+    var attempts = new AtomicInteger();
+
+    assertThatThrownBy(() -> retryTemplate.execute(() -> {
+      attempts.incrementAndGet();
+      throw new IllegalStateException("boom");
+    })).isInstanceOf(RetryException.class);
+
+    assertThat(attempts.get()).isEqualTo(1);
   }
 }

--- a/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
+++ b/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
@@ -34,6 +34,7 @@ import org.folio.search.configuration.RetryTemplateConfiguration;
 import org.folio.search.configuration.kafka.InstanceResourceEventKafkaConfiguration;
 import org.folio.search.configuration.kafka.InstanceSharingCompleteEventKafkaConfiguration;
 import org.folio.search.configuration.kafka.ResourceEventKafkaConfiguration;
+import org.folio.search.configuration.properties.OpensearchProperties;
 import org.folio.search.domain.dto.ResourceEvent;
 import org.folio.search.integration.KafkaMessageListenerIT.KafkaListenerTestConfiguration;
 import org.folio.search.integration.message.FolioMessageBatchProcessor;
@@ -85,7 +86,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 @Import({KafkaListenerTestConfiguration.class, DefaultErrorHandler.class})
 @ExtendWith(MockitoExtension.class)
 @SpringBootTest(
-  classes = {KafkaMessageListener.class, FolioKafkaProperties.class, InstanceEventMapper.class},
+  classes = {
+    KafkaMessageListener.class,
+    FolioKafkaProperties.class,
+    InstanceEventMapper.class,
+    OpensearchProperties.class
+  },
   properties = {
     "ENV=kafka-listener-it",
     "folio.environment=${ENV:kafka-listener-it}",

--- a/src/test/java/org/folio/search/integration/folio/InventoryServiceTest.java
+++ b/src/test/java/org/folio/search/integration/folio/InventoryServiceTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import org.folio.search.client.InventoryInstanceClient;
 import org.folio.search.client.InventoryReindexRecordsClient;
 import org.folio.search.configuration.RetryTemplateConfiguration;
+import org.folio.search.configuration.properties.OpensearchProperties;
 import org.folio.search.configuration.properties.ReindexConfigurationProperties;
 import org.folio.search.configuration.properties.StreamIdsProperties;
 import org.folio.search.exception.FolioIntegrationException;
@@ -40,7 +41,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties
 @ContextConfiguration(classes = {InventoryService.class, RetryTemplateConfiguration.class, FolioKafkaProperties.class,
-                                 StreamIdsProperties.class, ReindexConfigurationProperties.class})
+                                 StreamIdsProperties.class, ReindexConfigurationProperties.class,
+                                 OpensearchProperties.class})
 @TestPropertySource(properties = {
   "folio.reindex.reindex-type=EXPORT",
   "folio.reindex.merge-range-publisher-retry-attempts=5",

--- a/src/test/java/org/folio/search/repository/SearchRepositoryTest.java
+++ b/src/test/java/org/folio/search/repository/SearchRepositoryTest.java
@@ -39,7 +39,6 @@ import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.action.search.ClearScrollRequest;
@@ -65,7 +64,6 @@ class SearchRepositoryTest {
   private static final String SCROLL_ID = randomId();
   private static final TimeValue KEEP_ALIVE_INTERVAL = TimeValue.timeValueMinutes(1L);
 
-  @InjectMocks
   private SearchRepository searchRepository;
   @Mock
   private RestHighLevelClient esClient;
@@ -74,12 +72,18 @@ class SearchRepositoryTest {
   @Mock
   private RetryTemplate retryTemplate;
   @Mock
+  private RetryTemplate searchRetryTemplate;
+  @Mock
   private IndexNameProvider indexNameProvider;
 
+  @SuppressWarnings({"rawtypes", "unchecked"})
   @BeforeEach
   void setUp() {
+    searchRepository = new SearchRepository(esClient, retryTemplate, searchRetryTemplate, indexNameProvider);
     lenient().when(indexNameProvider.getIndexName(any(ResourceRequest.class)))
       .thenAnswer(invocation -> SearchUtils.getIndexName(invocation.<ResourceRequest>getArgument(0)));
+    lenient().when(searchRetryTemplate.invoke(any(Supplier.class)))
+      .thenAnswer(invocation -> invocation.<Supplier>getArgument(0).get());
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Handle issue: [{"code":"elasticsearch_error"_"message":"Failed to perform elasticsearch request [index=folio-etesting-sprint_instance_cs00000int_ type=searchApi_ message: Connection is closed]"_"type":"SearchOperationException"}]_"total_records":1}

### Approach
Add retry for search operations

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MSEARCH-1194
