### PR TITLE
perf(reindex): eliminate JSON re-serialization round-trip in EXPORT merge path

### DIFF
--- a/src/main/java/org/folio/search/service/reindex/ExportReindexOrchestrationService.java
+++ b/src/main/java/org/folio/search/service/reindex/ExportReindexOrchestrationService.java
@@ -12,9 +12,9 @@ import org.folio.s3.client.FolioS3Client;
 import org.folio.search.configuration.properties.ReindexConfigurationProperties;
 import org.folio.search.exception.ReindexException;
 import org.folio.search.model.event.ReindexFileReadyEvent;
-import org.folio.search.model.event.ReindexRecordsEvent;
 import org.folio.search.repository.PrimaryResourceRepository;
 import org.folio.search.service.converter.MultiTenantSearchDocumentConverter;
+import org.folio.search.service.reindex.jdbc.RawLine;
 import org.folio.search.utils.JsonConverter;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -81,11 +81,11 @@ public class ExportReindexOrchestrationService extends ReindexOrchestrationServi
     try (var is = folioS3Client.read(event.getObjectKey());
          var isr = new InputStreamReader(is, StandardCharsets.UTF_8);
          var reader = new BufferedReader(isr)) {
-      List<Object> batch = new ArrayList<>(batchSize);
+      List<RawLine> batch = new ArrayList<>(batchSize);
       String line;
       while ((line = reader.readLine()) != null) {
         if (!line.isBlank()) {
-          batch.add(jsonConverter.fromJsonToMap(line));
+          batch.add(new RawLine(line, jsonConverter.fromJsonToMap(line)));
         }
         if (batch.size() >= batchSize) {
           saveBatch(event, batch, true);
@@ -95,22 +95,13 @@ public class ExportReindexOrchestrationService extends ReindexOrchestrationServi
     }
   }
 
-  private void saveBatch(ReindexFileReadyEvent event, List<Object> batch, boolean clearAfterSave) {
+  private void saveBatch(ReindexFileReadyEvent event, List<RawLine> batch, boolean clearAfterSave) {
     if (batch.isEmpty()) {
       return;
     }
-    mergeRangeService.saveEntities(toReindexRecordsEvent(event, batch));
+    mergeRangeService.saveEntitiesRaw(event.getTenantId(), event.getRecordType(), batch);
     if (clearAfterSave) {
       batch.clear();
     }
-  }
-
-  private ReindexRecordsEvent toReindexRecordsEvent(ReindexFileReadyEvent event, List<Object> records) {
-    var reindexRecordsEvent = new ReindexRecordsEvent();
-    reindexRecordsEvent.setRangeId(event.getRangeId());
-    reindexRecordsEvent.setTenant(event.getTenantId());
-    reindexRecordsEvent.setRecordType(event.getRecordType());
-    reindexRecordsEvent.setRecords(records);
-    return reindexRecordsEvent;
   }
 }

--- a/src/main/java/org/folio/search/service/reindex/ReindexMergeRangeIndexService.java
+++ b/src/main/java/org/folio/search/service/reindex/ReindexMergeRangeIndexService.java
@@ -14,6 +14,7 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.search.configuration.properties.ReindexConfigurationProperties;
 import org.folio.search.integration.folio.InventoryService;
+import org.folio.search.model.event.ReindexRecordType;
 import org.folio.search.model.event.ReindexRecordsEvent;
 import org.folio.search.model.reindex.MergeRangeEntity;
 import org.folio.search.model.types.InventoryRecordType;
@@ -21,6 +22,7 @@ import org.folio.search.model.types.ReindexEntityType;
 import org.folio.search.model.types.ReindexRangeStatus;
 import org.folio.search.service.InstanceChildrenResourceService;
 import org.folio.search.service.reindex.jdbc.MergeRangeRepository;
+import org.folio.search.service.reindex.jdbc.RawLine;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -114,6 +116,20 @@ public class ReindexMergeRangeIndexService {
       }
     } finally {
       // Only clear reindex mode, preserve member tenant context for outer scope
+      ReindexContext.setReindexMode(false);
+    }
+  }
+
+  public void saveEntitiesRaw(String tenant, ReindexRecordType recordType, List<RawLine> entities) {
+    var maps = entities.stream().map(RawLine::data).toList();
+    try {
+      ReindexContext.setReindexMode(true);
+      repositories.get(recordType.getEntityType()).saveEntitiesRaw(tenant, entities);
+      if (instanceChildrenResourceService != null) {
+        instanceChildrenResourceService.persistChildrenOnReindex(
+          tenant, RESOURCE_NAME_MAP.get(recordType.getEntityType()), maps);
+      }
+    } finally {
       ReindexContext.setReindexMode(false);
     }
   }

--- a/src/main/java/org/folio/search/service/reindex/jdbc/HoldingRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/HoldingRepository.java
@@ -53,6 +53,41 @@ public class HoldingRepository extends MergeRangeRepository {
     }
   }
 
+  @Override
+  public void saveEntitiesRaw(String tenantId, List<RawLine> entities) {
+    if (ReindexContext.isReindexMode() && ReindexContext.getMemberTenantId() != null) {
+      saveEntitiesToStagingRaw(tenantId, entities);
+    } else {
+      saveEntitiesToMainRaw(tenantId, entities);
+    }
+  }
+
+  private void saveEntitiesToMainRaw(String tenantId, List<RawLine> entities) {
+    var fullTableName = getFullTableName(context, entityTable());
+    var sql = INSERT_SQL.formatted(fullTableName);
+    jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
+      (statement, entity) -> {
+        statement.setObject(1, entity.data().get("id"));
+        statement.setString(2, tenantId);
+        statement.setObject(3, entity.data().get("instanceId"));
+        statement.setString(4, entity.rawJson());
+      });
+  }
+
+  @SuppressWarnings("java:S2077")
+  private void saveEntitiesToStagingRaw(String tenantId, List<RawLine> entities) {
+    var fullTableName = getFullTableName(context, ReindexConstants.STAGING_HOLDING_TABLE);
+    var sql = INSERT_STAGING_SQL.formatted(fullTableName);
+    jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
+      (statement, entity) -> {
+        statement.setObject(1, entity.data().get("id"));
+        statement.setString(2, tenantId);
+        statement.setObject(3, entity.data().get("instanceId"));
+        statement.setString(4, entity.rawJson());
+      });
+    log.debug("Saved {} entities to staging table {}", entities.size(), ReindexConstants.STAGING_HOLDING_TABLE);
+  }
+
   private void saveEntitiesToMain(String tenantId, List<Map<String, Object>> entities) {
     var fullTableName = getFullTableName(context, entityTable());
     var sql = INSERT_SQL.formatted(fullTableName);

--- a/src/main/java/org/folio/search/service/reindex/jdbc/HoldingRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/HoldingRepository.java
@@ -9,7 +9,6 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.search.configuration.properties.SearchConfigurationProperties;
 import org.folio.search.model.types.ReindexEntityType;
 import org.folio.search.service.reindex.ReindexConstants;
-import org.folio.search.service.reindex.ReindexContext;
 import org.folio.search.utils.JsonConverter;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -45,75 +44,63 @@ public class HoldingRepository extends MergeRangeRepository {
   }
 
   @Override
-  public void saveEntities(String tenantId, List<Map<String, Object>> entities) {
-    if (ReindexContext.isReindexMode() && ReindexContext.getMemberTenantId() != null) {
-      saveEntitiesToStaging(tenantId, entities);
-    } else {
-      saveEntitiesToMain(tenantId, entities);
-    }
+  @SuppressWarnings("java:S2077")
+  protected void saveEntitiesToMain(String tenantId, List<Map<String, Object>> entities) {
+    var fullTableName = getFullTableName(context, entityTable());
+    var sql = INSERT_SQL.formatted(fullTableName);
+
+    jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
+      (statement, entity) -> {
+        statement.setObject(1, entity.get("id"));
+        statement.setString(2, tenantId);
+        statement.setObject(3, entity.get("instanceId"));
+        statement.setString(4, jsonConverter.toJson(entity));
+      });
   }
 
   @Override
-  public void saveEntitiesRaw(String tenantId, List<RawLine> entities) {
-    if (ReindexContext.isReindexMode() && ReindexContext.getMemberTenantId() != null) {
-      saveEntitiesToStagingRaw(tenantId, entities);
-    } else {
-      saveEntitiesToMainRaw(tenantId, entities);
-    }
-  }
-
-  private void saveEntitiesToMainRaw(String tenantId, List<RawLine> entities) {
-    var fullTableName = getFullTableName(context, entityTable());
-    var sql = INSERT_SQL.formatted(fullTableName);
-    jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
-      (statement, entity) -> {
-        statement.setObject(1, entity.data().get("id"));
-        statement.setString(2, tenantId);
-        statement.setObject(3, entity.data().get("instanceId"));
-        statement.setString(4, entity.rawJson());
-      });
-  }
-
   @SuppressWarnings("java:S2077")
-  private void saveEntitiesToStagingRaw(String tenantId, List<RawLine> entities) {
+  protected void saveEntitiesToStaging(String tenantId, List<Map<String, Object>> entities) {
     var fullTableName = getFullTableName(context, ReindexConstants.STAGING_HOLDING_TABLE);
     var sql = INSERT_STAGING_SQL.formatted(fullTableName);
+
     jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
       (statement, entity) -> {
-        statement.setObject(1, entity.data().get("id"));
+        statement.setObject(1, entity.get("id"));
         statement.setString(2, tenantId);
-        statement.setObject(3, entity.data().get("instanceId"));
-        statement.setString(4, entity.rawJson());
+        statement.setObject(3, entity.get("instanceId"));
+        statement.setString(4, jsonConverter.toJson(entity));
       });
+
     log.debug("Saved {} entities to staging table {}", entities.size(), ReindexConstants.STAGING_HOLDING_TABLE);
   }
 
-  private void saveEntitiesToMain(String tenantId, List<Map<String, Object>> entities) {
+  @Override
+  @SuppressWarnings("java:S2077")
+  protected void saveEntitiesToMainRaw(String tenantId, List<RawLine> entities) {
     var fullTableName = getFullTableName(context, entityTable());
     var sql = INSERT_SQL.formatted(fullTableName);
-
     jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
       (statement, entity) -> {
-        statement.setObject(1, entity.get("id"));
+        statement.setObject(1, entity.data().get("id"));
         statement.setString(2, tenantId);
-        statement.setObject(3, entity.get("instanceId"));
-        statement.setString(4, jsonConverter.toJson(entity));
+        statement.setObject(3, entity.data().get("instanceId"));
+        statement.setString(4, entity.rawJson());
       });
   }
 
+  @Override
   @SuppressWarnings("java:S2077")
-  private void saveEntitiesToStaging(String tenantId, List<Map<String, Object>> entities) {
+  protected void saveEntitiesToStagingRaw(String tenantId, List<RawLine> entities) {
     var fullTableName = getFullTableName(context, ReindexConstants.STAGING_HOLDING_TABLE);
     var sql = INSERT_STAGING_SQL.formatted(fullTableName);
-
     jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
       (statement, entity) -> {
-        statement.setObject(1, entity.get("id"));
+        statement.setObject(1, entity.data().get("id"));
         statement.setString(2, tenantId);
-        statement.setObject(3, entity.get("instanceId"));
-        statement.setString(4, jsonConverter.toJson(entity));
+        statement.setObject(3, entity.data().get("instanceId"));
+        statement.setString(4, entity.rawJson());
       });
-
     log.debug("Saved {} entities to staging table {}", entities.size(), ReindexConstants.STAGING_HOLDING_TABLE);
   }
 

--- a/src/main/java/org/folio/search/service/reindex/jdbc/ItemRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/ItemRepository.java
@@ -75,6 +75,44 @@ public class ItemRepository extends MergeRangeRepository {
     }
   }
 
+  @Override
+  public void saveEntitiesRaw(String tenantId, List<RawLine> entities) {
+    if (ReindexContext.isReindexMode() && ReindexContext.getMemberTenantId() != null) {
+      saveEntitiesToStagingRaw(tenantId, entities);
+    } else {
+      saveEntitiesToMainRaw(tenantId, entities);
+    }
+  }
+
+  @SuppressWarnings("java:S2077")
+  private void saveEntitiesToMainRaw(String tenantId, List<RawLine> entities) {
+    var fullTableName = getFullTableName(context, entityTable());
+    var sql = INSERT_SQL.formatted(fullTableName);
+    jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
+      (statement, entity) -> {
+        statement.setObject(1, entity.data().get("id"));
+        statement.setString(2, tenantId);
+        statement.setObject(3, entity.data().get("instanceId"));
+        statement.setObject(4, entity.data().get("holdingsRecordId"));
+        statement.setString(5, entity.rawJson());
+      });
+  }
+
+  @SuppressWarnings("java:S2077")
+  private void saveEntitiesToStagingRaw(String tenantId, List<RawLine> entities) {
+    var fullTableName = getFullTableName(context, ReindexConstants.STAGING_ITEM_TABLE);
+    var sql = INSERT_STAGING_SQL.formatted(fullTableName);
+    jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
+      (statement, entity) -> {
+        statement.setObject(1, entity.data().get("id"));
+        statement.setString(2, tenantId);
+        statement.setObject(3, entity.data().get("instanceId"));
+        statement.setObject(4, entity.data().get("holdingsRecordId"));
+        statement.setString(5, entity.rawJson());
+      });
+    log.debug("Saved {} entities to staging table {}", entities.size(), ReindexConstants.STAGING_ITEM_TABLE);
+  }
+
   @SuppressWarnings("java:S2077")
   private void saveEntitiesToMain(String tenantId, List<Map<String, Object>> entities) {
     var fullTableName = getFullTableName(context, entityTable());

--- a/src/main/java/org/folio/search/service/reindex/jdbc/ItemRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/ItemRepository.java
@@ -10,7 +10,6 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.search.configuration.properties.SearchConfigurationProperties;
 import org.folio.search.model.types.ReindexEntityType;
 import org.folio.search.service.reindex.ReindexConstants;
-import org.folio.search.service.reindex.ReindexContext;
 import org.folio.search.utils.JsonConverter;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -67,25 +66,8 @@ public class ItemRepository extends MergeRangeRepository {
   }
 
   @Override
-  public void saveEntities(String tenantId, List<Map<String, Object>> entities) {
-    if (ReindexContext.isReindexMode() && ReindexContext.getMemberTenantId() != null) {
-      saveEntitiesToStaging(tenantId, entities);
-    } else {
-      saveEntitiesToMain(tenantId, entities);
-    }
-  }
-
-  @Override
-  public void saveEntitiesRaw(String tenantId, List<RawLine> entities) {
-    if (ReindexContext.isReindexMode() && ReindexContext.getMemberTenantId() != null) {
-      saveEntitiesToStagingRaw(tenantId, entities);
-    } else {
-      saveEntitiesToMainRaw(tenantId, entities);
-    }
-  }
-
   @SuppressWarnings("java:S2077")
-  private void saveEntitiesToMainRaw(String tenantId, List<RawLine> entities) {
+  protected void saveEntitiesToMainRaw(String tenantId, List<RawLine> entities) {
     var fullTableName = getFullTableName(context, entityTable());
     var sql = INSERT_SQL.formatted(fullTableName);
     jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
@@ -98,8 +80,9 @@ public class ItemRepository extends MergeRangeRepository {
       });
   }
 
+  @Override
   @SuppressWarnings("java:S2077")
-  private void saveEntitiesToStagingRaw(String tenantId, List<RawLine> entities) {
+  protected void saveEntitiesToStagingRaw(String tenantId, List<RawLine> entities) {
     var fullTableName = getFullTableName(context, ReindexConstants.STAGING_ITEM_TABLE);
     var sql = INSERT_STAGING_SQL.formatted(fullTableName);
     jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
@@ -113,8 +96,9 @@ public class ItemRepository extends MergeRangeRepository {
     log.debug("Saved {} entities to staging table {}", entities.size(), ReindexConstants.STAGING_ITEM_TABLE);
   }
 
+  @Override
   @SuppressWarnings("java:S2077")
-  private void saveEntitiesToMain(String tenantId, List<Map<String, Object>> entities) {
+  protected void saveEntitiesToMain(String tenantId, List<Map<String, Object>> entities) {
     var fullTableName = getFullTableName(context, entityTable());
     var sql = INSERT_SQL.formatted(fullTableName);
 
@@ -128,8 +112,9 @@ public class ItemRepository extends MergeRangeRepository {
       });
   }
 
+  @Override
   @SuppressWarnings("java:S2077")
-  private void saveEntitiesToStaging(String tenantId, List<Map<String, Object>> entities) {
+  protected void saveEntitiesToStaging(String tenantId, List<Map<String, Object>> entities) {
     var fullTableName = getFullTableName(context, ReindexConstants.STAGING_ITEM_TABLE);
     var sql = INSERT_STAGING_SQL.formatted(fullTableName);
 

--- a/src/main/java/org/folio/search/service/reindex/jdbc/MergeInstanceRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/MergeInstanceRepository.java
@@ -84,6 +84,54 @@ public class MergeInstanceRepository extends MergeRangeRepository {
     }
   }
 
+  @Override
+  public void saveEntitiesRaw(String tenantId, List<RawLine> entities) {
+    if (ReindexContext.isReindexMode() && ReindexContext.getMemberTenantId() != null) {
+      saveEntitiesToStagingRaw(tenantId, entities);
+    } else {
+      saveEntitiesToMainRaw(tenantId, entities);
+    }
+  }
+
+  @SuppressWarnings("java:S2077")
+  private void saveEntitiesToMainRaw(String tenantId, List<RawLine> entities) {
+    var fullTableName = getFullTableName(context, entityTable());
+    var sql = INSERT_SQL.formatted(fullTableName);
+    var shared = consortiumTenantProvider.isCentralTenant(tenantId);
+    try {
+      jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
+        (statement, entity) -> {
+          statement.setObject(1, entity.data().get("id"));
+          statement.setString(2, tenantId);
+          statement.setObject(3, shared);
+          statement.setObject(4, entity.data().getOrDefault("isBoundWith", false));
+          statement.setString(5, entity.rawJson());
+        });
+    } catch (DataAccessException e) {
+      log.warn("saveEntitiesToMainRaw::Failed to save batch. Starting processing one-by-one", e);
+      for (RawLine entity : entities) {
+        jdbcTemplate.update(sql, entity.data().get("id"), tenantId, shared,
+          entity.data().getOrDefault("isBoundWith", false), entity.rawJson());
+      }
+    }
+  }
+
+  @SuppressWarnings("java:S2077")
+  private void saveEntitiesToStagingRaw(String tenantId, List<RawLine> entities) {
+    var fullTableName = getFullTableName(context, ReindexConstants.STAGING_INSTANCE_TABLE);
+    var sql = INSERT_STAGING_SQL.formatted(fullTableName);
+    var shared = consortiumTenantProvider.isCentralTenant(tenantId);
+    jdbcTemplate.batchUpdate(sql, entities, BATCH_OPERATION_SIZE,
+      (statement, entity) -> {
+        statement.setObject(1, entity.data().get("id"));
+        statement.setString(2, tenantId);
+        statement.setObject(3, shared);
+        statement.setObject(4, entity.data().getOrDefault("isBoundWith", false));
+        statement.setString(5, entity.rawJson());
+      });
+    log.debug("Saved {} entities to staging table {}", entities.size(), ReindexConstants.STAGING_INSTANCE_TABLE);
+  }
+
   @SuppressWarnings("java:S2077")
   private void saveEntitiesToMain(String tenantId, List<Map<String, Object>> entities) {
     var fullTableName = getFullTableName(context, entityTable());

--- a/src/main/java/org/folio/search/service/reindex/jdbc/MergeInstanceRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/MergeInstanceRepository.java
@@ -11,7 +11,6 @@ import org.folio.search.configuration.properties.SearchConfigurationProperties;
 import org.folio.search.model.types.ReindexEntityType;
 import org.folio.search.service.consortium.ConsortiumTenantProvider;
 import org.folio.search.service.reindex.ReindexConstants;
-import org.folio.search.service.reindex.ReindexContext;
 import org.folio.search.utils.JsonConverter;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.dao.DataAccessException;
@@ -76,25 +75,8 @@ public class MergeInstanceRepository extends MergeRangeRepository {
   }
 
   @Override
-  public void saveEntities(String tenantId, List<Map<String, Object>> entities) {
-    if (ReindexContext.isReindexMode() && ReindexContext.getMemberTenantId() != null) {
-      saveEntitiesToStaging(tenantId, entities);
-    } else {
-      saveEntitiesToMain(tenantId, entities);
-    }
-  }
-
-  @Override
-  public void saveEntitiesRaw(String tenantId, List<RawLine> entities) {
-    if (ReindexContext.isReindexMode() && ReindexContext.getMemberTenantId() != null) {
-      saveEntitiesToStagingRaw(tenantId, entities);
-    } else {
-      saveEntitiesToMainRaw(tenantId, entities);
-    }
-  }
-
   @SuppressWarnings("java:S2077")
-  private void saveEntitiesToMainRaw(String tenantId, List<RawLine> entities) {
+  protected void saveEntitiesToMainRaw(String tenantId, List<RawLine> entities) {
     var fullTableName = getFullTableName(context, entityTable());
     var sql = INSERT_SQL.formatted(fullTableName);
     var shared = consortiumTenantProvider.isCentralTenant(tenantId);
@@ -116,8 +98,9 @@ public class MergeInstanceRepository extends MergeRangeRepository {
     }
   }
 
+  @Override
   @SuppressWarnings("java:S2077")
-  private void saveEntitiesToStagingRaw(String tenantId, List<RawLine> entities) {
+  protected void saveEntitiesToStagingRaw(String tenantId, List<RawLine> entities) {
     var fullTableName = getFullTableName(context, ReindexConstants.STAGING_INSTANCE_TABLE);
     var sql = INSERT_STAGING_SQL.formatted(fullTableName);
     var shared = consortiumTenantProvider.isCentralTenant(tenantId);
@@ -132,8 +115,9 @@ public class MergeInstanceRepository extends MergeRangeRepository {
     log.debug("Saved {} entities to staging table {}", entities.size(), ReindexConstants.STAGING_INSTANCE_TABLE);
   }
 
+  @Override
   @SuppressWarnings("java:S2077")
-  private void saveEntitiesToMain(String tenantId, List<Map<String, Object>> entities) {
+  protected void saveEntitiesToMain(String tenantId, List<Map<String, Object>> entities) {
     var fullTableName = getFullTableName(context, entityTable());
     var sql = INSERT_SQL.formatted(fullTableName);
     var shared = consortiumTenantProvider.isCentralTenant(tenantId);
@@ -159,8 +143,9 @@ public class MergeInstanceRepository extends MergeRangeRepository {
     }
   }
 
+  @Override
   @SuppressWarnings("java:S2077")
-  private void saveEntitiesToStaging(String tenantId, List<Map<String, Object>> entities) {
+  protected void saveEntitiesToStaging(String tenantId, List<Map<String, Object>> entities) {
     var fullTableName = getFullTableName(context, ReindexConstants.STAGING_INSTANCE_TABLE);
     var sql = INSERT_STAGING_SQL.formatted(fullTableName);
     var shared = consortiumTenantProvider.isCentralTenant(tenantId);

--- a/src/main/java/org/folio/search/service/reindex/jdbc/MergeRangeRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/MergeRangeRepository.java
@@ -109,6 +109,8 @@ public abstract class MergeRangeRepository extends ReindexJdbcRepository {
 
   public abstract void saveEntities(String tenantId, List<Map<String, Object>> entities);
 
+  public abstract void saveEntitiesRaw(String tenantId, List<RawLine> entities);
+
   @Transactional
   public void deleteEntitiesForTenant(List<String> ids, String tenantId) {
     var hard = !instanceChildrenIndexEnabled;

--- a/src/main/java/org/folio/search/service/reindex/jdbc/MergeRangeRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/MergeRangeRepository.java
@@ -12,6 +12,7 @@ import org.folio.search.configuration.properties.SearchConfigurationProperties;
 import org.folio.search.model.reindex.MergeRangeEntity;
 import org.folio.search.model.types.ReindexEntityType;
 import org.folio.search.model.types.ReindexRangeStatus;
+import org.folio.search.service.reindex.ReindexContext;
 import org.folio.search.utils.JdbcUtils;
 import org.folio.search.utils.JsonConverter;
 import org.folio.spring.FolioExecutionContext;
@@ -107,9 +108,29 @@ public abstract class MergeRangeRepository extends ReindexJdbcRepository {
     return MERGE_RANGE_TABLE;
   }
 
-  public abstract void saveEntities(String tenantId, List<Map<String, Object>> entities);
+  public final void saveEntities(String tenantId, List<Map<String, Object>> entities) {
+    if (ReindexContext.isReindexMode() && ReindexContext.getMemberTenantId() != null) {
+      saveEntitiesToStaging(tenantId, entities);
+    } else {
+      saveEntitiesToMain(tenantId, entities);
+    }
+  }
 
-  public abstract void saveEntitiesRaw(String tenantId, List<RawLine> entities);
+  public final void saveEntitiesRaw(String tenantId, List<RawLine> entities) {
+    if (ReindexContext.isReindexMode() && ReindexContext.getMemberTenantId() != null) {
+      saveEntitiesToStagingRaw(tenantId, entities);
+    } else {
+      saveEntitiesToMainRaw(tenantId, entities);
+    }
+  }
+
+  protected abstract void saveEntitiesToMain(String tenantId, List<Map<String, Object>> entities);
+
+  protected abstract void saveEntitiesToStaging(String tenantId, List<Map<String, Object>> entities);
+
+  protected abstract void saveEntitiesToMainRaw(String tenantId, List<RawLine> entities);
+
+  protected abstract void saveEntitiesToStagingRaw(String tenantId, List<RawLine> entities);
 
   @Transactional
   public void deleteEntitiesForTenant(List<String> ids, String tenantId) {

--- a/src/main/java/org/folio/search/service/reindex/jdbc/RawLine.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/RawLine.java
@@ -1,0 +1,6 @@
+package org.folio.search.service.reindex.jdbc;
+
+import java.util.Map;
+
+public record RawLine(String rawJson, Map<String, Object> data) {
+}

--- a/src/test/java/org/folio/search/service/reindex/ExportReindexOrchestrationServiceTest.java
+++ b/src/test/java/org/folio/search/service/reindex/ExportReindexOrchestrationServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -25,7 +26,6 @@ import org.folio.search.domain.dto.ResourceEvent;
 import org.folio.search.exception.ReindexException;
 import org.folio.search.model.event.ReindexFileReadyEvent;
 import org.folio.search.model.event.ReindexRangeIndexEvent;
-import org.folio.search.model.event.ReindexRecordsEvent;
 import org.folio.search.model.index.SearchDocumentBody;
 import org.folio.search.model.types.IndexActionType;
 import org.folio.search.model.types.IndexingDataFormat;
@@ -33,6 +33,7 @@ import org.folio.search.model.types.ReindexEntityType;
 import org.folio.search.model.types.ReindexRangeStatus;
 import org.folio.search.repository.PrimaryResourceRepository;
 import org.folio.search.service.converter.MultiTenantSearchDocumentConverter;
+import org.folio.search.service.reindex.jdbc.RawLine;
 import org.folio.search.utils.JsonConverter;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.testing.type.UnitTest;
@@ -202,9 +203,12 @@ class ExportReindexOrchestrationServiceTest {
 
     service.process(event);
 
-    var eventCaptor = ArgumentCaptor.forClass(ReindexRecordsEvent.class);
-    verify(mergeRangeService).saveEntities(eventCaptor.capture());
-    assertEquals(List.of(inventoryRecord), eventCaptor.getValue().getRecords());
+    var captor = ArgumentCaptor.<List<RawLine>>captor();
+    verify(mergeRangeService).saveEntitiesRaw(eq(event.getTenantId()), eq(INSTANCE), captor.capture());
+    var captured = captor.getValue();
+    assertEquals(1, captured.size());
+    assertEquals(line, captured.get(0).rawJson());
+    assertEquals(inventoryRecord, captured.get(0).data());
     verify(reindexStatusService).addProcessedMergeRanges(ReindexEntityType.INSTANCE, 1);
     verify(mergeRangeService).updateStatus(ReindexEntityType.INSTANCE, rangeId, SUCCESS, null);
   }
@@ -224,9 +228,14 @@ class ExportReindexOrchestrationServiceTest {
 
     service.process(event);
 
-    var eventCaptor = ArgumentCaptor.forClass(ReindexRecordsEvent.class);
-    verify(mergeRangeService).saveEntities(eventCaptor.capture());
-    assertEquals(List.of(record1, record2), eventCaptor.getValue().getRecords());
+    var captor = ArgumentCaptor.<List<RawLine>>captor();
+    verify(mergeRangeService).saveEntitiesRaw(eq(event.getTenantId()), eq(INSTANCE), captor.capture());
+    var captured = captor.getValue();
+    assertEquals(2, captured.size());
+    assertEquals(line1, captured.get(0).rawJson());
+    assertEquals(record1, captured.get(0).data());
+    assertEquals(line2, captured.get(1).rawJson());
+    assertEquals(record2, captured.get(1).data());
     verify(reindexStatusService).addProcessedMergeRanges(ReindexEntityType.INSTANCE, 1);
     verify(mergeRangeService).updateStatus(ReindexEntityType.INSTANCE, rangeId, SUCCESS, null);
   }
@@ -241,7 +250,7 @@ class ExportReindexOrchestrationServiceTest {
     when(reindexStatusService.getTargetTenantId()).thenReturn(MEMBER_TENANT_ID);
     when(folioS3Client.read(event.getObjectKey())).thenReturn(new ByteArrayInputStream((line + "\n").getBytes(UTF_8)));
     when(jsonConverter.fromJsonToMap(line)).thenReturn(inventoryRecord);
-    doThrow(new RuntimeException(failCause)).when(mergeRangeService).saveEntities(any(ReindexRecordsEvent.class));
+    doThrow(new RuntimeException(failCause)).when(mergeRangeService).saveEntitiesRaw(any(), any(), any());
 
     var result = service.process(event);
 
@@ -261,7 +270,7 @@ class ExportReindexOrchestrationServiceTest {
     when(folioS3Client.read(event.getObjectKey())).thenReturn(new ByteArrayInputStream((line + "\n").getBytes(UTF_8)));
     when(jsonConverter.fromJsonToMap(line)).thenReturn(inventoryRecord);
     doThrow(new PessimisticLockingFailureException("Deadlock"))
-      .when(mergeRangeService).saveEntities(any(ReindexRecordsEvent.class));
+      .when(mergeRangeService).saveEntitiesRaw(any(), any(), any());
 
     assertThrows(ReindexException.class, () -> service.process(event));
 

--- a/src/test/java/org/folio/search/service/reindex/ReindexMergeRangeIndexServiceTest.java
+++ b/src/test/java/org/folio/search/service/reindex/ReindexMergeRangeIndexServiceTest.java
@@ -36,6 +36,7 @@ import org.folio.search.service.reindex.jdbc.HoldingRepository;
 import org.folio.search.service.reindex.jdbc.ItemRepository;
 import org.folio.search.service.reindex.jdbc.MergeInstanceRepository;
 import org.folio.search.service.reindex.jdbc.MergeRangeRepository;
+import org.folio.search.service.reindex.jdbc.RawLine;
 import org.folio.search.service.reindex.jdbc.ReindexJdbcRepository;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -200,6 +201,37 @@ class ReindexMergeRangeIndexServiceTest {
     serviceWithoutChildren.saveEntities(event);
 
     verify(repositoryMap.get(recordType.getEntityType())).saveEntities(TENANT_ID, List.of(entities));
+    verify(instanceChildrenResourceService, never()).persistChildrenOnReindex(any(), any(), any());
+  }
+
+  @EnumSource(value = ReindexRecordType.class)
+  @ParameterizedTest
+  void saveEntitiesRaw_savesViaRepositoryAndPersistsChildren(ReindexRecordType recordType) {
+    var rawJson = "{\"id\":\"" + UUID.randomUUID() + "\"}";
+    var data = Map.<String, Object>of("id", UUID.randomUUID().toString());
+    var rawLine = new RawLine(rawJson, data);
+
+    service.saveEntitiesRaw(TENANT_ID, recordType, List.of(rawLine));
+
+    verify(repositoryMap.get(recordType.getEntityType())).saveEntitiesRaw(TENANT_ID, List.of(rawLine));
+    verify(instanceChildrenResourceService).persistChildrenOnReindex(TENANT_ID,
+      RESOURCE_NAME_MAP.get(recordType.getEntityType()),
+      List.of(data));
+  }
+
+  @EnumSource(value = ReindexRecordType.class)
+  @ParameterizedTest
+  void saveEntitiesRaw_positive_withoutInstanceChildrenResourceService(ReindexRecordType recordType) {
+    var rawJson = "{\"id\":\"" + UUID.randomUUID() + "\"}";
+    var data = Map.<String, Object>of("id", UUID.randomUUID().toString());
+    var rawLine = new RawLine(rawJson, data);
+    var serviceWithoutChildren = new ReindexMergeRangeIndexService(
+      List.of(instanceRepository, itemRepository, holdingRepository),
+      inventoryService, config, stagingMigrationService);
+
+    serviceWithoutChildren.saveEntitiesRaw(TENANT_ID, recordType, List.of(rawLine));
+
+    verify(repositoryMap.get(recordType.getEntityType())).saveEntitiesRaw(TENANT_ID, List.of(rawLine));
     verify(instanceChildrenResourceService, never()).persistChildrenOnReindex(any(), any(), any());
   }
 

--- a/src/test/java/org/folio/search/service/reindex/jdbc/MergeRangeRepositoriesIT.java
+++ b/src/test/java/org/folio/search/service/reindex/jdbc/MergeRangeRepositoriesIT.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.assertj.core.api.Condition;
 import org.folio.search.configuration.properties.ReindexConfigurationProperties;
 import org.folio.search.configuration.properties.SearchConfigurationProperties;
@@ -30,6 +31,8 @@ import org.folio.support.config.TestNoOpCacheConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
@@ -166,9 +169,10 @@ class MergeRangeRepositoriesIT {
                          && "Some error".equals(range.getFailCause()));
   }
 
-  @Test
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("saveStrategies")
   @SuppressWarnings("checkstyle:MethodLength")
-  void saveEntities() {
+  void saveEntities_savesToMainTables(String label, SaveStrategy strategy) {
     var mainInstanceId = UUID.randomUUID();
     var holdingId1 = UUID.randomUUID();
     var holdingId2 = UUID.randomUUID();
@@ -183,9 +187,9 @@ class MergeRangeRepositoriesIT {
       Map.<String, Object>of("id", UUID.randomUUID(), "instanceId", mainInstanceId, "holdingsRecordId", holdingId2));
 
     // act
-    instanceRepository.saveEntities(TENANT_ID, instances);
-    holdingRepository.saveEntities(TENANT_ID, holdings);
-    itemRepository.saveEntities(TENANT_ID, items);
+    strategy.save(instanceRepository, TENANT_ID, instances);
+    strategy.save(holdingRepository, TENANT_ID, holdings);
+    strategy.save(itemRepository, TENANT_ID, items);
 
     // assert
     var instanceCount = instanceRepository.countEntities();
@@ -257,10 +261,11 @@ class MergeRangeRepositoriesIT {
     assertThat(itemRepository.countEntities()).isEqualTo(4);
   }
 
-  @Test
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("saveStrategies")
   @Sql("/sql/populate-instances.sql")
   @SuppressWarnings("checkstyle:MethodLength")
-  void saveEntities_savesToStagingTables_whenInReindexModeWithMemberTenant() {
+  void saveEntities_savesToStagingTables_whenInReindexModeWithMemberTenant(String label, SaveStrategy strategy) {
     var instanceId = UUID.randomUUID();
     var holdingId = UUID.randomUUID();
     var itemId = UUID.randomUUID();
@@ -272,9 +277,9 @@ class MergeRangeRepositoriesIT {
     ReindexContext.setReindexMode(true);
     ReindexContext.setMemberTenantId(MEMBER_TENANT_ID);
     try {
-      instanceRepository.saveEntities(TENANT_ID, instanceEntities);
-      holdingRepository.saveEntities(TENANT_ID, holdingEntities);
-      itemRepository.saveEntities(TENANT_ID, itemEntities);
+      strategy.save(instanceRepository, TENANT_ID, instanceEntities);
+      strategy.save(holdingRepository, TENANT_ID, holdingEntities);
+      strategy.save(itemRepository, TENANT_ID, itemEntities);
     } finally {
       ReindexContext.setReindexMode(false);
       ReindexContext.clearMemberTenantId();
@@ -288,6 +293,21 @@ class MergeRangeRepositoriesIT {
 
     assertThat(countById("staging_item", itemId)).isEqualTo(1);
     assertThat(countById("item", itemId)).isZero();
+  }
+
+  static Stream<Object[]> saveStrategies() {
+    var jsonConverter = new JsonConverter(new JsonMapper());
+    SaveStrategy mapStrategy = MergeRangeRepository::saveEntities;
+    SaveStrategy rawStrategy = (repo, tenantId, entities) -> {
+      var rawLines = entities.stream()
+        .map(e -> new RawLine(jsonConverter.toJson(e), e))
+        .toList();
+      repo.saveEntitiesRaw(tenantId, rawLines);
+    };
+    return Stream.of(
+      new Object[]{"map (saveEntities)", mapStrategy},
+      new Object[]{"raw (saveEntitiesRaw)", rawStrategy}
+    );
   }
 
   @Test
@@ -337,5 +357,10 @@ class MergeRangeRepositoriesIT {
 
   private List<String> extractMapValues(List<Map<String, Object>> maps) {
     return maps.stream().map(Map::values).flatMap(Collection::stream).map(String::valueOf).toList();
+  }
+
+  @FunctionalInterface
+  interface SaveStrategy {
+    void save(MergeRangeRepository repo, String tenantId, List<Map<String, Object>> entities);
   }
 }


### PR DESCRIPTION
### Purpose
Reduce Export reindex type merge phase memory/cpu pressure

### Approach
eliminate JSON re-serialization round-trip in EXPORT merge path

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-1175](https://folio-org.atlassian.net/browse/MSEARCH-1175)
