### PR TITLE
test(call-number-browse): add TestRailCase annotation and SUDOC browse integration test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,8 @@
 * Add retry for search operations ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Tech Dept
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Add `@TestRailCase` annotation for linking integration tests to TestRail cases
+* Add integration test coverage for SUDOC call-number browse type filtering (TestRail C627509)
 
 ### Dependencies
 * Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`

--- a/src/test/java/org/folio/api/browse/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/api/browse/BrowseCallNumberIT.java
@@ -14,6 +14,7 @@ import static org.folio.support.base.ApiEndpoints.instanceCallNumberBrowsePath;
 import static org.folio.support.base.ApiEndpoints.instanceSearchPath;
 import static org.folio.support.base.ApiEndpoints.recordFacetsPath;
 import static org.folio.support.utils.CallNumberTestData.CallNumberTypeId.LC;
+import static org.folio.support.utils.CallNumberTestData.CallNumberTypeId.SUDOC;
 import static org.folio.support.utils.CallNumberTestData.callNumbers;
 import static org.folio.support.utils.CallNumberTestData.cnBrowseItem;
 import static org.folio.support.utils.CallNumberTestData.cnBrowseResult;
@@ -46,12 +47,14 @@ import org.folio.search.model.types.ReindexEntityType;
 import org.folio.search.model.types.ResourceType;
 import org.folio.search.service.reindex.jdbc.SubResourcesLockRepository;
 import org.folio.spring.testing.type.IntegrationTest;
+import org.folio.support.TestRailCase;
 import org.folio.support.base.BaseIntegrationTest;
 import org.folio.support.utils.CallNumberTestData;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -93,6 +96,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
   @BeforeEach
   void setUp() {
     updateLcConfig(List.of(UUID.fromString(LC.getId())));
+    updateSudocConfig(List.of(UUID.fromString(SUDOC.getId())));
   }
 
   @MethodSource("callNumberBrowsingDataProvider")
@@ -121,6 +125,37 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       assertThat(actualFacet.getValues())
         .containsExactlyInAnyOrderElementsOf(expectedFacet.getValues());
     });
+  }
+
+  /**
+   * Only call numbers of the type(s) configured for a browse option appear as exact matches.
+   * Non-configured types (LC, DEWEY, NLM, OTHER) must NOT produce an exact match when browsing
+   * with the SUDOC option; only SUDOC-typed call numbers should.
+   */
+  @Test
+  @TestRailCase(627509)
+  void browseByCallNumber_sudocOption_onlyConfiguredTypesReturnExactMatch() {
+    var cnByNum = callNumbers().stream()
+      .map(CallNumberTestData.CallNumberTestDataRecord::callNumber)
+      .collect(Collectors.toMap(cn -> Integer.parseInt(cn.id()), identity()));
+
+    // Non-configured types (IDs 1=LC, 2=DEWEY, 3=NLM, 5=OTHER) must NOT produce an exact match
+    for (var cnId : List.of(1, 2, 3, 5)) {
+      var cn = cnByNum.get(cnId);
+      assertThat(browseSudoc(cn.fullCallNumber()).getItems())
+        .as("Expected no exact match for non-SUDOC call number '%s' (id=%d)", cn.callNumber(), cnId)
+        .anySatisfy(item -> assertThat(item).isEqualTo(cnEmptyBrowseItem(cn.fullCallNumber())));
+    }
+
+    // ID 4 = "Y 10.13:980" (SUDOC type) SHOULD produce an exact match
+    var sudocCn = cnByNum.get(4);
+    assertThat(browseSudoc(sudocCn.fullCallNumber()).getItems())
+      .as("Expected exact match for SUDOC call number '%s'", sudocCn.callNumber())
+      .anySatisfy(item -> {
+        assertThat(item.getFullCallNumber()).isEqualTo(sudocCn.fullCallNumber());
+        assertThat(item.getIsAnchor()).isTrue();
+        assertThat(item.getTotalRecords()).isGreaterThan(0);
+      });
   }
 
   private static Stream<Arguments> facetQueriesProvider() {
@@ -248,6 +283,26 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       arguments(11, backwardQuery, BrowseOptionType.ALL, callNumbers.get(50).fullCallNumber(), 5,
         cnBrowseResult(null, null, 100, emptyList()))
     );
+  }
+
+  private CallNumberBrowseResult browseSudoc(String fullCallNumber) {
+    var query = "fullCallNumber >= {value} or fullCallNumber < {value}";
+    var request = get(instanceCallNumberBrowsePath(BrowseOptionType.SUDOC))
+      .param("expandAll", "true")
+      .param("query", prepareQuery(query, '"' + fullCallNumber + '"'))
+      .param("limit", "5");
+    return parseResponse(doGet(request), CallNumberBrowseResult.class);
+  }
+
+  private static void updateSudocConfig(List<UUID> typeIds) {
+    var config = new BrowseConfig()
+      .id(BrowseOptionType.SUDOC)
+      .shelvingAlgorithm(ShelvingOrderAlgorithmType.SUDOC)
+      .typeIds(typeIds);
+
+    var stub = mockCallNumberTypes(okapi.wireMockServer(), typeIds.toArray(new UUID[0]));
+    doPut(browseConfigPath(BrowseType.INSTANCE_CALL_NUMBER, BrowseOptionType.SUDOC), config);
+    okapi.wireMockServer().removeStub(stub);
   }
 
   private static void updateLcConfig(List<UUID> typeIds) {

--- a/src/test/java/org/folio/support/TestRailCase.java
+++ b/src/test/java/org/folio/support/TestRailCase.java
@@ -1,0 +1,35 @@
+package org.folio.support;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a test method or class as covering one or more TestRail test cases.
+ *
+ * <p>Usage example:
+ * <pre>{@code
+ * @Test
+ * @TestRailCase(627509)
+ * void myTest() { ... }
+ * }</pre>
+ * or for a class:
+ * <pre>{@code
+ * @TestRailCase({627509, 627510})
+ * class MyTestClass { ... }
+ * }
+ * </pre>
+ *
+ * <p>The value is the numeric TestRail case ID visible in the case URL:
+ * {@code .../cases/view/<id>}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface TestRailCase {
+
+  /** One or more TestRail case IDs covered by this test. */
+  long[] value();
+}


### PR DESCRIPTION
### Purpose
Improve test traceability by introducing a reusable `@TestRailCase` annotation and add backend integration test coverage for TestRail case [C627509](https://foliotest.testrail.io/index.php?/cases/view/627509), which verifies that only call numbers of configured types appear as exact matches when browsing with the SuDoc option.

### Approach
- Added a new `@TestRailCase(long[] value)` annotation (`org.folio.support.TestRailCase`) that links any test method or class to one or more TestRail case IDs. It uses `@Retention(RUNTIME)` so it is discoverable by reporting tooling.
- Extended `BrowseCallNumberIT` with:
  - `updateSudocConfig` helper — mirrors the existing `updateLcConfig` pattern; PUTs a `BrowseConfig` for `BrowseOptionType.SUDOC` with `ShelvingOrderAlgorithmType.SUDOC`.
  - `@BeforeEach` reset of the SUDOC config to ensure test isolation.
  - `browseSudoc` private helper that builds and fires the browse request.
  - `browseByCallNumber_sudocOption_onlyConfiguredTypesReturnExactMatch` — annotated with `@TestRailCase(627509)`; asserts that LC, DEWEY, NLM, and OTHER call numbers produce no exact match under the SUDOC browse option, while a SUDOC-typed call number does.

### Changes Checklist
- [ ] **API Changes**: No API changes.
- [ ] **Database Schema Changes**: No schema changes.
- [ ] **Interface Version Changes**: No interface version changes.
- [ ] **Interface Dependencies**: No dependency changes.
- [ ] **Permissions**: No permission changes.
- [ ] **Logging**: No logging changes.
- [ ] **Unit Testing**: No production code changed; test-only changes.
- [x] **Integration Testing**: New integration test added in `BrowseCallNumberIT`.
- [ ] **Manual Testing**: Test-only change; no manual testing required.
- [x] **NEWS**: NEWS.md updated under Tech Debt for v6.1.0.

### Related Issues
[MSEARCH-1210](https://folio-org.atlassian.net/browse/MSEARCH-1210)