### PR TITLE
test(call-number-browse): add Other scheme browse empty-config integration test (TestRail C627502)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Add `@TestRailCase` annotation for linking integration tests to TestRail cases
 * Add integration test coverage for SUDOC call-number browse type filtering (TestRail C627509)
 * Add integration test coverage for LC call-number browse with empty config returning all types (TestRail C627500)
+* Add integration test coverage for NLM call-number browse with empty config returning all types (TestRail C627501)
 
 ### Dependencies
 * Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * Add integration test coverage for SUDOC call-number browse type filtering (TestRail C627509)
 * Add integration test coverage for LC call-number browse with empty config returning all types (TestRail C627500)
 * Add integration test coverage for NLM call-number browse with empty config returning all types (TestRail C627501)
+* Add integration test coverage for Other scheme call-number browse with empty config returning all types (TestRail C627502)
 
 ### Dependencies
 * Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`

--- a/src/test/java/org/folio/api/browse/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/api/browse/BrowseCallNumberIT.java
@@ -14,6 +14,7 @@ import static org.folio.support.base.ApiEndpoints.instanceCallNumberBrowsePath;
 import static org.folio.support.base.ApiEndpoints.instanceSearchPath;
 import static org.folio.support.base.ApiEndpoints.recordFacetsPath;
 import static org.folio.support.utils.CallNumberTestData.CallNumberTypeId.LC;
+import static org.folio.support.utils.CallNumberTestData.CallNumberTypeId.NLM;
 import static org.folio.support.utils.CallNumberTestData.CallNumberTypeId.SUDOC;
 import static org.folio.support.utils.CallNumberTestData.callNumbers;
 import static org.folio.support.utils.CallNumberTestData.cnBrowseItem;
@@ -97,6 +98,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
   @BeforeEach
   void setUp() {
     updateLcConfig(List.of(UUID.fromString(LC.getId())));
+    updateNlmConfig(List.of(UUID.fromString(NLM.getId())));
     updateSudocConfig(List.of(UUID.fromString(SUDOC.getId())));
   }
 
@@ -158,28 +160,34 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
   }
 
   /**
-   * When the LC browse config has no configured call number types (empty typeIds),
-   * call numbers of every type should produce an exact match when browsing with the LC option.
+   * When a browse config has no configured call number types (empty typeIds),
+   * call numbers of every type should produce an exact match for that browse option.
    */
-  @Test
-  @TestRailCase(627500)
-  void browseByCallNumber_lcOption_emptyConfig_allTypesReturnExactMatch() {
-    updateLcConfig(emptyList());
+  @TestRailCase({627500, 627501})
+  @ParameterizedTest(name = "[{0}] empty config - all types return exact match")
+  @MethodSource("emptyConfigBrowseOptionProvider")
+  void browseByCallNumber_emptyConfig_allTypesReturnExactMatch(BrowseOptionType browseOptionType) {
+    updateCnConfig(emptyList(), browseOptionType,
+      ShelvingOrderAlgorithmType.valueOf(browseOptionType.name()));
 
     var cnByNum = createCallNumberLookup();
 
     // IDs 1=LC, 2=DEWEY, 3=NLM, 4=SUDOC, 5=OTHER
     for (var cnId : List.of(1, 2, 3, 4, 5)) {
       var cn = cnByNum.get(cnId);
-      assertThat(browse(cn.fullCallNumber(), BrowseOptionType.LC).getItems())
-        .as("Expected exact match for '%s' (id=%d, type=%s) with empty LC config",
-          cn.callNumber(), cnId, cn.callNumberTypeId())
+      assertThat(browse(cn.fullCallNumber(), browseOptionType).getItems())
+        .as("Expected exact match for '%s' (id=%d, type=%s) with empty %s config",
+          cn.callNumber(), cnId, cn.callNumberTypeId(), browseOptionType)
         .anySatisfy(item -> {
           assertThat(item.getFullCallNumber()).isEqualTo(cn.fullCallNumber());
           assertThat(item.getIsAnchor()).isTrue();
           assertThat(item.getTotalRecords()).isGreaterThan(0);
         });
     }
+  }
+
+  private static Stream<Arguments> emptyConfigBrowseOptionProvider() {
+    return Stream.of(arguments(BrowseOptionType.LC), arguments(BrowseOptionType.NLM));
   }
 
   private static Map<Integer, CallNumberResource> createCallNumberLookup() {
@@ -320,6 +328,10 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
       .param("query", prepareQuery(query, '"' + fullCallNumber + '"'))
       .param("limit", "5");
     return parseResponse(doGet(request), CallNumberBrowseResult.class);
+  }
+
+  private static void updateNlmConfig(List<UUID> typeIds) {
+    updateCnConfig(typeIds, BrowseOptionType.NLM, ShelvingOrderAlgorithmType.NLM);
   }
 
   private static void updateSudocConfig(List<UUID> typeIds) {

--- a/src/test/java/org/folio/api/browse/BrowseCallNumberIT.java
+++ b/src/test/java/org/folio/api/browse/BrowseCallNumberIT.java
@@ -15,6 +15,7 @@ import static org.folio.support.base.ApiEndpoints.instanceSearchPath;
 import static org.folio.support.base.ApiEndpoints.recordFacetsPath;
 import static org.folio.support.utils.CallNumberTestData.CallNumberTypeId.LC;
 import static org.folio.support.utils.CallNumberTestData.CallNumberTypeId.NLM;
+import static org.folio.support.utils.CallNumberTestData.CallNumberTypeId.OTHER;
 import static org.folio.support.utils.CallNumberTestData.CallNumberTypeId.SUDOC;
 import static org.folio.support.utils.CallNumberTestData.callNumbers;
 import static org.folio.support.utils.CallNumberTestData.cnBrowseItem;
@@ -99,6 +100,7 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
   void setUp() {
     updateLcConfig(List.of(UUID.fromString(LC.getId())));
     updateNlmConfig(List.of(UUID.fromString(NLM.getId())));
+    updateOtherConfig(List.of(UUID.fromString(OTHER.getId())));
     updateSudocConfig(List.of(UUID.fromString(SUDOC.getId())));
   }
 
@@ -163,12 +165,12 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
    * When a browse config has no configured call number types (empty typeIds),
    * call numbers of every type should produce an exact match for that browse option.
    */
-  @TestRailCase({627500, 627501})
+  @TestRailCase({627500, 627501, 627502})
   @ParameterizedTest(name = "[{0}] empty config - all types return exact match")
   @MethodSource("emptyConfigBrowseOptionProvider")
-  void browseByCallNumber_emptyConfig_allTypesReturnExactMatch(BrowseOptionType browseOptionType) {
-    updateCnConfig(emptyList(), browseOptionType,
-      ShelvingOrderAlgorithmType.valueOf(browseOptionType.name()));
+  void browseByCallNumber_emptyConfig_allTypesReturnExactMatch(BrowseOptionType browseOptionType,
+                                                               ShelvingOrderAlgorithmType algorithmType) {
+    updateCnConfig(emptyList(), browseOptionType, algorithmType);
 
     var cnByNum = createCallNumberLookup();
 
@@ -187,7 +189,11 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
   }
 
   private static Stream<Arguments> emptyConfigBrowseOptionProvider() {
-    return Stream.of(arguments(BrowseOptionType.LC), arguments(BrowseOptionType.NLM));
+    return Stream.of(
+      arguments(BrowseOptionType.LC, ShelvingOrderAlgorithmType.LC),
+      arguments(BrowseOptionType.NLM, ShelvingOrderAlgorithmType.NLM),
+      arguments(BrowseOptionType.OTHER, ShelvingOrderAlgorithmType.DEFAULT)
+    );
   }
 
   private static Map<Integer, CallNumberResource> createCallNumberLookup() {
@@ -332,6 +338,10 @@ class BrowseCallNumberIT extends BaseIntegrationTest {
 
   private static void updateNlmConfig(List<UUID> typeIds) {
     updateCnConfig(typeIds, BrowseOptionType.NLM, ShelvingOrderAlgorithmType.NLM);
+  }
+
+  private static void updateOtherConfig(List<UUID> typeIds) {
+    updateCnConfig(typeIds, BrowseOptionType.OTHER, ShelvingOrderAlgorithmType.DEFAULT);
   }
 
   private static void updateSudocConfig(List<UUID> typeIds) {


### PR DESCRIPTION
### Purpose
Add backend integration test coverage for TestRail case [C627502](https://foliotest.testrail.io/index.php?/cases/view/627502): verify that call numbers of each type are returned as exact-match results when browsing by the "Other scheme" option with an empty browse configuration.

Also extends the existing parameterized test (introduced for C627500/C627501) to cover this case, keeping all three browse-option/empty-config scenarios in a single test method.

### Approach
- Added `BrowseOptionType.OTHER` / `ShelvingOrderAlgorithmType.DEFAULT` entry to `emptyConfigBrowseOptionProvider()`
- Updated test signature to accept explicit `ShelvingOrderAlgorithmType` argument (needed because OTHER maps to DEFAULT, not OTHER)
- Added `updateOtherConfig` helper using `ShelvingOrderAlgorithmType.DEFAULT`
- `@BeforeEach` now resets LC, NLM, OTHER, and SUDOC configs before each test
- `@TestRailCase` updated to `{627500, 627501, 627502}`

### Changes Checklist
- [ ] **API Changes**: No API changes.
- [ ] **Database Schema Changes**: No schema changes.
- [ ] **Interface Version Changes**: No interface version changes.
- [ ] **Interface Dependencies**: No dependency changes.
- [ ] **Permissions**: No permission changes.
- [ ] **Logging**: No logging changes.
- [ ] **Unit Testing**: No production classes changed.
- [x] **Integration Testing**: Parameterized test now covers LC, NLM, and Other scheme empty-config browse.
- [ ] **Manual Testing**: Test-only change; covered by automated integration test.
- [x] **NEWS**: NEWS.md updated.

### Related Issues
[MSEARCH-1213](https://folio-org.atlassian.net/browse/MSEARCH-1213)