### PR TITLE
fix(indexing): skip background processing on BadSqlGrammarException

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 * Add retry for search operations ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Skip background processing on BadSqlGrammarException ([MSEARCH-1214](https://folio-org.atlassian.net/browse/MSEARCH-1214))
 
 ### Tech Dept
 * Add `@TestRailCase` annotation for linking integration tests to TestRail cases

--- a/src/main/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesService.java
+++ b/src/main/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesService.java
@@ -31,6 +31,7 @@ import org.folio.search.service.reindex.jdbc.TenantRepository;
 import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -77,13 +78,17 @@ public class ScheduledInstanceSubResourcesService {
   @Scheduled(fixedDelayString = "#{searchConfigurationProperties.indexing.instanceChildrenIndexDelayMs}")
   public void persistChildren() {
     log.info("persistChildren::Starting instance children processing");
-    tenantRepository.fetchDataTenantIds()
-      .forEach(tenant -> executionService.executeSystemUserScoped(tenant, () -> {
-        processAllEntityTypes(tenant);
-        return null;
-      }));
+    try {
+      tenantRepository.fetchDataTenantIds()
+        .forEach(tenant -> executionService.executeSystemUserScoped(tenant, () -> {
+          processAllEntityTypes(tenant);
+          return null;
+        }));
 
-    log.debug("persistChildren::Finished instance children processing");
+      log.debug("persistChildren::Finished instance children processing");
+    } catch (BadSqlGrammarException e) {
+      log.warn("persistChildren::Module upgrade may be in progress - database schema is outdated. Skipping cycle.");
+    }
   }
 
   public List<ResourceEvent> mapToResourceEvents(List<Map<String, Object>> recordMaps,
@@ -136,6 +141,8 @@ public class ScheduledInstanceSubResourcesService {
   private boolean isReindexInProgressOrFailedNotForConsortiumMember() {
     try {
       return reindexStatusService.isReindexInProgressOrFailedNotForConsortiumMember();
+    } catch (BadSqlGrammarException e) {
+      throw e;
     } catch (Exception e) {
       log.warn("persistChildren::Failed to check reindex status, assuming no reindex in progress or failed", e);
       return false;

--- a/src/test/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesServiceTest.java
+++ b/src/test/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesServiceTest.java
@@ -1,6 +1,7 @@
 package org.folio.search.service.scheduled;
 
 import static org.folio.support.TestConstants.TENANT_ID;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;
@@ -14,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.BadSqlGrammarException;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -238,6 +241,23 @@ class ScheduledInstanceSubResourcesServiceTest {
     verify(subResourcesLockRepository, never()).unlockSubResource(any(), any(), any());
     verify(subjectRepository, never()).fetchByTimestamp(anyString(), any(), anyInt());
     verifyNoInteractions(instanceRepository, itemRepository, resourceService);
+  }
+
+  @Test
+  void persistChildren_ShouldLogWarnAndSkipCycleOnException() {
+    // Arrange
+    doAnswer(invocation -> invocation.<Callable<?>>getArgument(1).call())
+      .when(executionService).executeSystemUserScoped(anyString(), any());
+    when(tenantRepository.fetchDataTenantIds()).thenReturn(List.of(TENANT_ID));
+    when(subResourcesLockRepository.lockSubResource(any(), eq(TENANT_ID))).thenReturn(Optional.empty());
+    when(reindexStatusService.isReindexInProgressOrFailedNotForConsortiumMember())
+      .thenThrow(
+        new BadSqlGrammarException("SELECT", "SELECT * FROM reindex_status", new SQLException("column not found")));
+
+    // Act & Assert
+    assertDoesNotThrow(() -> service.persistChildren());
+    verify(subResourcesLockRepository, never()).checkAndReleaseStaleLock(any(), any(), anyLong());
+    verifyNoInteractions(resourceService);
   }
 
   private void mockSubResourceResult(String tenantId, Timestamp timestamp) {


### PR DESCRIPTION
### Purpose
Fix BadSqlGrammarException on reindex status retrieval in a background job

### Approach
Log informative messages for BadSqlGrammarException on background job reindex status check and skip processing in case on encounter

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [x] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-1214](https://folio-org.atlassian.net/browse/MSEARCH-1214)