### PR TITLE
fix(integration-tests): disable JVM container support to avoid cgroup v2 NullPointerException in Elasticsearch8 testcontainer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Honor spring.cache.type=noop for cache manager ([MSEARCH-1204](https://folio-org.atlassian.net/browse/MSEARCH-1204))
 
 ### Bug fixes
-* Add retry for search operations ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Disable JVM container support to avoid cgroup v2 NullPointerException in Elasticsearch8  testcontainer ([MSEARCH-1209](https://folio-org.atlassian.net/browse/MSEARCH-1209))
 
 ### Tech Dept
 * Add `@TestRailCase` annotation for linking integration tests to TestRail cases

--- a/src/test/java/org/folio/support/extension/impl/ElasticSearchContainerExtension.java
+++ b/src/test/java/org/folio/support/extension/impl/ElasticSearchContainerExtension.java
@@ -42,7 +42,8 @@ public class ElasticSearchContainerExtension implements BeforeAllCallback, After
       return new ElasticsearchContainer(
         DockerImageName.parse(imageTag)
           .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
-        .withEnv("xpack.security.enabled", "false");
+        .withEnv("xpack.security.enabled", "false")
+        .withEnv("_JAVA_OPTIONS", "-XX:-UseContainerSupport");
     }
   }
 


### PR DESCRIPTION
### Purpose
All integration tests are failing in the CI pipeline (elasticsearch8 job) due to container startup failure for the `dev.folio/searchengine:latest` image when using the `Elasticsearch 8` Dockerfile.
This failure is specific to the Elasticsearch 8 job where SEARCH_ENGINE_DOCKERFILE="docker/elasticsearch8/Dockerfile" is set.

### Approach
- set `_JAVA_OPTIONS=-XX:-UseContainerSupport` for Elasticsearch testcontainer to avoid cgroup v2 NullPointerException.

Disabled JVM container support for Elasticsearch Testcontainer by setting `_JAVA_OPTIONS=-XX:-UseContainerSupport`. This avoids a JVM cgroup v2 detection issue causing NullPointerException during Elasticsearch startup (CgroupV2Subsystem.getInstance). Since container resource awareness is not needed for tests (CPU and memory limits/metrics detection from cgroups), disabling it provides a stable workaround in CI environment.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-1209](https://folio-org.atlassian.net/browse/MSEARCH-1209)

### Screenshots (if applicable)
<img width="1275" height="628" alt="image" src="https://github.com/user-attachments/assets/bbd9f6a6-3d98-42b8-be62-d15bafb76267" />
