### PR TITLE
fix(consortium-search): Limit consortium search api calls to Elasticsearch to SEARCH_CONSORTIUM_RECORDS_PAGE_SIZE per request

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,9 @@
 * Honor spring.cache.type=noop for cache manager ([MSEARCH-1204](https://folio-org.atlassian.net/browse/MSEARCH-1204))
 
 ### Bug fixes
-* Add retry for search operations ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Add retry for search operations ([MSEARCH-1194](https://folio-org.atlassian.net/browse/MSEARCH-1194))
 * Skip background processing on BadSqlGrammarException ([MSEARCH-1214](https://folio-org.atlassian.net/browse/MSEARCH-1214))
+* Limit consortium search api calls to Elasticsearch to SEARCH_CONSORTIUM_RECORDS_PAGE_SIZE per request ([MSEARCH-1194](https://folio-org.atlassian.net/browse/MSEARCH-1194))
 
 ### Tech Dept
 * Add `@TestRailCase` annotation for linking integration tests to TestRail cases

--- a/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
@@ -85,6 +85,7 @@ public class RetryTemplateConfiguration {
   }
 
   private static boolean isConnectionClosedException(Throwable throwable) {
+    log.warn("isConnectionClosedException:: encountered exception: ", throwable);
     var cause = throwable;
     while (cause != null) {
       if (cause instanceof ConnectionClosedException) {

--- a/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
@@ -57,11 +57,22 @@ public class RetryTemplateConfiguration {
 
   @Bean(name = SEARCH_RETRY_TEMPLATE_NAME)
   public RetryTemplate searchRetryTemplate(OpensearchProperties properties) {
-    return new RetryTemplate(RetryPolicy.builder()
+    var retryTemplate =  new RetryTemplate(RetryPolicy.builder()
       .maxRetries(properties.getSearchRetryAttempts())
       .delay(Duration.ofMillis(properties.getSearchRetryIntervalMs()))
       .predicate(RetryTemplateConfiguration::isConnectionClosedException)
       .build());
+    retryTemplate.setRetryListener(new RetryListener() {
+      @Override
+      public void onRetryPolicyExhaustion(@NonNull RetryPolicy retryPolicy,
+                                          @NonNull Retryable<?> retryable,
+                                          @NonNull RetryException exception) {
+        var lastThrowable = exception.getLastException();
+        log.warn(new FormattedMessage("Failed to execute search"), lastThrowable);
+        throw new FolioIntegrationException("Failed to execute search after all retries", lastThrowable);
+      }
+    });
+    return retryTemplate;
   }
 
   @ConditionalOnBean(ReindexConfigurationProperties.class)

--- a/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
@@ -96,7 +96,6 @@ public class RetryTemplateConfiguration {
   }
 
   private static boolean isConnectionClosedException(Throwable throwable) {
-    log.warn("isConnectionClosedException:: encountered exception: ", throwable);
     var cause = throwable;
     while (cause != null) {
       if (cause instanceof ConnectionClosedException) {

--- a/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceSearchService.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceSearchService.java
@@ -4,7 +4,6 @@ import static org.apache.commons.collections4.CollectionUtils.containsAny;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.folio.search.converter.ConsortiumHoldingMapper.toConsortiumHolding;
 import static org.folio.search.converter.ConsortiumItemMapper.toConsortiumItem;
-import static org.folio.search.service.SearchService.DEFAULT_MAX_SEARCH_RESULT_WINDOW;
 import static org.folio.search.utils.IdentifierUtils.getHoldingIdentifierValue;
 import static org.folio.search.utils.IdentifierUtils.getHoldingTargetField;
 import static org.folio.search.utils.IdentifierUtils.getItemIdentifierValue;
@@ -145,7 +144,7 @@ public class ConsortiumInstanceSearchService {
       .build();
     var termsQuery = termsQuery(targetField, identifierValues);
 
-    if (identifierValues.size() <= DEFAULT_MAX_SEARCH_RESULT_WINDOW) {
+    if (identifierValues.size() <= properties.getSearchConsortiumRecordsPageSize()) {
       return executeSearch(request, termsQuery, recordMapper, identifierType, identifierValues);
     }
 

--- a/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceSearchService.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceSearchService.java
@@ -160,7 +160,7 @@ public class ConsortiumInstanceSearchService {
     Mapper<Instance, IdentifierTypeEnum, Set<String>, List<T>> recordMapper,
     IdentifierTypeEnum identifierType,
     Set<String> identifierValues) {
-    var searchSourceBuilder = queryBuilder(query, SearchService.DEFAULT_MAX_SEARCH_RESULT_WINDOW);
+    var searchSourceBuilder = queryBuilder(query, properties.getSearchConsortiumRecordsPageSize());
     var response = searchRepository.search(request, searchSourceBuilder);
     var searchResult = documentConverter.convertToSearchResult(response, request.resourceClass(),
       (hits, item) -> recordMapper.apply(item, identifierType, identifierValues));

--- a/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceSearchService.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceSearchService.java
@@ -145,7 +145,7 @@ public class ConsortiumInstanceSearchService {
       .build();
     var termsQuery = termsQuery(targetField, identifierValues);
 
-    if (identifierValues.size() < DEFAULT_MAX_SEARCH_RESULT_WINDOW) {
+    if (identifierValues.size() <= DEFAULT_MAX_SEARCH_RESULT_WINDOW) {
       return executeSearch(request, termsQuery, recordMapper, identifierType, identifierValues);
     }
 

--- a/src/test/java/org/folio/search/configuration/RetryTemplateConfigurationTest.java
+++ b/src/test/java/org/folio/search/configuration/RetryTemplateConfigurationTest.java
@@ -9,6 +9,7 @@ import org.apache.hc.core5.http.ConnectionClosedException;
 import org.folio.search.configuration.properties.OpensearchProperties;
 import org.folio.search.configuration.properties.ReindexConfigurationProperties;
 import org.folio.search.configuration.properties.StreamIdsProperties;
+import org.folio.search.exception.FolioIntegrationException;
 import org.folio.spring.testing.type.UnitTest;
 import org.folio.spring.tools.kafka.FolioKafkaProperties;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.retry.RetryException;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -67,7 +67,7 @@ class RetryTemplateConfigurationTest {
     assertThatThrownBy(() -> retryTemplate.execute(() -> {
       attempts.incrementAndGet();
       throw new ConnectionClosedException("closed");
-    })).isInstanceOf(RetryException.class);
+    })).isInstanceOf(FolioIntegrationException.class);
 
     assertThat(attempts.get()).isGreaterThan(1);
   }
@@ -84,7 +84,7 @@ class RetryTemplateConfigurationTest {
     assertThatThrownBy(() -> retryTemplate.execute(() -> {
       attempts.incrementAndGet();
       throw new RuntimeException(new ConnectionClosedException("closed"));
-    })).isInstanceOf(RetryException.class)
+    })).isInstanceOf(FolioIntegrationException.class)
       .hasRootCauseInstanceOf(ConnectionClosedException.class);
 
     assertThat(attempts.get()).isGreaterThan(1);
@@ -102,7 +102,7 @@ class RetryTemplateConfigurationTest {
     assertThatThrownBy(() -> retryTemplate.execute(() -> {
       attempts.incrementAndGet();
       throw new IllegalStateException("boom");
-    })).isInstanceOf(RetryException.class);
+    })).isInstanceOf(FolioIntegrationException.class);
 
     assertThat(attempts.get()).isEqualTo(1);
   }

--- a/src/test/java/org/folio/search/service/consortium/ConsortiumInstanceSearchServiceTest.java
+++ b/src/test/java/org/folio/search/service/consortium/ConsortiumInstanceSearchServiceTest.java
@@ -201,6 +201,7 @@ class ConsortiumInstanceSearchServiceTest {
       toConsortiumHolding(randomUUID().toString(), holding(ids.get(1), CENTRAL_TENANT_ID))
     );
     when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
+    when(properties.getSearchConsortiumRecordsPageSize()).thenReturn(10);
     when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
       .thenReturn(mock(SearchResponse.class));
     mockConvertion(any(SearchResponse.class), List.of(expectedConsortiumHoldings));
@@ -237,6 +238,7 @@ class ConsortiumInstanceSearchServiceTest {
   @Test
   void fetchConsortiumBatchHoldings_positive_noRecordsFound() {
     when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
+    when(properties.getSearchConsortiumRecordsPageSize()).thenReturn(10);
     when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
       .thenReturn(mock(SearchResponse.class));
     mockConvertion(any(SearchResponse.class), Collections.emptyList());
@@ -272,6 +274,7 @@ class ConsortiumInstanceSearchServiceTest {
       toConsortiumItem(randomUUID().toString(), item(ids.get(1), CENTRAL_TENANT_ID))
     );
     when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
+    when(properties.getSearchConsortiumRecordsPageSize()).thenReturn(10);
     when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
       .thenReturn(mock(SearchResponse.class));
     mockConvertion(any(SearchResponse.class), List.of(expectedConsortiumItems));
@@ -308,6 +311,7 @@ class ConsortiumInstanceSearchServiceTest {
   @Test
   void fetchConsortiumBatchItems_positive_noRecordsFound() {
     when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
+    when(properties.getSearchConsortiumRecordsPageSize()).thenReturn(10);
     when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
       .thenReturn(mock(SearchResponse.class));
     mockConvertion(any(SearchResponse.class), Collections.emptyList());

--- a/src/test/java/org/folio/search/service/consortium/ConsortiumInstanceSearchServiceTest.java
+++ b/src/test/java/org/folio/search/service/consortium/ConsortiumInstanceSearchServiceTest.java
@@ -195,15 +195,16 @@ class ConsortiumInstanceSearchServiceTest {
 
   @Test
   void fetchConsortiumBatchHoldings_positive_notExceedsSearchResultWindow() {
+    when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
+    when(properties.getSearchConsortiumRecordsPageSize()).thenReturn(10);
+    when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
+      .thenReturn(mock(SearchResponse.class));
+
     var ids = List.of(randomUUID().toString(), randomUUID().toString());
     var expectedConsortiumHoldings = List.of(
       toConsortiumHolding(randomUUID().toString(), holding(ids.get(0), MEMBER_TENANT_ID)),
       toConsortiumHolding(randomUUID().toString(), holding(ids.get(1), CENTRAL_TENANT_ID))
     );
-    when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
-    when(properties.getSearchConsortiumRecordsPageSize()).thenReturn(10);
-    when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
-      .thenReturn(mock(SearchResponse.class));
     mockConvertion(any(SearchResponse.class), List.of(expectedConsortiumHoldings));
     var expected = holdingCollection(expectedConsortiumHoldings);
 
@@ -268,15 +269,16 @@ class ConsortiumInstanceSearchServiceTest {
 
   @Test
   void fetchConsortiumBatchItems_positive_notExceedsSearchResultWindow() {
+    when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
+    when(properties.getSearchConsortiumRecordsPageSize()).thenReturn(10);
+    when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
+      .thenReturn(mock(SearchResponse.class));
+
     var ids = List.of(randomUUID().toString(), randomUUID().toString());
     var expectedConsortiumItems = List.of(
       toConsortiumItem(randomUUID().toString(), item(ids.get(0), MEMBER_TENANT_ID)),
       toConsortiumItem(randomUUID().toString(), item(ids.get(1), CENTRAL_TENANT_ID))
     );
-    when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
-    when(properties.getSearchConsortiumRecordsPageSize()).thenReturn(10);
-    when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
-      .thenReturn(mock(SearchResponse.class));
     mockConvertion(any(SearchResponse.class), List.of(expectedConsortiumItems));
     var expected = itemCollection(expectedConsortiumItems);
 


### PR DESCRIPTION
### Purpose
Fix failing search consortium holdings endpoint for 10000 ids passed

### Approach
Use paging approach when ids amount exceeds SEARCH_CONSORTIUM_RECORDS_PAGE_SIZE

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [x] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-1194](https://folio-org.atlassian.net/browse/MSEARCH-1194)