### PR TITLE
fix(deps): bump httpclient5 to 5.6.1 and httpcore5 to 5.4.2 to fix CVE-2026-40542 mutual authentication bypass

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Skip background processing on BadSqlGrammarException ([MSEARCH-1214](https://folio-org.atlassian.net/browse/MSEARCH-1214))
 * Disable JVM container support to avoid cgroup v2 NullPointerException in Elasticsearch8  testcontainer ([MSEARCH-1209](https://folio-org.atlassian.net/browse/MSEARCH-1209))
 * Limit consortium search api calls to Elasticsearch to SEARCH_CONSORTIUM_RECORDS_PAGE_SIZE per request ([MSEARCH-1194](https://folio-org.atlassian.net/browse/MSEARCH-1194))
+* Bump httpclient5 to 5.6.1 and httpcore5 to 5.4.2 to fix CVE-2026-40542 mutual authentication bypass ([MSEARCH-1208](https://folio-org.atlassian.net/browse/MSEARCH-1208))
 
 ### Tech Dept
 * Add `@TestRailCase` annotation for linking integration tests to TestRail cases

--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,8 @@
     <folio-isbn-utils.version>1.9.0</folio-isbn-utils.version>
     <folio-cql2pgjson.version>36.0.0</folio-cql2pgjson.version>
     <opensearch.version>3.6.0</opensearch.version>
-    <!-- opensearch-rest-client:3.5.0 removed manual gzip decompression relying on httpclient5 5.6's
-         automatic async decompression. Spring Boot 4.x manages older versions, so we pin to 5.6/5.4. -->
-    <httpclient5.version>5.6</httpclient5.version>
-    <httpcore5.version>5.4</httpcore5.version>
+    <httpclient5.version>5.6.1</httpclient5.version>
+    <httpcore5.version>5.4.2</httpcore5.version>
     <mapstruct.version>1.6.3</mapstruct.version>
     <apache-commons-io.version>2.22.0</apache-commons-io.version>
     <apache-commons-collections.version>4.5.0</apache-commons-collections.version>


### PR DESCRIPTION
### Purpose
Missing critical step in authentication in Apache HttpClient 5.6 allows an attacker to cause the client to accept SCRAM-SHA-256 authentication without proper mutual authentication verification.

### Approach
- bump httpclient5 to 5.6.1 and httpcore5 to 5.4.2 to fix CVE-2026-40542 mutual authentication bypass

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-1208](https://folio-org.atlassian.net/browse/MSEARCH-1208)
