### PR TITLE
Release v6.0.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## v6.0.2 2026-05-21
+### Bug fixes
+* Add retry for search operations ([MSEARCH-1194](https://folio-org.atlassian.net/browse/MSEARCH-1194))
+* Limit consortium search api calls to Elasticsearch to SEARCH_CONSORTIUM_RECORDS_PAGE_SIZE per request ([MSEARCH-1194](https://folio-org.atlassian.net/browse/MSEARCH-1194))
+* Bump httpclient5 to 5.6.1 and httpcore5 to 5.4.2 to fix CVE-2026-40542 mutual authentication bypass ([MSEARCH-1208](https://folio-org.atlassian.net/browse/MSEARCH-1208))
+
 ## v6.0.1 2026-05-15
 ### Bug fixes
 * Skip background processing on BadSqlGrammarException ([MSEARCH-1214](https://folio-org.atlassian.net/browse/MSEARCH-1214))

--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,8 @@
     <folio-isbn-utils.version>1.9.0</folio-isbn-utils.version>
     <folio-cql2pgjson.version>36.0.0</folio-cql2pgjson.version>
     <opensearch.version>3.6.0</opensearch.version>
-    <!-- opensearch-rest-client:3.5.0 removed manual gzip decompression relying on httpclient5 5.6's
-         automatic async decompression. Spring Boot 4.x manages older versions, so we pin to 5.6/5.4. -->
-    <httpclient5.version>5.6</httpclient5.version>
-    <httpcore5.version>5.4</httpcore5.version>
+    <httpclient5.version>5.6.1</httpclient5.version>
+    <httpcore5.version>5.4.2</httpcore5.version>
     <mapstruct.version>1.6.3</mapstruct.version>
     <apache-commons-io.version>2.21.0</apache-commons-io.version>
     <apache-commons-collections.version>4.5.0</apache-commons-collections.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <name>mod-search</name>
   <groupId>org.folio</groupId>
   <artifactId>mod-search</artifactId>
-  <version>6.0.2</version>
+  <version>6.0.3-SNAPSHOT</version>
   <description>FOLIO search service</description>
   <packaging>jar</packaging>
 
@@ -664,7 +664,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>v6.0.2</tag>
+    <tag>release/v6.0</tag>
   </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <name>mod-search</name>
   <groupId>org.folio</groupId>
   <artifactId>mod-search</artifactId>
-  <version>6.0.2-SNAPSHOT</version>
+  <version>6.0.2</version>
   <description>FOLIO search service</description>
   <packaging>jar</packaging>
 
@@ -664,7 +664,7 @@
     <url>https://github.com/folio-org/${project.artifactId}</url>
     <connection>scm:git:git://github.com/folio-org/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/${project.artifactId}.git</developerConnection>
-    <tag>release/v6.0</tag>
+    <tag>v6.0.2</tag>
   </scm>
 
 </project>

--- a/src/main/java/org/folio/search/configuration/OpensearchRestClientConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/OpensearchRestClientConfiguration.java
@@ -156,6 +156,7 @@ public class OpensearchRestClientConfiguration {
         .to(timeout -> builder.setConnectTimeout(Timeout.ofMilliseconds(timeout)));
       MAPPER.from(this.properties::getSocketTimeout).asInt(Duration::toMillis)
         .to(timeout -> builder.setSocketTimeout(Timeout.ofMilliseconds(timeout)));
+      builder.setValidateAfterInactivity(Timeout.ofSeconds(5));
       return builder.build();
     }
 

--- a/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
@@ -3,7 +3,9 @@ package org.folio.search.configuration;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.apache.hc.core5.http.ConnectionClosedException;
 import org.apache.logging.log4j.message.FormattedMessage;
+import org.folio.search.configuration.properties.OpensearchProperties;
 import org.folio.search.configuration.properties.ReindexConfigurationProperties;
 import org.folio.search.configuration.properties.StreamIdsProperties;
 import org.folio.search.exception.FolioIntegrationException;
@@ -25,6 +27,7 @@ public class RetryTemplateConfiguration {
 
   public static final String KAFKA_RETRY_TEMPLATE_NAME = "kafkaMessageListenerRetryTemplate";
   public static final String STREAM_IDS_RETRY_TEMPLATE_NAME = "streamIdsRetryTemplate";
+  public static final String SEARCH_RETRY_TEMPLATE_NAME = "searchRetryTemplate";
   public static final String REINDEX_PUBLISH_RANGE_RETRY_TEMPLATE_NAME = "reindexPublishRangeRetryTemplate";
 
   /**
@@ -52,6 +55,15 @@ public class RetryTemplateConfiguration {
       .build());
   }
 
+  @Bean(name = SEARCH_RETRY_TEMPLATE_NAME)
+  public RetryTemplate searchRetryTemplate(OpensearchProperties properties) {
+    return new RetryTemplate(RetryPolicy.builder()
+      .maxRetries(properties.getSearchRetryAttempts())
+      .delay(Duration.ofMillis(properties.getSearchRetryIntervalMs()))
+      .predicate(RetryTemplateConfiguration::isConnectionClosedException)
+      .build());
+  }
+
   @ConditionalOnBean(ReindexConfigurationProperties.class)
   @Bean(name = REINDEX_PUBLISH_RANGE_RETRY_TEMPLATE_NAME)
   public RetryTemplate reindexPublishRangeRetryTemplate(ReindexConfigurationProperties properties) {
@@ -70,5 +82,16 @@ public class RetryTemplateConfiguration {
       }
     });
     return retryTemplate;
+  }
+
+  private static boolean isConnectionClosedException(Throwable throwable) {
+    var cause = throwable;
+    while (cause != null) {
+      if (cause instanceof ConnectionClosedException) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    return false;
   }
 }

--- a/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
+++ b/src/main/java/org/folio/search/configuration/RetryTemplateConfiguration.java
@@ -57,11 +57,22 @@ public class RetryTemplateConfiguration {
 
   @Bean(name = SEARCH_RETRY_TEMPLATE_NAME)
   public RetryTemplate searchRetryTemplate(OpensearchProperties properties) {
-    return new RetryTemplate(RetryPolicy.builder()
+    var retryTemplate =  new RetryTemplate(RetryPolicy.builder()
       .maxRetries(properties.getSearchRetryAttempts())
       .delay(Duration.ofMillis(properties.getSearchRetryIntervalMs()))
       .predicate(RetryTemplateConfiguration::isConnectionClosedException)
       .build());
+    retryTemplate.setRetryListener(new RetryListener() {
+      @Override
+      public void onRetryPolicyExhaustion(@NonNull RetryPolicy retryPolicy,
+                                          @NonNull Retryable<?> retryable,
+                                          @NonNull RetryException exception) {
+        var lastThrowable = exception.getLastException();
+        log.warn(new FormattedMessage("Failed to execute search"), lastThrowable);
+        throw new FolioIntegrationException("Failed to execute search after all retries", lastThrowable);
+      }
+    });
+    return retryTemplate;
   }
 
   @ConditionalOnBean(ReindexConfigurationProperties.class)

--- a/src/main/java/org/folio/search/configuration/properties/OpensearchProperties.java
+++ b/src/main/java/org/folio/search/configuration/properties/OpensearchProperties.java
@@ -42,4 +42,14 @@ public class OpensearchProperties {
   private String pathPrefix;
 
   private boolean compressionEnabled = true;
+
+  /**
+   * Specifies the number of retry attempts for search requests on transient connection errors.
+   */
+  private int searchRetryAttempts = 3;
+
+  /**
+   * Specifies time in milliseconds to wait before reattempting a failed search request.
+   */
+  private long searchRetryIntervalMs = 500;
 }

--- a/src/main/java/org/folio/search/repository/SearchRepository.java
+++ b/src/main/java/org/folio/search/repository/SearchRepository.java
@@ -2,6 +2,7 @@ package org.folio.search.repository;
 
 import static java.util.Arrays.stream;
 import static org.apache.commons.lang3.ArrayUtils.isNotEmpty;
+import static org.folio.search.configuration.RetryTemplateConfiguration.SEARCH_RETRY_TEMPLATE_NAME;
 import static org.folio.search.configuration.RetryTemplateConfiguration.STREAM_IDS_RETRY_TEMPLATE_NAME;
 import static org.folio.search.utils.CollectionUtils.anyMatch;
 import static org.folio.search.utils.CollectionUtils.getValuesByPath;
@@ -49,6 +50,8 @@ public class SearchRepository {
   private final RestHighLevelClient client;
   @Qualifier(value = STREAM_IDS_RETRY_TEMPLATE_NAME)
   private final RetryTemplate retryTemplate;
+  @Qualifier(value = SEARCH_RETRY_TEMPLATE_NAME)
+  private final RetryTemplate searchRetryTemplate;
   private final IndexNameProvider indexNameProvider;
 
   public String analyze(String text, String field, ResourceType resource, String tenantId) {
@@ -72,7 +75,8 @@ public class SearchRepository {
   public SearchResponse search(ResourceRequest resourceRequest, SearchSourceBuilder searchSource) {
     var index = indexNameProvider.getIndexName(resourceRequest);
     var searchRequest = buildSearchRequest(index, searchSource);
-    return performExceptionalOperation(() -> client.search(searchRequest, DEFAULT), index, SEARCH_OPERATION_TYPE);
+    return searchRetryTemplate.invoke(
+      () -> performExceptionalOperation(() -> client.search(searchRequest, DEFAULT), index, SEARCH_OPERATION_TYPE));
   }
 
   /**
@@ -86,7 +90,8 @@ public class SearchRepository {
   public SearchResponse search(ResourceRequest resourceRequest, SearchSourceBuilder searchSource, String preference) {
     var index = indexNameProvider.getIndexName(resourceRequest);
     var searchRequest = buildSearchRequest(index, searchSource, preference);
-    return performExceptionalOperation(() -> client.search(searchRequest, DEFAULT), index, SEARCH_OPERATION_TYPE);
+    return searchRetryTemplate.invoke(
+      () -> performExceptionalOperation(() -> client.search(searchRequest, DEFAULT), index, SEARCH_OPERATION_TYPE));
   }
 
   /**
@@ -100,7 +105,8 @@ public class SearchRepository {
     var index = indexNameProvider.getIndexName(resourceRequest);
     var request = new MultiSearchRequest();
     searchSources.forEach(source -> request.add(buildSearchRequest(index, source)));
-    var response = performExceptionalOperation(() -> client.msearch(request, DEFAULT), index, "multiSearchApi");
+    var response = searchRetryTemplate.invoke(
+      () -> performExceptionalOperation(() -> client.msearch(request, DEFAULT), index, "multiSearchApi"));
 
     if (isFailedMultiSearchRequest(response.getResponses(), searchSources.size())) {
       var failureMessages = stream(response.getResponses())

--- a/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceSearchService.java
+++ b/src/main/java/org/folio/search/service/consortium/ConsortiumInstanceSearchService.java
@@ -4,7 +4,6 @@ import static org.apache.commons.collections4.CollectionUtils.containsAny;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.folio.search.converter.ConsortiumHoldingMapper.toConsortiumHolding;
 import static org.folio.search.converter.ConsortiumItemMapper.toConsortiumItem;
-import static org.folio.search.service.SearchService.DEFAULT_MAX_SEARCH_RESULT_WINDOW;
 import static org.folio.search.utils.IdentifierUtils.getHoldingIdentifierValue;
 import static org.folio.search.utils.IdentifierUtils.getHoldingTargetField;
 import static org.folio.search.utils.IdentifierUtils.getItemIdentifierValue;
@@ -145,7 +144,7 @@ public class ConsortiumInstanceSearchService {
       .build();
     var termsQuery = termsQuery(targetField, identifierValues);
 
-    if (identifierValues.size() < DEFAULT_MAX_SEARCH_RESULT_WINDOW) {
+    if (identifierValues.size() <= properties.getSearchConsortiumRecordsPageSize()) {
       return executeSearch(request, termsQuery, recordMapper, identifierType, identifierValues);
     }
 
@@ -161,7 +160,7 @@ public class ConsortiumInstanceSearchService {
     Mapper<Instance, IdentifierTypeEnum, Set<String>, List<T>> recordMapper,
     IdentifierTypeEnum identifierType,
     Set<String> identifierValues) {
-    var searchSourceBuilder = queryBuilder(query, SearchService.DEFAULT_MAX_SEARCH_RESULT_WINDOW);
+    var searchSourceBuilder = queryBuilder(query, properties.getSearchConsortiumRecordsPageSize());
     var response = searchRepository.search(request, searchSourceBuilder);
     var searchResult = documentConverter.convertToSearchResult(response, request.resourceClass(),
       (hits, item) -> recordMapper.apply(item, identifierType, identifierValues));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
     password: ${ELASTICSEARCH_PASSWORD:}
     uris: ${ELASTICSEARCH_URL:http://localhost:9200}
     compression-enabled: ${ELASTICSEARCH_COMPRESSION_ENABLED:true}
+    search-retry-attempts: ${OPENSEARCH_SEARCH_RETRY_ATTEMPTS:3}
+    search-retry-interval-ms: ${OPENSEARCH_SEARCH_RETRY_INTERVAL_MS:500}
     elasticsearch-server: ${ELASTICSEARCH_SERVER:false}
   kafka:
     bootstrap-servers: ${KAFKA_HOST:localhost}:${KAFKA_PORT:9092}

--- a/src/test/java/org/folio/search/configuration/RetryTemplateConfigurationTest.java
+++ b/src/test/java/org/folio/search/configuration/RetryTemplateConfigurationTest.java
@@ -1,8 +1,12 @@
 package org.folio.search.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.hc.core5.http.ConnectionClosedException;
+import org.folio.search.configuration.properties.OpensearchProperties;
 import org.folio.search.configuration.properties.ReindexConfigurationProperties;
 import org.folio.search.configuration.properties.StreamIdsProperties;
 import org.folio.spring.testing.type.UnitTest;
@@ -12,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.retry.RetryException;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -48,5 +53,57 @@ class RetryTemplateConfigurationTest {
     when(reindexConfigurationProperties.getMergeRangePublisherRetryIntervalMs()).thenReturn(200L);
     var actual = configuration.reindexPublishRangeRetryTemplate(reindexConfigurationProperties);
     assertThat(actual).isNotNull();
+  }
+
+  @Test
+  void searchRetryTemplate_connectionClosedException_retries() {
+    var properties = new OpensearchProperties();
+    properties.setSearchRetryAttempts(3);
+    properties.setSearchRetryIntervalMs(1);
+
+    var retryTemplate = configuration.searchRetryTemplate(properties);
+    var attempts = new AtomicInteger();
+
+    assertThatThrownBy(() -> retryTemplate.execute(() -> {
+      attempts.incrementAndGet();
+      throw new ConnectionClosedException("closed");
+    })).isInstanceOf(RetryException.class);
+
+    assertThat(attempts.get()).isGreaterThan(1);
+  }
+
+  @Test
+  void searchRetryTemplate_wrappedConnectionClosedException_retries() {
+    var properties = new OpensearchProperties();
+    properties.setSearchRetryAttempts(3);
+    properties.setSearchRetryIntervalMs(1);
+
+    var retryTemplate = configuration.searchRetryTemplate(properties);
+    var attempts = new AtomicInteger();
+
+    assertThatThrownBy(() -> retryTemplate.execute(() -> {
+      attempts.incrementAndGet();
+      throw new RuntimeException(new ConnectionClosedException("closed"));
+    })).isInstanceOf(RetryException.class)
+      .hasRootCauseInstanceOf(ConnectionClosedException.class);
+
+    assertThat(attempts.get()).isGreaterThan(1);
+  }
+
+  @Test
+  void searchRetryTemplate_otherException_doesNotRetry() {
+    var properties = new OpensearchProperties();
+    properties.setSearchRetryAttempts(3);
+    properties.setSearchRetryIntervalMs(1);
+
+    var retryTemplate = configuration.searchRetryTemplate(properties);
+    var attempts = new AtomicInteger();
+
+    assertThatThrownBy(() -> retryTemplate.execute(() -> {
+      attempts.incrementAndGet();
+      throw new IllegalStateException("boom");
+    })).isInstanceOf(RetryException.class);
+
+    assertThat(attempts.get()).isEqualTo(1);
   }
 }

--- a/src/test/java/org/folio/search/configuration/RetryTemplateConfigurationTest.java
+++ b/src/test/java/org/folio/search/configuration/RetryTemplateConfigurationTest.java
@@ -9,6 +9,7 @@ import org.apache.hc.core5.http.ConnectionClosedException;
 import org.folio.search.configuration.properties.OpensearchProperties;
 import org.folio.search.configuration.properties.ReindexConfigurationProperties;
 import org.folio.search.configuration.properties.StreamIdsProperties;
+import org.folio.search.exception.FolioIntegrationException;
 import org.folio.spring.testing.type.UnitTest;
 import org.folio.spring.tools.kafka.FolioKafkaProperties;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.retry.RetryException;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -67,7 +67,7 @@ class RetryTemplateConfigurationTest {
     assertThatThrownBy(() -> retryTemplate.execute(() -> {
       attempts.incrementAndGet();
       throw new ConnectionClosedException("closed");
-    })).isInstanceOf(RetryException.class);
+    })).isInstanceOf(FolioIntegrationException.class);
 
     assertThat(attempts.get()).isGreaterThan(1);
   }
@@ -84,7 +84,7 @@ class RetryTemplateConfigurationTest {
     assertThatThrownBy(() -> retryTemplate.execute(() -> {
       attempts.incrementAndGet();
       throw new RuntimeException(new ConnectionClosedException("closed"));
-    })).isInstanceOf(RetryException.class)
+    })).isInstanceOf(FolioIntegrationException.class)
       .hasRootCauseInstanceOf(ConnectionClosedException.class);
 
     assertThat(attempts.get()).isGreaterThan(1);
@@ -102,7 +102,7 @@ class RetryTemplateConfigurationTest {
     assertThatThrownBy(() -> retryTemplate.execute(() -> {
       attempts.incrementAndGet();
       throw new IllegalStateException("boom");
-    })).isInstanceOf(RetryException.class);
+    })).isInstanceOf(FolioIntegrationException.class);
 
     assertThat(attempts.get()).isEqualTo(1);
   }

--- a/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
+++ b/src/test/java/org/folio/search/integration/KafkaMessageListenerIT.java
@@ -34,6 +34,7 @@ import org.folio.search.configuration.RetryTemplateConfiguration;
 import org.folio.search.configuration.kafka.InstanceResourceEventKafkaConfiguration;
 import org.folio.search.configuration.kafka.InstanceSharingCompleteEventKafkaConfiguration;
 import org.folio.search.configuration.kafka.ResourceEventKafkaConfiguration;
+import org.folio.search.configuration.properties.OpensearchProperties;
 import org.folio.search.domain.dto.ResourceEvent;
 import org.folio.search.integration.KafkaMessageListenerIT.KafkaListenerTestConfiguration;
 import org.folio.search.integration.message.FolioMessageBatchProcessor;
@@ -85,7 +86,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 @Import({KafkaListenerTestConfiguration.class, DefaultErrorHandler.class})
 @ExtendWith(MockitoExtension.class)
 @SpringBootTest(
-  classes = {KafkaMessageListener.class, FolioKafkaProperties.class, InstanceEventMapper.class},
+  classes = {
+    KafkaMessageListener.class,
+    FolioKafkaProperties.class,
+    InstanceEventMapper.class,
+    OpensearchProperties.class
+  },
   properties = {
     "ENV=kafka-listener-it",
     "folio.environment=${ENV:kafka-listener-it}",

--- a/src/test/java/org/folio/search/integration/folio/InventoryServiceTest.java
+++ b/src/test/java/org/folio/search/integration/folio/InventoryServiceTest.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import org.folio.search.client.InventoryInstanceClient;
 import org.folio.search.client.InventoryReindexRecordsClient;
 import org.folio.search.configuration.RetryTemplateConfiguration;
+import org.folio.search.configuration.properties.OpensearchProperties;
 import org.folio.search.configuration.properties.ReindexConfigurationProperties;
 import org.folio.search.configuration.properties.StreamIdsProperties;
 import org.folio.search.exception.FolioIntegrationException;
@@ -37,7 +38,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @UnitTest
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {InventoryService.class, RetryTemplateConfiguration.class, FolioKafkaProperties.class,
-                                 StreamIdsProperties.class, ReindexConfigurationProperties.class})
+                                 StreamIdsProperties.class, ReindexConfigurationProperties.class,
+                                 OpensearchProperties.class})
 class InventoryServiceTest {
 
   @MockitoBean

--- a/src/test/java/org/folio/search/repository/SearchRepositoryTest.java
+++ b/src/test/java/org/folio/search/repository/SearchRepositoryTest.java
@@ -39,7 +39,6 @@ import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.action.search.ClearScrollRequest;
@@ -65,7 +64,6 @@ class SearchRepositoryTest {
   private static final String SCROLL_ID = randomId();
   private static final TimeValue KEEP_ALIVE_INTERVAL = TimeValue.timeValueMinutes(1L);
 
-  @InjectMocks
   private SearchRepository searchRepository;
   @Mock
   private RestHighLevelClient esClient;
@@ -74,12 +72,18 @@ class SearchRepositoryTest {
   @Mock
   private RetryTemplate retryTemplate;
   @Mock
+  private RetryTemplate searchRetryTemplate;
+  @Mock
   private IndexNameProvider indexNameProvider;
 
+  @SuppressWarnings({"rawtypes", "unchecked"})
   @BeforeEach
   void setUp() {
+    searchRepository = new SearchRepository(esClient, retryTemplate, searchRetryTemplate, indexNameProvider);
     lenient().when(indexNameProvider.getIndexName(any(ResourceRequest.class)))
       .thenAnswer(invocation -> SearchUtils.getIndexName(invocation.<ResourceRequest>getArgument(0)));
+    lenient().when(searchRetryTemplate.invoke(any(Supplier.class)))
+      .thenAnswer(invocation -> invocation.<Supplier>getArgument(0).get());
   }
 
   @Test

--- a/src/test/java/org/folio/search/service/consortium/ConsortiumInstanceSearchServiceTest.java
+++ b/src/test/java/org/folio/search/service/consortium/ConsortiumInstanceSearchServiceTest.java
@@ -195,14 +195,16 @@ class ConsortiumInstanceSearchServiceTest {
 
   @Test
   void fetchConsortiumBatchHoldings_positive_notExceedsSearchResultWindow() {
+    when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
+    when(properties.getSearchConsortiumRecordsPageSize()).thenReturn(10);
+    when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
+      .thenReturn(mock(SearchResponse.class));
+
     var ids = List.of(randomUUID().toString(), randomUUID().toString());
     var expectedConsortiumHoldings = List.of(
       toConsortiumHolding(randomUUID().toString(), holding(ids.get(0), MEMBER_TENANT_ID)),
       toConsortiumHolding(randomUUID().toString(), holding(ids.get(1), CENTRAL_TENANT_ID))
     );
-    when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
-    when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
-      .thenReturn(mock(SearchResponse.class));
     mockConvertion(any(SearchResponse.class), List.of(expectedConsortiumHoldings));
     var expected = holdingCollection(expectedConsortiumHoldings);
 
@@ -237,6 +239,7 @@ class ConsortiumInstanceSearchServiceTest {
   @Test
   void fetchConsortiumBatchHoldings_positive_noRecordsFound() {
     when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
+    when(properties.getSearchConsortiumRecordsPageSize()).thenReturn(10);
     when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
       .thenReturn(mock(SearchResponse.class));
     mockConvertion(any(SearchResponse.class), Collections.emptyList());
@@ -266,14 +269,16 @@ class ConsortiumInstanceSearchServiceTest {
 
   @Test
   void fetchConsortiumBatchItems_positive_notExceedsSearchResultWindow() {
+    when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
+    when(properties.getSearchConsortiumRecordsPageSize()).thenReturn(10);
+    when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
+      .thenReturn(mock(SearchResponse.class));
+
     var ids = List.of(randomUUID().toString(), randomUUID().toString());
     var expectedConsortiumItems = List.of(
       toConsortiumItem(randomUUID().toString(), item(ids.get(0), MEMBER_TENANT_ID)),
       toConsortiumItem(randomUUID().toString(), item(ids.get(1), CENTRAL_TENANT_ID))
     );
-    when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
-    when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
-      .thenReturn(mock(SearchResponse.class));
     mockConvertion(any(SearchResponse.class), List.of(expectedConsortiumItems));
     var expected = itemCollection(expectedConsortiumItems);
 
@@ -308,6 +313,7 @@ class ConsortiumInstanceSearchServiceTest {
   @Test
   void fetchConsortiumBatchItems_positive_noRecordsFound() {
     when(properties.getMaxSearchBatchRequestIdsCount()).thenReturn(10L);
+    when(properties.getSearchConsortiumRecordsPageSize()).thenReturn(10);
     when(searchRepository.search(any(CqlSearchRequest.class), any(SearchSourceBuilder.class)))
       .thenReturn(mock(SearchResponse.class));
     mockConvertion(any(SearchResponse.class), Collections.emptyList());


### PR DESCRIPTION
### Purpose
Release v6.0.2

### Bug fixes
* Add retry for search operations ([MSEARCH-1194](https://folio-org.atlassian.net/browse/MSEARCH-1194))
* Limit consortium search api calls to Elasticsearch to SEARCH_CONSORTIUM_RECORDS_PAGE_SIZE per request ([MSEARCH-1194](https://folio-org.atlassian.net/browse/MSEARCH-1194))
* Bump httpclient5 to 5.6.1 and httpcore5 to 5.4.2 to fix CVE-2026-40542 mutual authentication bypass ([MSEARCH-1208](https://folio-org.atlassian.net/browse/MSEARCH-1208))

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-1221](https://folio-org.atlassian.net/browse/MSEARCH-1221)
