### PR TITLE
fix(reindex): Fix background sub-resource processing running during reindex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Disable JVM container support to avoid cgroup v2 NullPointerException in Elasticsearch8  testcontainer ([MSEARCH-1209](https://folio-org.atlassian.net/browse/MSEARCH-1209))
 * Limit consortium search api calls to Elasticsearch to SEARCH_CONSORTIUM_RECORDS_PAGE_SIZE per request ([MSEARCH-1194](https://folio-org.atlassian.net/browse/MSEARCH-1194))
 * Bump httpclient5 to 5.6.1 and httpcore5 to 5.4.2 to fix CVE-2026-40542 mutual authentication bypass ([MSEARCH-1208](https://folio-org.atlassian.net/browse/MSEARCH-1208))
+* Move reindex sub-resource locks acquisition from trigger to code, add fencing tokens to scheduler-side unlock/refresh ([MSEARCH-1238](https://folio-org.atlassian.net/browse/MSEARCH-1238)
 
 ### Tech Dept
 * Adjust default configuration and improve parallelism for reindex ([MSEARCH-1236](https://folio-org.atlassian.net/browse/MSEARCH-1236))

--- a/src/main/java/org/folio/search/service/reindex/ReindexStatusService.java
+++ b/src/main/java/org/folio/search/service/reindex/ReindexStatusService.java
@@ -1,6 +1,7 @@
 package org.folio.search.service.reindex;
 
 import static java.util.Collections.singletonList;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.folio.search.configuration.SearchCacheNames.REINDEX_TARGET_TENANT_CACHE;
 
@@ -18,6 +19,8 @@ import org.folio.search.model.types.ReindexEntityType;
 import org.folio.search.model.types.ReindexStatus;
 import org.folio.search.service.consortium.ConsortiumTenantProvider;
 import org.folio.search.service.reindex.jdbc.ReindexStatusRepository;
+import org.folio.search.service.reindex.jdbc.SubResourcesLockRepository;
+import org.folio.spring.FolioExecutionContext;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -31,6 +34,8 @@ public class ReindexStatusService {
   private final ReindexStatusRepository statusRepository;
   private final ReindexStatusMapper reindexStatusMapper;
   private final ConsortiumTenantProvider consortiumTenantProvider;
+  private final SubResourcesLockRepository subResourcesLockRepository;
+  private final FolioExecutionContext folioExecutionContext;
 
   public List<ReindexStatusItem> getReindexStatuses(String tenantId) {
     if (consortiumTenantProvider.isMemberTenant(tenantId)) {
@@ -57,6 +62,15 @@ public class ReindexStatusService {
     statusRepository.truncate();
     statusRepository.recreateReindexStatusTrigger(isNotBlank(targetTenantId));
     statusRepository.saveReindexStatusRecords(statusRecords);
+    // For full (non-consortium-member) reindex, proactively acquire sub-resource locks before
+    // any ranges are processed so that background processing cannot race in during the gap
+    // between status creation and the first processed range. Consortium-member reindex must
+    // not touch the locks - background processing is expected to keep running there.
+    if (isBlank(targetTenantId)) {
+      log.info("recreateMergeStatusRecords:: force-locking sub-resources for full reindex [tenant: {}]",
+        folioExecutionContext.getTenantId());
+      subResourcesLockRepository.forceLockAllForReindex(folioExecutionContext.getTenantId());
+    }
   }
 
   @Transactional
@@ -129,21 +143,30 @@ public class ReindexStatusService {
   }
 
   /**
-   * Checks if any reindex operation is currently in progress or has failed, excluding operations
-   * scoped to a specific consortium member tenant (i.e. where targetTenantId is not null).
+   * Checks if any reindex operation is currently in progress, has failed, or is between phases,
+   * excluding operations scoped to a specific consortium member tenant
+   * (i.e. where targetTenantId is not null).
    *
-   * @return true if any entity type has a status of MERGE_IN_PROGRESS, UPLOAD_IN_PROGRESS, STAGING_IN_PROGRESS,
-   *     MERGE_FAILED, STAGING_FAILED or UPLOAD_FAILED and the operation is not scoped to a consortium member tenant
+   * <p>{@code MERGE_COMPLETED} is included for entity types that also support upload
+   * (currently only {@code INSTANCE}), because for those types it is a transient between-phases
+   * state: merge is done but the upload phase has not yet started. During this window the
+   * sub-resource lock is still held and must not be released as "stale", otherwise background
+   * processing could race in before the upload phase begins.
+   * For entity types without an upload phase (e.g. {@code ITEM}, {@code HOLDINGS}),
+   * {@code MERGE_COMPLETED} is a genuine terminal status and must not block stale-lock release.
+   *
+   * @return true if any entity type has a non-terminal, non-consortium-member-scoped status
    */
   public boolean isReindexInProgressOrFailedNotForConsortiumMember() {
     return statusRepository.getReindexStatuses().stream()
       .anyMatch(status -> status.getTargetTenantId() == null
-                          && (status.getStatus() == ReindexStatus.MERGE_IN_PROGRESS
-                              || status.getStatus() == ReindexStatus.UPLOAD_IN_PROGRESS
-                              || status.getStatus() == ReindexStatus.STAGING_IN_PROGRESS
-                              || status.getStatus() == ReindexStatus.MERGE_FAILED
-                              || status.getStatus() == ReindexStatus.STAGING_FAILED
-                              || status.getStatus() == ReindexStatus.UPLOAD_FAILED));
+        && (status.getStatus() == ReindexStatus.MERGE_IN_PROGRESS
+        || status.getStatus() == ReindexStatus.UPLOAD_IN_PROGRESS
+        || status.getStatus() == ReindexStatus.STAGING_IN_PROGRESS
+        || status.getStatus() == ReindexStatus.MERGE_FAILED
+        || status.getStatus() == ReindexStatus.STAGING_FAILED
+        || status.getStatus() == ReindexStatus.UPLOAD_FAILED
+        || status.getStatus() == ReindexStatus.MERGE_COMPLETED && status.getEntityType().isSupportsUpload()));
   }
 
   private List<ReindexStatusEntity> constructNewStatusRecords(List<ReindexEntityType> entityTypes,

--- a/src/main/java/org/folio/search/service/reindex/jdbc/SubResourcesLockRepository.java
+++ b/src/main/java/org/folio/search/service/reindex/jdbc/SubResourcesLockRepository.java
@@ -21,16 +21,24 @@ public class SubResourcesLockRepository {
     RETURNING last_updated_date
     """;
 
-  private static final String UNLOCK_SUB_RESOURCE_SQL = """
+  /**
+   * Scheduler-side unlock with fencing. Releases the lock only if {@code expectedLastUpdatedDate}
+   * still matches the row, so a lock taken over by a reindex via {@link #forceLockAllForReindex(String)}
+   * is not cleared by the scheduler.
+   */
+  private static final String UNLOCK_SUB_RESOURCE_FENCED_SQL = """
     UPDATE %s.sub_resources_lock
     SET locked_flag = FALSE, last_updated_date = ?
-    WHERE entity_type = ?
+    WHERE entity_type = ? AND last_updated_date = ?
     """;
 
-  private static final String UPDATE_LOCK_TIMESTAMP_SQL = """
+  /**
+   * Scheduler-side heartbeat with fencing semantics, see {@link #UNLOCK_SUB_RESOURCE_FENCED_SQL}.
+   */
+  private static final String UPDATE_LOCK_TIMESTAMP_FENCED_SQL = """
     UPDATE %s.sub_resources_lock
     SET last_updated_date = ?
-    WHERE entity_type = ? AND locked_flag = TRUE
+    WHERE entity_type = ? AND locked_flag = TRUE AND last_updated_date = ?
     """;
 
   private static final String RELEASE_STALE_LOCK_SQL = """
@@ -39,6 +47,15 @@ public class SubResourcesLockRepository {
     WHERE entity_type = ?
       AND locked_flag = TRUE
       AND last_updated_date < ?
+    """;
+
+  /**
+   * Reindex-side unconditional lock of all entity types. Bumps {@code last_updated_date}
+   * so any in-flight scheduler cycle holding a stale fencing token is preempted.
+   */
+  private static final String FORCE_LOCK_ALL_SUB_RESOURCES_SQL = """
+    UPDATE %s.sub_resources_lock
+    SET locked_flag = TRUE, last_updated_date = ?
     """;
 
   private final JdbcTemplate jdbcTemplate;
@@ -53,23 +70,40 @@ public class SubResourcesLockRepository {
     );
   }
 
-  public void unlockSubResource(ReindexEntityType entityType, Timestamp lastUpdatedDate, String tenantId) {
-
-    var formattedSql = formatSqlWithSchema(UNLOCK_SUB_RESOURCE_SQL, tenantId);
-    jdbcTemplate.update(formattedSql, lastUpdatedDate, entityType.getType());
+  /**
+   * Releases the lock from the scheduler side, but only if the row has not been
+   * preempted by a reindex (fencing token check on {@code expectedLastUpdatedDate}).
+   *
+   * @return {@code true} if the lock was released, {@code false} if it had been taken over
+   *     (typically by {@link #forceLockAllForReindex(String)} during a reindex).
+   */
+  public boolean unlockSubResourceFenced(ReindexEntityType entityType, Timestamp lastUpdatedDate, String tenantId,
+                                         Timestamp expectedLastUpdatedDate) {
+    var formattedSql = formatSqlWithSchema(UNLOCK_SUB_RESOURCE_FENCED_SQL, tenantId);
+    var rowsAffected = jdbcTemplate.update(formattedSql, lastUpdatedDate, entityType.getType(),
+      expectedLastUpdatedDate);
+    return rowsAffected > 0;
   }
 
   /**
-   * Updates the lock timestamp for a sub-resource without releasing the lock.
-   * This prevents the lock from appearing stale during long-running batch processing.
+   * Updates the lock timestamp for a sub-resource without releasing the lock, using a fencing
+   * token. This prevents the lock from appearing stale during long-running batch processing
+   * while also allowing the scheduler to detect preemption by a reindex
+   * (see {@link #forceLockAllForReindex(String)}).
    *
    * @param entityType the type of entity being processed
-   * @param lastUpdatedDate the timestamp to update in the lock record
+   * @param lastUpdatedDate the new timestamp to set
    * @param tenantId the tenant identifier
+   * @param expectedLastUpdatedDate the timestamp value the caller previously saw / wrote
+   * @return {@code true} if the timestamp was refreshed, {@code false} if the lock was
+   *     preempted (caller should abort its current cycle without releasing the lock).
    */
-  public void updateLockTimestamp(ReindexEntityType entityType, Timestamp lastUpdatedDate, String tenantId) {
-    var formattedSql = formatSqlWithSchema(UPDATE_LOCK_TIMESTAMP_SQL, tenantId);
-    jdbcTemplate.update(formattedSql, lastUpdatedDate, entityType.getType());
+  public boolean updateLockTimestampFenced(ReindexEntityType entityType, Timestamp lastUpdatedDate, String tenantId,
+                                           Timestamp expectedLastUpdatedDate) {
+    var formattedSql = formatSqlWithSchema(UPDATE_LOCK_TIMESTAMP_FENCED_SQL, tenantId);
+    var rowsAffected = jdbcTemplate.update(formattedSql, lastUpdatedDate, entityType.getType(),
+      expectedLastUpdatedDate);
+    return rowsAffected > 0;
   }
 
   /**
@@ -88,6 +122,18 @@ public class SubResourcesLockRepository {
 
     var rowsAffected = jdbcTemplate.update(formattedSql, entityType.getType(), staleThresholdTimestamp);
     return rowsAffected > 0;
+  }
+
+  /**
+   * Reindex-side: unconditionally locks all sub-resource rows for the given tenant and
+   * advances {@code last_updated_date}. The timestamp bump invalidates any fencing token
+   * held by an in-flight scheduler cycle so it will abort instead of clearing the lock.
+   *
+   * @param tenantId the tenant identifier
+   */
+  public void forceLockAllForReindex(String tenantId) {
+    var formattedSql = formatSqlWithSchema(FORCE_LOCK_ALL_SUB_RESOURCES_SQL, tenantId);
+    jdbcTemplate.update(formattedSql, new Timestamp(System.currentTimeMillis()));
   }
 
   private String formatSqlWithSchema(String sqlTemplate, String tenantId) {

--- a/src/main/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesService.java
+++ b/src/main/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesService.java
@@ -150,33 +150,51 @@ public class ScheduledInstanceSubResourcesService {
   }
 
   private void processSubResources(ReindexEntityType entityType, String tenant, Timestamp timestamp) {
-    SubResourceResult result = null;
-    String lastId = null;
-    Timestamp lastTimestamp = timestamp;
-
+    var loopResult = new ProcessingLoopResult();
     try {
-      do {
-        result = fetchSubResourceBatch(entityType, tenant, timestamp, lastId, lastTimestamp);
-
-        if (isEmptyResult(result)) {
-          break;
-        }
-
-        processBatch(entityType, tenant, result);
-
-        if (hasMoreBatches(result)) {
-          updateLockForNextBatch(entityType, tenant, result, lastTimestamp);
-          lastId = extractLastRecordId(result);
-          lastTimestamp = result.lastUpdateDate();
-        } else {
-          break;
-        }
-      } while (result.hasRecords());
+      runProcessingLoop(entityType, tenant, timestamp, loopResult);
     } catch (Exception e) {
       log.error("processSubResources::Error processing {} entities", entityType, e);
     } finally {
-      releaseProcessingLock(entityType, tenant, timestamp, result);
+      if (!loopResult.preempted) {
+        releaseProcessingLock(entityType, tenant, timestamp, loopResult.lastResult, loopResult.fencingToken);
+      }
     }
+  }
+
+  private void runProcessingLoop(ReindexEntityType entityType, String tenant, Timestamp timestamp,
+                                 ProcessingLoopResult loopResult) {
+    String lastId = null;
+    Timestamp lastTimestamp = timestamp;
+    loopResult.fencingToken = timestamp;
+
+    do {
+      loopResult.lastResult = fetchSubResourceBatch(entityType, tenant, timestamp, lastId, lastTimestamp);
+      if (isEmptyResult(loopResult.lastResult)) {
+        return;
+      }
+      processBatch(entityType, tenant, loopResult.lastResult);
+      if (!hasMoreBatches(loopResult.lastResult)
+          || !refreshFencingToken(entityType, tenant, lastTimestamp, loopResult)) {
+        return;
+      }
+      lastId = extractLastRecordId(loopResult.lastResult);
+      lastTimestamp = loopResult.lastResult.lastUpdateDate();
+    } while (loopResult.lastResult.hasRecords());
+  }
+
+  private boolean refreshFencingToken(ReindexEntityType entityType, String tenant, Timestamp lastTimestamp,
+                                      ProcessingLoopResult loopResult) {
+    var newToken = updateLockForNextBatch(entityType, tenant, loopResult.lastResult, lastTimestamp,
+      loopResult.fencingToken);
+    if (newToken == null) {
+      log.warn("processSubResources::Lock for entity type {} in tenant {} was preempted "
+               + "(reindex started). Aborting current cycle.", entityType, tenant);
+      loopResult.preempted = true;
+      return false;
+    }
+    loopResult.fencingToken = newToken;
+    return true;
   }
 
   private boolean isEmptyResult(SubResourceResult result) {
@@ -204,10 +222,13 @@ public class ScheduledInstanceSubResourcesService {
     return result.records().size() == subResourceBatchSize;
   }
 
-  private void updateLockForNextBatch(ReindexEntityType entityType, String tenant,
-                                      SubResourceResult result, Timestamp lastTimestamp) {
+  private Timestamp updateLockForNextBatch(ReindexEntityType entityType, String tenant,
+                                           SubResourceResult result, Timestamp lastTimestamp,
+                                           Timestamp fencingToken) {
     var currentTimestamp = result.lastUpdateDate() != null ? result.lastUpdateDate() : lastTimestamp;
-    subResourcesLockRepository.updateLockTimestamp(entityType, currentTimestamp, tenant);
+    var refreshed = subResourcesLockRepository.updateLockTimestampFenced(entityType, currentTimestamp, tenant,
+      fencingToken);
+    return refreshed ? currentTimestamp : null;
   }
 
   private String extractLastRecordId(SubResourceResult result) {
@@ -216,9 +237,14 @@ public class ScheduledInstanceSubResourcesService {
   }
 
   private void releaseProcessingLock(ReindexEntityType entityType, String tenant,
-                                     Timestamp timestamp, SubResourceResult result) {
+                                     Timestamp timestamp, SubResourceResult result, Timestamp fencingToken) {
     var lastUpdatedDate = determineLastUpdatedDate(timestamp, result);
-    subResourcesLockRepository.unlockSubResource(entityType, lastUpdatedDate, tenant);
+    var released = subResourcesLockRepository.unlockSubResourceFenced(entityType, lastUpdatedDate, tenant,
+      fencingToken);
+    if (!released) {
+      log.warn("releaseProcessingLock::Lock for entity type {} in tenant {} was preempted "
+               + "(reindex started). Skipping unlock.", entityType, tenant);
+    }
   }
 
   private Timestamp determineLastUpdatedDate(Timestamp timestamp, SubResourceResult result) {
@@ -338,5 +364,16 @@ public class ScheduledInstanceSubResourcesService {
       .resourceName(ReindexConstants.RESOURCE_NAME_MAP.get(entityType).getName())
       ._new(instancesEmpty ? null : map)
       .tenant(tenant);
+  }
+
+  private static final class ProcessingLoopResult {
+    private SubResourceResult lastResult;
+    /**
+     * The last {@code last_updated_date} value the scheduler believes is stored in the row.
+     * Used by scheduler-side lock writes to detect preemption by a reindex
+     * ({@code forceLockAllForReindex} bumps the timestamp so this token goes stale).
+     */
+    private Timestamp fencingToken;
+    private boolean preempted;
   }
 }

--- a/src/main/resources/changelog/changelog-master.xml
+++ b/src/main/resources/changelog/changelog-master.xml
@@ -25,4 +25,5 @@
   <include file="changes/v6.0/add_staging_time_columns_to_reindex_status.xml" relativeToChangelogFile="true"/>
   <include file="changes/v6.0/create_consortium_member_reindex_status_function.xml" relativeToChangelogFile="true"/>
   <include file="changes/v6.0/add-trace-id-range-column.xml" relativeToChangelogFile="true"/>
+  <include file="changes/v6.0/update-reindex-status-trigger-v4.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog/changes/v6.0/sql/update-reindex-status-trigger-v4.sql
+++ b/src/main/resources/changelog/changes/v6.0/sql/update-reindex-status-trigger-v4.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE FUNCTION update_reindex_status_trigger()
+    RETURNS TRIGGER AS
+$$
+BEGIN
+    -- update status and end time for merge
+    IF OLD.status IN ('MERGE_IN_PROGRESS', 'MERGE_FAILED') and NEW.total_merge_ranges = NEW.processed_merge_ranges
+    THEN
+        NEW.status = 'MERGE_COMPLETED';
+        NEW.end_time_merge = current_timestamp;
+        IF OLD.entity_type = 'ITEM' THEN
+            UPDATE sub_resources_lock
+            SET last_updated_date = current_timestamp, locked_flag = FALSE
+            WHERE entity_type = 'item';
+        END IF;
+    ELSE
+        -- update status and end time for upload
+        IF OLD.status IN ('UPLOAD_IN_PROGRESS', 'UPLOAD_FAILED') and NEW.total_upload_ranges = NEW.processed_upload_ranges
+        THEN
+            NEW.status = 'UPLOAD_COMPLETED';
+            NEW.end_time_upload = current_timestamp;
+            UPDATE sub_resources_lock
+            SET last_updated_date = current_timestamp, locked_flag = FALSE
+            WHERE entity_type = lower(OLD.entity_type);
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS reindex_status_updated_trigger ON reindex_status CASCADE;
+CREATE TRIGGER reindex_status_updated_trigger
+    BEFORE UPDATE OF processed_merge_ranges, processed_upload_ranges
+    ON reindex_status
+    FOR EACH ROW
+EXECUTE FUNCTION update_reindex_status_trigger();
+

--- a/src/main/resources/changelog/changes/v6.0/update-reindex-status-trigger-v4.xml
+++ b/src/main/resources/changelog/changes/v6.0/update-reindex-status-trigger-v4.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
+
+  <changeSet id="MSEARCH-1238@@update-reindex-status-trigger-v4" author="viacheslav_kolesnyk">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="reindex_status"/>
+      <tableExists tableName="sub_resources_lock"/>
+    </preConditions>
+
+    <comment>
+      Remove proactive lock acquisition from the reindex status trigger. Sub-resource locks are now
+      acquired explicitly from Java at reindex phase boundaries; the trigger keeps only the
+      unlock-on-completion behavior alongside the existing status/timestamp updates.
+    </comment>
+
+    <sqlFile path="sql/update-reindex-status-trigger-v4.sql" relativeToChangelogFile="true" splitStatements="false"/>
+  </changeSet>
+
+</databaseChangeLog>
+

--- a/src/test/java/org/folio/api/SearchBrowseSuiteIT.java
+++ b/src/test/java/org/folio/api/SearchBrowseSuiteIT.java
@@ -204,10 +204,10 @@ class SearchBrowseSuiteIT extends BaseIntegrationTest {
 
     @Override
     public void unlockAll() {
-      lockRepo.unlockSubResource(ReindexEntityType.CALL_NUMBER, cnLock, TENANT_ID);
-      lockRepo.unlockSubResource(ReindexEntityType.CONTRIBUTOR, contribLock, TENANT_ID);
-      lockRepo.unlockSubResource(ReindexEntityType.CLASSIFICATION, classifLock, TENANT_ID);
-      lockRepo.unlockSubResource(ReindexEntityType.SUBJECT, subjLock, TENANT_ID);
+      lockRepo.unlockSubResourceFenced(ReindexEntityType.CALL_NUMBER, cnLock, TENANT_ID, cnLock);
+      lockRepo.unlockSubResourceFenced(ReindexEntityType.CONTRIBUTOR, contribLock, TENANT_ID, contribLock);
+      lockRepo.unlockSubResourceFenced(ReindexEntityType.CLASSIFICATION, classifLock, TENANT_ID, classifLock);
+      lockRepo.unlockSubResourceFenced(ReindexEntityType.SUBJECT, subjLock, TENANT_ID, subjLock);
     }
 
     private Timestamp lockOrFail(ReindexEntityType entityType) {

--- a/src/test/java/org/folio/api/browse/BrowseCallNumberConsortiumIT.java
+++ b/src/test/java/org/folio/api/browse/BrowseCallNumberConsortiumIT.java
@@ -97,9 +97,12 @@ class BrowseCallNumberConsortiumIT extends BaseConsortiumIntegrationTest {
     saveTestRecords();
 
     // Unlock all resources in reverse order
-    lockRepository.unlockSubResource(ReindexEntityType.INSTANCE, instanceTimestamp.get(), CENTRAL_TENANT_ID);
-    lockRepository.unlockSubResource(ReindexEntityType.ITEM, itemTimestamp.get(), CENTRAL_TENANT_ID);
-    lockRepository.unlockSubResource(ReindexEntityType.CALL_NUMBER, callNumberTimestamp.get(), CENTRAL_TENANT_ID);
+    lockRepository.unlockSubResourceFenced(
+      ReindexEntityType.INSTANCE, instanceTimestamp.get(), CENTRAL_TENANT_ID, instanceTimestamp.get());
+    lockRepository.unlockSubResourceFenced(
+      ReindexEntityType.ITEM, itemTimestamp.get(), CENTRAL_TENANT_ID, itemTimestamp.get());
+    lockRepository.unlockSubResourceFenced(
+      ReindexEntityType.CALL_NUMBER, callNumberTimestamp.get(), CENTRAL_TENANT_ID, callNumberTimestamp.get());
 
     await().atMost(ONE_MINUTE).pollInterval(ONE_HUNDRED_MILLISECONDS).untilAsserted(() -> {
       var counted = countIndexDocument(ResourceType.INSTANCE_CALL_NUMBER, CENTRAL_TENANT_ID);

--- a/src/test/java/org/folio/api/browse/BrowseClassificationConsortiumIT.java
+++ b/src/test/java/org/folio/api/browse/BrowseClassificationConsortiumIT.java
@@ -68,6 +68,7 @@ class BrowseClassificationConsortiumIT extends BaseConsortiumIntegrationTest {
   private static final Instance[] INSTANCES_CENTRAL = instancesCentral();
 
   @BeforeAll
+  @SuppressWarnings("checkstyle:methodLength")
   static void prepare(@Autowired SubResourcesLockRepository subResourcesLockRepository) {
     enableTenant(CENTRAL_TENANT_ID);
     enableTenant(MEMBER_TENANT_ID);
@@ -86,7 +87,8 @@ class BrowseClassificationConsortiumIT extends BaseConsortiumIntegrationTest {
       INSTANCES_CENTRAL.length + INSTANCES_MEMBER.length,
       instance -> inventoryApi.createInstance(MEMBER_TENANT_ID, instance));
 
-    subResourcesLockRepository.unlockSubResource(ReindexEntityType.CLASSIFICATION, timestamp.get(), CENTRAL_TENANT_ID);
+    subResourcesLockRepository.unlockSubResourceFenced(
+      ReindexEntityType.CLASSIFICATION, timestamp.get(), CENTRAL_TENANT_ID, timestamp.get());
 
     await().atMost(ONE_MINUTE).pollInterval(ONE_HUNDRED_MILLISECONDS).untilAsserted(() -> {
       var searchRequest = new SearchRequest()

--- a/src/test/java/org/folio/api/browse/BrowseContributorConsortiumIT.java
+++ b/src/test/java/org/folio/api/browse/BrowseContributorConsortiumIT.java
@@ -87,7 +87,8 @@ class BrowseContributorConsortiumIT extends BaseConsortiumIntegrationTest {
     instanceToUpdate.setContributors(Collections.emptyList());
     inventoryApi.updateInstance(CENTRAL_TENANT_ID, instanceToUpdate);
 
-    subResourcesLockRepository.unlockSubResource(ReindexEntityType.CONTRIBUTOR, timestamp.get(), CENTRAL_TENANT_ID);
+    subResourcesLockRepository.unlockSubResourceFenced(
+      ReindexEntityType.CONTRIBUTOR, timestamp.get(), CENTRAL_TENANT_ID, timestamp.get());
 
     await().atMost(ONE_MINUTE).pollInterval(ONE_HUNDRED_MILLISECONDS).untilAsserted(() -> {
       var counted = countIndexDocument(ResourceType.INSTANCE_CONTRIBUTOR, CENTRAL_TENANT_ID);

--- a/src/test/java/org/folio/api/browse/BrowseSubjectConsortiumIT.java
+++ b/src/test/java/org/folio/api/browse/BrowseSubjectConsortiumIT.java
@@ -82,7 +82,8 @@ class BrowseSubjectConsortiumIT extends BaseConsortiumIntegrationTest {
       INSTANCES_CENTRAL.length + INSTANCES_MEMBER.length,
       instance -> inventoryApi.createInstance(MEMBER_TENANT_ID, instance));
 
-    subResourcesLockRepository.unlockSubResource(ReindexEntityType.SUBJECT, timestamp.get(), CENTRAL_TENANT_ID);
+    subResourcesLockRepository.unlockSubResourceFenced(
+      ReindexEntityType.SUBJECT, timestamp.get(), CENTRAL_TENANT_ID, timestamp.get());
 
     await().atMost(ONE_MINUTE).pollInterval(ONE_HUNDRED_MILLISECONDS).untilAsserted(() -> {
       var counted = countIndexDocument(INSTANCE_SUBJECT, CENTRAL_TENANT_ID);

--- a/src/test/java/org/folio/search/service/reindex/ReindexStatusServiceTest.java
+++ b/src/test/java/org/folio/search/service/reindex/ReindexStatusServiceTest.java
@@ -23,6 +23,8 @@ import org.folio.search.model.types.ReindexEntityType;
 import org.folio.search.model.types.ReindexStatus;
 import org.folio.search.service.consortium.ConsortiumTenantProvider;
 import org.folio.search.service.reindex.jdbc.ReindexStatusRepository;
+import org.folio.search.service.reindex.jdbc.SubResourcesLockRepository;
+import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Assertions;
@@ -48,6 +50,12 @@ class ReindexStatusServiceTest {
 
   @Mock
   private ConsortiumTenantProvider consortiumTenantProvider;
+
+  @Mock
+  private SubResourcesLockRepository subResourcesLockRepository;
+
+  @Mock
+  private FolioExecutionContext folioExecutionContext;
 
   @InjectMocks
   private ReindexStatusService service;
@@ -157,6 +165,9 @@ class ReindexStatusServiceTest {
 
   @Test
   void shouldRecreateMergeReindexStatusEntities() {
+    // given
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
+
     // act
     service.recreateMergeStatusRecords(null);
 
@@ -164,6 +175,7 @@ class ReindexStatusServiceTest {
     verify(statusRepository).truncate();
     verify(statusRepository).recreateReindexStatusTrigger(false);
     verify(statusRepository).saveReindexStatusRecords(reindexStatusEntitiesCaptor.capture());
+    verify(subResourcesLockRepository).forceLockAllForReindex(TENANT_ID);
     var savedEntities = reindexStatusEntitiesCaptor.getValue();
     assertThat(savedEntities)
       .hasSize(ReindexEntityType.supportMergeTypes().size())
@@ -203,6 +215,7 @@ class ReindexStatusServiceTest {
       .hasSize(ReindexEntityType.supportMergeTypes().size())
       .allMatch(entity -> targetTenantId.equals(entity.getTargetTenantId()),
         "All entities should have targetTenantId set");
+    verifyNoInteractions(subResourcesLockRepository);
   }
 
   @Test
@@ -408,6 +421,36 @@ class ReindexStatusServiceTest {
     var actual = service.isReindexInProgressOrFailedNotForConsortiumMember();
 
     // assert
+    assertThat(actual).isFalse();
+  }
+
+  @Test
+  void isReindexInProgressOrFailedNotForConsortiumMember_true_whenInstanceIsMergeCompleted() {
+    // given: INSTANCE has MERGE_COMPLETED (transient between-phases state for upload-supporting types)
+    when(statusRepository.getReindexStatuses()).thenReturn(List.of(
+      new ReindexStatusEntity(ReindexEntityType.INSTANCE, ReindexStatus.MERGE_COMPLETED),
+      new ReindexStatusEntity(ReindexEntityType.ITEM, ReindexStatus.MERGE_COMPLETED),
+      new ReindexStatusEntity(ReindexEntityType.HOLDINGS, ReindexStatus.MERGE_COMPLETED)));
+
+    // act
+    var actual = service.isReindexInProgressOrFailedNotForConsortiumMember();
+
+    // assert: INSTANCE supports upload so MERGE_COMPLETED is not terminal for it
+    assertThat(actual).isTrue();
+  }
+
+  @Test
+  void isReindexInProgressOrFailedNotForConsortiumMember_false_whenOnlyItemAndHoldingsAreMergeCompleted() {
+    // given: only non-upload entity types have MERGE_COMPLETED — this is genuinely terminal for them
+    when(statusRepository.getReindexStatuses()).thenReturn(List.of(
+      new ReindexStatusEntity(ReindexEntityType.INSTANCE, ReindexStatus.UPLOAD_COMPLETED),
+      new ReindexStatusEntity(ReindexEntityType.ITEM, ReindexStatus.MERGE_COMPLETED),
+      new ReindexStatusEntity(ReindexEntityType.HOLDINGS, ReindexStatus.MERGE_COMPLETED)));
+
+    // act
+    var actual = service.isReindexInProgressOrFailedNotForConsortiumMember();
+
+    // assert: ITEM and HOLDINGS don't support upload so MERGE_COMPLETED is terminal for them
     assertThat(actual).isFalse();
   }
 }

--- a/src/test/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesServiceTest.java
+++ b/src/test/java/org/folio/search/service/scheduled/ScheduledInstanceSubResourcesServiceTest.java
@@ -101,7 +101,8 @@ class ScheduledInstanceSubResourcesServiceTest {
     verify(resourceService).indexResources(anyList());
     verify(itemRepository).deleteEntitiesForTenant(List.of("4"), TENANT_ID, true);
     verify(instanceRepository).deleteEntities(List.of("5"), true);
-    verify(subResourcesLockRepository).unlockSubResource(eq(ReindexEntityType.SUBJECT), any(), eq(TENANT_ID));
+    verify(subResourcesLockRepository).unlockSubResourceFenced(
+      eq(ReindexEntityType.SUBJECT), any(), eq(TENANT_ID), any());
   }
 
   @Test
@@ -110,6 +111,7 @@ class ScheduledInstanceSubResourcesServiceTest {
     doAnswer(invocation -> invocation.<Callable<?>>getArgument(1).call())
       .when(executionService).executeSystemUserScoped(anyString(), any());
     when(subResourcesLockRepository.lockSubResource(any(), any())).thenReturn(Optional.of(timestamp));
+    when(subResourcesLockRepository.updateLockTimestampFenced(any(), any(), any(), any())).thenReturn(true);
     when(tenantRepository.fetchDataTenantIds()).thenReturn(List.of(TENANT_ID));
     when(subjectRepository.fetchByTimestamp(TENANT_ID, timestamp, 3))
       .thenReturn(new SubResourceResult(List.of(Map.of("id", "1", "tenantId", TENANT_ID),
@@ -127,7 +129,8 @@ class ScheduledInstanceSubResourcesServiceTest {
     verify(instanceRepository).fetchByTimestamp(TENANT_ID, timestamp, 3);
     verify(subjectRepository).fetchByTimestamp(TENANT_ID, timestamp, 3);
     verify(resourceService).indexResources(anyList());
-    verify(subResourcesLockRepository).unlockSubResource(eq(ReindexEntityType.SUBJECT), any(), eq(TENANT_ID));
+    verify(subResourcesLockRepository).unlockSubResourceFenced(
+      eq(ReindexEntityType.SUBJECT), any(), eq(TENANT_ID), any());
   }
 
   @Test
@@ -141,7 +144,7 @@ class ScheduledInstanceSubResourcesServiceTest {
     // Assert
     verify(subjectRepository, never()).fetchByTimestamp(anyString(), any(), anyInt());
     verify(resourceService, never()).indexResources(anyList());
-    verify(subResourcesLockRepository, never()).unlockSubResource(any(), any(), any());
+    verify(subResourcesLockRepository, never()).unlockSubResourceFenced(any(), any(), any(), any());
   }
 
   @Test
@@ -161,7 +164,7 @@ class ScheduledInstanceSubResourcesServiceTest {
     // Assert
     verify(subjectRepository, times(2)).fetchByTimestamp(anyString(), any(), anyInt());
     verify(resourceService, times(2)).indexResources(anyList());
-    verify(subResourcesLockRepository, times(6)).unlockSubResource(any(), any(), any());
+    verify(subResourcesLockRepository, times(6)).unlockSubResourceFenced(any(), any(), any(), any());
   }
 
   @Test
@@ -175,7 +178,7 @@ class ScheduledInstanceSubResourcesServiceTest {
     // Assert
     verify(subjectRepository, never()).fetchByTimestamp(anyString(), any(), anyInt());
     verify(resourceService, never()).indexResources(anyList());
-    verify(subResourcesLockRepository, never()).unlockSubResource(any(), any(), any());
+    verify(subResourcesLockRepository, never()).unlockSubResourceFenced(any(), any(), any(), any());
   }
 
   @Test
@@ -195,7 +198,7 @@ class ScheduledInstanceSubResourcesServiceTest {
     verify(subResourcesLockRepository, times(3)).lockSubResource(any(), eq(TENANT_ID));
     verify(reindexStatusService, times(3)).isReindexInProgressOrFailedNotForConsortiumMember();
     verify(subResourcesLockRepository, times(3)).checkAndReleaseStaleLock(any(), eq(TENANT_ID), anyLong());
-    verify(subResourcesLockRepository, never()).unlockSubResource(any(), any(), any());
+    verify(subResourcesLockRepository, never()).unlockSubResourceFenced(any(), any(), any(), any());
     verify(subjectRepository, never()).fetchByTimestamp(anyString(), any(), anyInt());
     verifyNoInteractions(instanceRepository, itemRepository, resourceService);
   }
@@ -217,7 +220,7 @@ class ScheduledInstanceSubResourcesServiceTest {
     verify(subResourcesLockRepository, times(3)).lockSubResource(any(), eq(TENANT_ID));
     verify(reindexStatusService, times(3)).isReindexInProgressOrFailedNotForConsortiumMember();
     verify(subResourcesLockRepository, times(3)).checkAndReleaseStaleLock(any(), eq(TENANT_ID), anyLong());
-    verify(subResourcesLockRepository, never()).unlockSubResource(any(), any(), any());
+    verify(subResourcesLockRepository, never()).unlockSubResourceFenced(any(), any(), any(), any());
     verify(subjectRepository, never()).fetchByTimestamp(anyString(), any(), anyInt());
     verifyNoInteractions(instanceRepository, itemRepository, resourceService);
   }
@@ -238,7 +241,7 @@ class ScheduledInstanceSubResourcesServiceTest {
     verify(subResourcesLockRepository, times(3)).lockSubResource(any(), eq(TENANT_ID));
     verify(reindexStatusService, times(3)).isReindexInProgressOrFailedNotForConsortiumMember();
     verify(subResourcesLockRepository, never()).checkAndReleaseStaleLock(any(), any(), anyLong());
-    verify(subResourcesLockRepository, never()).unlockSubResource(any(), any(), any());
+    verify(subResourcesLockRepository, never()).unlockSubResourceFenced(any(), any(), any(), any());
     verify(subjectRepository, never()).fetchByTimestamp(anyString(), any(), anyInt());
     verifyNoInteractions(instanceRepository, itemRepository, resourceService);
   }


### PR DESCRIPTION
### Purpose
Fix background sub-resource processing running during reindex

### Approach
- Move reindex sub-resource locks acquisition from trigger to code
- Add fencing tokens to scheduler-side unlock/refresh to prevent background job from unlocking reindex locks in case reindex started during background processing
Moving locks acquisition from trigger to code ensures resources are locked right at the start of the reindex.
Fencing tokens in a background job ensure background job doesn't release locks acquired by the reindex in case reindex is started during background job processing.
Additionally reindex check in a background job now treats INSTANCE reindex status MERGE_COMPLETED as reindex running to account for a gap when merge is completed but upload has not yet started.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MSEARCH-1238](https://folio-org.atlassian.net/browse/MSEARCH-1238)

### Manual testing
Reindex ran 2 times, 6:05h and 5:50h, no background processing happened during processing
